### PR TITLE
fix(wear): smooth scrub + play/pause crossfade + square buffering state

### DIFF
--- a/wear/src/main/kotlin/in/jphe/storyvox/wear/components/CircularScrubber.kt
+++ b/wear/src/main/kotlin/in/jphe/storyvox/wear/components/CircularScrubber.kt
@@ -1,11 +1,15 @@
 package `in`.jphe.storyvox.wear.components
 
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -59,6 +63,14 @@ fun CircularScrubber(
     } else {
         Modifier
     }
+    // Smooth the brass sweep so discrete position pushes from the phone bridge
+    // glide instead of jumping. Only consumed by the determinate branch; the
+    // indeterminate branch uses CircularProgressIndicator's built-in spin.
+    val animatedProgress by animateFloatAsState(
+        targetValue = progress.coerceIn(0f, 1f),
+        animationSpec = tween(durationMillis = 240, easing = FastOutSlowInEasing),
+        label = "ring-scrub-progress",
+    )
     Box(modifier = modifier.then(scrubModifier), contentAlignment = Alignment.Center) {
         if (indeterminate) {
             CircularProgressIndicator(
@@ -69,7 +81,7 @@ fun CircularScrubber(
             )
         } else {
             CircularProgressIndicator(
-                progress = progress.coerceIn(0f, 1f),
+                progress = animatedProgress,
                 modifier = Modifier.fillMaxSize(),
                 indicatorColor = BrassPrimary,
                 trackColor = BrassRingTrack,

--- a/wear/src/main/kotlin/in/jphe/storyvox/wear/components/LinearScrubber.kt
+++ b/wear/src/main/kotlin/in/jphe/storyvox/wear/components/LinearScrubber.kt
@@ -1,9 +1,17 @@
 package `in`.jphe.storyvox.wear.components
 
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.StrokeCap
@@ -18,13 +26,29 @@ import `in`.jphe.storyvox.wear.theme.BrassRingTrack
  * ring around the cover art reads awkwardly inside the rectangular safe area.
  * We fall back to a horizontal brass track. Read-only in v1 (touch-to-seek is
  * a follow-up; same constraint as [CircularScrubber]).
+ *
+ * The filled fraction is run through [animateFloatAsState] so the position
+ * pushes that arrive in discrete steps from the phone bridge sweep smoothly
+ * instead of snapping. When [indeterminate] is true (buffering) a brass segment
+ * slides across the track on a loop — the square-face analogue of the round
+ * [CircularScrubber]'s spinner, so buffering reads the same on both form
+ * factors.
  */
 @Composable
 fun LinearScrubber(
     progress: Float,
     modifier: Modifier = Modifier,
+    indeterminate: Boolean = false,
 ) {
-    val clamped = progress.coerceIn(0f, 1f)
+    if (indeterminate) {
+        IndeterminateLinearScrubber(modifier)
+        return
+    }
+    val animatedProgress by animateFloatAsState(
+        targetValue = progress.coerceIn(0f, 1f),
+        animationSpec = tween(durationMillis = 240, easing = FastOutSlowInEasing),
+        label = "linear-scrub-progress",
+    )
     Canvas(
         modifier = modifier
             .fillMaxWidth()
@@ -41,11 +65,64 @@ fun LinearScrubber(
             cap = StrokeCap.Round,
         )
         // Filled portion
-        if (clamped > 0f) {
+        if (animatedProgress > 0f) {
             drawLine(
                 color = BrassPrimary,
                 start = Offset(0f, mid),
-                end = Offset(trackEnd * clamped, mid),
+                end = Offset(trackEnd * animatedProgress, mid),
+                strokeWidth = size.height,
+                cap = StrokeCap.Round,
+            )
+        }
+    }
+}
+
+/**
+ * Indeterminate buffering animation for the square scrubber: a ~35%-wide brass
+ * segment that sweeps left→right and loops, disappearing off both ends. Kept in
+ * its own composable so the [rememberInfiniteTransition] only exists while
+ * buffering — when the determinate scrubber is shown, no frame-by-frame
+ * animation runs.
+ */
+@Composable
+private fun IndeterminateLinearScrubber(modifier: Modifier) {
+    val transition = rememberInfiniteTransition(label = "linear-scrub-buffer")
+    val head by transition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 1100, easing = FastOutSlowInEasing),
+            repeatMode = RepeatMode.Restart,
+        ),
+        label = "linear-scrub-buffer-head",
+    )
+    Canvas(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(4.dp),
+    ) {
+        val mid = size.height / 2f
+        val w = size.width
+        // Track
+        drawLine(
+            color = BrassRingTrack,
+            start = Offset(0f, mid),
+            end = Offset(w, mid),
+            strokeWidth = size.height,
+            cap = StrokeCap.Round,
+        )
+        // Sweeping segment. `head` 0f..1f drives the leading edge; the segment
+        // starts off-screen left (-segFrac) and exits off-screen right (1f), so
+        // the visible brass slides fully across each cycle.
+        val segFrac = 0.35f
+        val startFrac = head * (1f + segFrac) - segFrac
+        val x0 = startFrac.coerceIn(0f, 1f) * w
+        val x1 = (startFrac + segFrac).coerceIn(0f, 1f) * w
+        if (x1 > x0) {
+            drawLine(
+                color = BrassPrimary,
+                start = Offset(x0, mid),
+                end = Offset(x1, mid),
                 strokeWidth = size.height,
                 cap = StrokeCap.Round,
             )

--- a/wear/src/main/kotlin/in/jphe/storyvox/wear/components/TransportRow.kt
+++ b/wear/src/main/kotlin/in/jphe/storyvox/wear/components/TransportRow.kt
@@ -1,5 +1,7 @@
 package `in`.jphe.storyvox.wear.components
 
+import androidx.compose.animation.Crossfade
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -101,10 +103,19 @@ private fun TransportButton(
             )
         },
     ) {
-        Icon(
-            imageVector = icon,
-            contentDescription = contentDescription,
-            modifier = Modifier.size(iconSize),
-        )
+        // ~150ms crossfade so the play↔pause icon swap dissolves instead of
+        // snapping. The skip buttons pass a constant icon, so Crossfade renders
+        // them statically (it never animates its initial / unchanged state).
+        Crossfade(
+            targetState = icon,
+            animationSpec = tween(durationMillis = 150),
+            label = "transport-icon",
+        ) { fadedIcon ->
+            Icon(
+                imageVector = fadedIcon,
+                contentDescription = contentDescription,
+                modifier = Modifier.size(iconSize),
+            )
+        }
     }
 }

--- a/wear/src/main/kotlin/in/jphe/storyvox/wear/screens/NowPlayingScreen.kt
+++ b/wear/src/main/kotlin/in/jphe/storyvox/wear/screens/NowPlayingScreen.kt
@@ -283,7 +283,11 @@ private fun SquareNowPlaying(
             modifier = Modifier.size(72.dp),
         )
         ChapterMeta(state = state)
-        LinearScrubber(progress = progress, modifier = Modifier.fillMaxWidth())
+        LinearScrubber(
+            progress = progress,
+            indeterminate = state.isBuffering,
+            modifier = Modifier.fillMaxWidth(),
+        )
         TransportRow(
             isPlaying = state.isPlaying,
             enabled = connected,
@@ -407,5 +411,9 @@ private fun PreviewSmallRound() = NowPlayingPreview(samplePlaying())
 @Preview(device = WearDevices.SQUARE, showSystemUi = true, name = "Square")
 @Composable
 private fun PreviewSquare() = NowPlayingPreview(samplePlaying())
+
+@Preview(device = WearDevices.SQUARE, showSystemUi = true, name = "Square · Buffering")
+@Composable
+private fun PreviewSquareBuffering() = NowPlayingPreview(sampleBuffering())
 
 // endregion


### PR DESCRIPTION
## What

Wear OS micro-interaction polish flagged by nebula-1268's animation audit. Three gaps, all visual-only — **no bridge/protocol changes**, safe to ship independently.

### 1. Smooth scrub progress
Both scrubbers fed their raw `progress` straight into the indicator, so each position push from the phone bridge made the brass jump. Now the filled fraction runs through `animateFloatAsState` (240ms, `FastOutSlowInEasing`):
- `CircularScrubber` — the determinate ring sweep.
- `LinearScrubber` — the square-face track fill.

### 2. Play/pause crossfade
`TransportRow`'s center button swapped the Play/Pause icon instantly. Wrapped the button icon in a ~150ms `Crossfade` so it dissolves. The flanking skip buttons pass a constant icon, so `Crossfade` renders them statically (it never animates an initial/unchanged state) — no overhead, no behavior change there.

### 3. Square buffering state
The round face already showed an indeterminate `CircularProgressIndicator` spinner while buffering; the square `LinearScrubber` had nothing. Added an `indeterminate` flag that animates a ~35%-wide brass segment sliding across the track on a loop — the square analogue of the spinner — wired from `SquareNowPlaying` via `state.isBuffering` (mirrors how `RoundNowPlaying` already feeds `CircularScrubber`). The `rememberInfiniteTransition` lives in its own private composable, so it only runs while buffering.

## Files
- `components/CircularScrubber.kt` — animate determinate ring progress
- `components/LinearScrubber.kt` — animate fill + new indeterminate sweep
- `components/TransportRow.kt` — crossfade the button icon
- `screens/NowPlayingScreen.kt` — pass `indeterminate = state.isBuffering`; add a "Square · Buffering" preview

## Testing
Visual-only Compose changes — no decision logic to unit-test (the existing `CircularScrubberTest` covers `tapFraction`, untouched). All animation APIs (`animateFloatAsState`, `rememberInfiniteTransition`, `Crossfade`) resolve transitively via the shared `libs.bundles.compose`. CI (`compileDebugUnitTestKotlin` + `:app:assembleRelease`) is the compile gate. New previews render the buffering states on round + square.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
