### PR TITLE
feat(wear): Ongoing Activity chip + retryable error surfacing on the watch

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackController.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackController.kt
@@ -673,11 +673,10 @@ class DefaultPlaybackController @Inject constructor(
     }
 
     /** #530 — which errors should surface a Retry button. */
-    private fun isRetryable(err: PlaybackError): Boolean = when (err) {
-        PlaybackError.AzureAuthFailed -> false // user has to re-paste key
-        is PlaybackError.EngineUnavailable -> false // install required
-        else -> true
-    }
+    // Delegates to the shared [PlaybackError.isRetryable] (PlaybackState.kt) so
+    // the phone's reader banner and the Wear NowPlaying error chip can never
+    // diverge on which errors offer a Retry.
+    private fun isRetryable(err: PlaybackError): Boolean = err.isRetryable()
 
     override suspend fun play(fictionId: String, chapterId: String, charOffset: Int) {
         DebugLog.i("PlaybackController") { "play fiction=$fictionId chapter=$chapterId charOffset=$charOffset" }

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackState.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackState.kt
@@ -107,6 +107,37 @@ sealed class PlaybackError {
     @Serializable data class AzureServerError(val httpCode: Int, val message: String) : PlaybackError()
 }
 
+/**
+ * Wear companion — single source of truth for "is this error worth a Retry?"
+ * Shared by the phone's reader error banner (via [PlaybackController]) and the
+ * Wear NowPlaying error chip so the two surfaces never disagree. Auth failure
+ * (re-paste a key) and a missing engine (install one) are terminal; every
+ * other failure is transient and a re-load can clear it.
+ */
+fun PlaybackError.isRetryable(): Boolean = when (this) {
+    PlaybackError.AzureAuthFailed -> false
+    PlaybackError.EngineUnavailable -> false
+    else -> true
+}
+
+/**
+ * Wear companion — compact, resource-free error copy for the glanceable Wear
+ * NowPlaying surface. The phone uses string resources
+ * ([PlaybackController.errorMessage]); the watch is offline-simple, so the
+ * errors that already carry their own message reuse it and the rest get a
+ * short fixed label. Kept here next to [isRetryable] so the watch's error
+ * presentation stays in lock-step with the typed error model.
+ */
+fun PlaybackError.watchSummary(): String = when (this) {
+    is PlaybackError.ChapterFetchFailed -> message
+    is PlaybackError.AzureThrottled -> message
+    is PlaybackError.AzureNetworkUnavailable -> message
+    is PlaybackError.AzureServerError -> message
+    PlaybackError.EngineUnavailable -> "Voice engine not installed on phone"
+    PlaybackError.AzureAuthFailed -> "Cloud voice key rejected"
+    is PlaybackError.TtsSpeakFailed -> "Couldn't read this chapter aloud"
+}
+
 sealed class SleepTimerMode {
     data class Duration(val minutes: Int) : SleepTimerMode()
     data object EndOfChapter : SleepTimerMode()

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/wear/PhoneWearBridge.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/wear/PhoneWearBridge.kt
@@ -150,6 +150,18 @@ class PhoneWearBridge @Inject constructor(
                 CMD_SKIP_BACK -> controller.skipBack30s()
                 CMD_NEXT_CH -> controller.nextChapter()
                 CMD_PREV_CH -> controller.previousChapter()
+                // Wear companion — Retry after a surfaced playback error. Re-loads
+                // the current chapter; loadAndPlay clears the error band, mirroring
+                // the phone reader banner's onRetry (playback.play()). No-op if there
+                // is no current chapter to reload (e.g. the error nulled the pointer).
+                CMD_RETRY -> {
+                    val s = controller.state.value
+                    val fictionId = s.currentFictionId
+                    val chapterId = s.currentChapterId
+                    if (fictionId != null && chapterId != null) {
+                        controller.play(fictionId, chapterId, s.charOffset)
+                    }
+                }
                 CMD_SLEEP_15 -> controller.startSleepTimer(SleepTimerMode.Duration(15))
                 CMD_SLEEP_OFF -> controller.cancelSleepTimer()
                 // Sleep timer from the wrist (15/30/45/end-of-chapter). CMD_SLEEP_SET
@@ -193,6 +205,10 @@ class PhoneWearBridge @Inject constructor(
         const val CMD_SKIP_BACK = "/playback/cmd/skipBack"
         const val CMD_NEXT_CH = "/playback/cmd/nextCh"
         const val CMD_PREV_CH = "/playback/cmd/prevCh"
+
+        /** Wear companion — re-load the current chapter after a surfaced
+         *  playback error (the watch's NowPlaying Retry chip). Payload-less. */
+        const val CMD_RETRY = "/playback/cmd/retry"
         const val CMD_SLEEP_15 = "/playback/cmd/sleep15"
         const val CMD_SLEEP_OFF = "/playback/cmd/sleepOff"
 

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/PlaybackErrorRetryableTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/PlaybackErrorRetryableTest.kt
@@ -1,0 +1,53 @@
+package `in`.jphe.storyvox.playback
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Wear companion — pins the shared [PlaybackError.isRetryable] /
+ * [PlaybackError.watchSummary] contract that both the phone reader banner
+ * (via PlaybackController) and the Wear NowPlaying error chip read from, so
+ * the two surfaces can never disagree on which errors offer a Retry.
+ */
+class PlaybackErrorRetryableTest {
+
+    @Test
+    fun `auth failure and missing engine are terminal`() {
+        // Re-paste a key / install an engine — nothing a Retry can fix.
+        assertFalse(PlaybackError.AzureAuthFailed.isRetryable())
+        assertFalse(PlaybackError.EngineUnavailable.isRetryable())
+    }
+
+    @Test
+    fun `every transient error is retryable`() {
+        assertTrue(PlaybackError.ChapterFetchFailed("boom").isRetryable())
+        assertTrue(PlaybackError.TtsSpeakFailed("u", 7).isRetryable())
+        assertTrue(PlaybackError.AzureThrottled("slow down").isRetryable())
+        assertTrue(PlaybackError.AzureNetworkUnavailable("offline").isRetryable())
+        assertTrue(PlaybackError.AzureServerError(503, "azure down").isRetryable())
+    }
+
+    @Test
+    fun `watchSummary reuses the message-bearing copy verbatim`() {
+        // The #1262/#1311 chapter errors carry their own user-facing text;
+        // the watch shows it as-is rather than inventing a second wording.
+        assertEquals(
+            "This chapter couldn't be read aloud — no audio was produced.",
+            PlaybackError.ChapterFetchFailed(
+                "This chapter couldn't be read aloud — no audio was produced.",
+            ).watchSummary(),
+        )
+        assertEquals("quota hit", PlaybackError.AzureThrottled("quota hit").watchSummary())
+        assertEquals("no wifi", PlaybackError.AzureNetworkUnavailable("no wifi").watchSummary())
+        assertEquals("500", PlaybackError.AzureServerError(500, "500").watchSummary())
+    }
+
+    @Test
+    fun `watchSummary gives a non-blank fixed label for payload-less errors`() {
+        assertTrue(PlaybackError.EngineUnavailable.watchSummary().isNotBlank())
+        assertTrue(PlaybackError.AzureAuthFailed.watchSummary().isNotBlank())
+        assertTrue(PlaybackError.TtsSpeakFailed("u", 7).watchSummary().isNotBlank())
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -74,6 +74,7 @@ androidx-media = "1.8.0"
 wear-compose = "1.6.2"
 wear-tooling = "1.0.0"
 wear-watchface = "1.2.1"
+wear-ongoing = "1.0.0"
 play-services-wearable = "20.0.1"
 
 # Test
@@ -222,6 +223,7 @@ androidx-wear-compose-foundation = { module = "androidx.wear.compose:compose-fou
 androidx-wear-compose-navigation = { module = "androidx.wear.compose:compose-navigation", version.ref = "wear-compose" }
 androidx-wear-tooling-preview = { module = "androidx.wear:wear-tooling-preview", version.ref = "wear-tooling" }
 androidx-wear-watchface-complications-datasource-ktx = { module = "androidx.wear.watchface:watchface-complications-data-source-ktx", version.ref = "wear-watchface" }
+androidx-wear-ongoing = { module = "androidx.wear:wear-ongoing", version.ref = "wear-ongoing" }
 
 # Desugaring
 android-desugar-jdk-libs = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugar" }

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -111,6 +111,8 @@ dependencies {
     // Wear watch-face complications — data-source services + update requester
     // (the watch-face renders our Now Playing / Listening Stats complications).
     implementation(libs.androidx.wear.watchface.complications.datasource.ktx)
+    // Wear Ongoing Activity — watch-face media chip while the phone plays
+    implementation(libs.androidx.wear.ongoing)
 
     // Hilt (optional in v1; wired so Hypnos can use @AndroidEntryPoint)
     implementation(libs.hilt.android)

--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -9,6 +9,11 @@
     <!-- Rotating-bezel / touch-ring volume control on NowPlayingScreen adjusts
          the watch's STREAM_MUSIC volume via AudioManager.adjustStreamVolume. -->
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
+    <!-- Ongoing Activity media chip — foreground service hosting the ongoing notification. -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+    <!-- Wear 4 / Android 13+ requires this to post the ongoing notification. -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
         android:allowBackup="true"
@@ -82,6 +87,27 @@
                 <action android:name="com.google.android.gms.wearable.DATA_CHANGED" />
                 <data android:scheme="wear" android:host="*" android:pathPrefix="/playback" />
                 <data android:scheme="wear" android:host="*" android:pathPrefix="/stats" />
+            </intent-filter>
+        </service>
+
+        <!-- Ongoing Activity media chip — foreground service reflecting phone playback. -->
+        <service
+            android:name=".ongoing.WearOngoingPlaybackService"
+            android:exported="false"
+            android:foregroundServiceType="mediaPlayback" />
+
+        <!-- Background driver: receives /playback/state changes (app open or not)
+             and starts/stops the chip service. WearableListenerService must be
+             exported so the GMS data layer can deliver DATA_CHANGED to it. -->
+        <service
+            android:name=".ongoing.PlaybackStateListenerService"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.google.android.gms.wearable.DATA_CHANGED" />
+                <data
+                    android:scheme="wear"
+                    android:host="*"
+                    android:pathPrefix="/playback" />
             </intent-filter>
         </service>
     </application>

--- a/wear/src/main/kotlin/in/jphe/storyvox/wear/ongoing/PlaybackStateListenerService.kt
+++ b/wear/src/main/kotlin/in/jphe/storyvox/wear/ongoing/PlaybackStateListenerService.kt
@@ -1,0 +1,80 @@
+package `in`.jphe.storyvox.wear.ongoing
+
+import android.util.Log
+import androidx.core.content.ContextCompat
+import com.google.android.gms.wearable.DataEventBuffer
+import com.google.android.gms.wearable.DataMapItem
+import com.google.android.gms.wearable.WearableListenerService
+import `in`.jphe.storyvox.playback.PlaybackState
+import `in`.jphe.storyvox.playback.wear.PhoneWearBridge
+import `in`.jphe.storyvox.wear.playback.WearPlaybackBridge
+
+/**
+ * Wear companion — background driver for the Ongoing Activity. As a
+ * [WearableListenerService] it receives `/playback/state` DataItem changes even
+ * when the watch app is closed, decodes them with the same seam the in-app
+ * bridge uses ([WearPlaybackBridge.decodeState]), and starts / stops
+ * [WearOngoingPlaybackService] so the watch-face media chip tracks whether the
+ * phone is actually playing.
+ *
+ * Decision logic lives in the pure [ongoingActionFor] so it can be unit-tested
+ * without GMS, mirroring the [in.jphe.storyvox.wear.playback.NodeSelection] seam.
+ */
+class PlaybackStateListenerService : WearableListenerService() {
+
+    override fun onDataChanged(events: DataEventBuffer) {
+        for (e in events) {
+            if (e.dataItem.uri.path != PhoneWearBridge.PATH_STATE) continue
+            val raw = DataMapItem.fromDataItem(e.dataItem).dataMap.getString("state")
+            val state = WearPlaybackBridge.decodeState(raw, PlaybackState()) { t ->
+                Log.w(TAG, "ongoing: dropping undecodable PlaybackState payload", t)
+            }
+            when (val action = ongoingActionFor(state)) {
+                is OngoingAction.Show ->
+                    // Background data-layer event → must use startForegroundService
+                    // so the service can promote within 5 s (it calls
+                    // startForeground in ACTION_UPDATE). BAL caveats: see the
+                    // WearOngoingPlaybackService VERIFICATION GAP note.
+                    ContextCompat.startForegroundService(
+                        this,
+                        WearOngoingPlaybackService.updateIntent(this, action.title, action.subtitle),
+                    )
+                OngoingAction.Hide ->
+                    // If the chip service is running (foreground) this delivers the
+                    // stop; if it isn't, a background startService throws and there
+                    // is nothing to stop — either way the chip ends up absent.
+                    runCatching { startService(WearOngoingPlaybackService.stopIntent(this)) }
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "WearPlaybackListener"
+    }
+}
+
+/**
+ * Pure rule: what should the Ongoing Activity chip do for [state]?
+ *
+ * Show only while the phone is actively playing a loaded chapter. Gating on
+ * `isPlaying` (not merely "a chapter is loaded") avoids a stale chip on watch
+ * boot — the last `/playback/state` DataItem persists, so a paused/idle phone
+ * would otherwise resurrect a chip for a chapter no longer playing. The title
+ * mirrors the in-app [in.jphe.storyvox.wear.screens.NowPlayingScreen] fallback
+ * chain (chapter → book → app name).
+ */
+internal fun ongoingActionFor(state: PlaybackState): OngoingAction =
+    if (state.isPlaying && state.currentChapterId != null) {
+        OngoingAction.Show(
+            title = state.chapterTitle ?: state.bookTitle ?: "storyvox",
+            subtitle = state.bookTitle?.takeIf { it.isNotBlank() && state.chapterTitle != null },
+        )
+    } else {
+        OngoingAction.Hide
+    }
+
+/** Outcome of [ongoingActionFor] — start/update the chip, or tear it down. */
+sealed interface OngoingAction {
+    data class Show(val title: String, val subtitle: String?) : OngoingAction
+    data object Hide : OngoingAction
+}

--- a/wear/src/main/kotlin/in/jphe/storyvox/wear/ongoing/WearOngoingPlaybackService.kt
+++ b/wear/src/main/kotlin/in/jphe/storyvox/wear/ongoing/WearOngoingPlaybackService.kt
@@ -1,0 +1,182 @@
+package `in`.jphe.storyvox.wear.ongoing
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.IBinder
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import androidx.wear.ongoing.OngoingActivity
+import androidx.wear.ongoing.Status
+import com.google.android.gms.wearable.Wearable
+import `in`.jphe.storyvox.playback.wear.PhoneWearBridge
+import `in`.jphe.storyvox.wear.WearMainActivity
+import `in`.jphe.storyvox.wear.playback.NodeSelection
+import `in`.jphe.storyvox.wear.playback.PhoneNode
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+
+/**
+ * Wear companion — foreground service that surfaces active phone playback as an
+ * **Ongoing Activity**: a media chip on the watch face + the system ongoing
+ * strip, carrying the chapter title and a play/pause control. The phone owns
+ * the MediaSession; this is the watch's reflection of it.
+ *
+ * Driven entirely by [PlaybackStateListenerService], which forwards every
+ * `/playback/state` change as an [ACTION_UPDATE] (playing) or [ACTION_STOP]
+ * (not playing) intent — so the chip appears even when the watch app was never
+ * opened this session.
+ *
+ * The play/pause action and the chip touch both route back through here:
+ * [ACTION_TOGGLE] sends [PhoneWearBridge.CMD_TOGGLE] to the phone over
+ * MessageClient; the touch intent opens [WearMainActivity].
+ *
+ * VERIFICATION GAP: built compile-only (no watch in CI). The OngoingActivity
+ * chip rendering, the foreground-start path from a background data-layer event
+ * (Android 12+ FGS-start rules), and POST_NOTIFICATIONS on Wear 4 all need
+ * on-watch verification. The platform-uncertain calls are wrapped in
+ * runCatching so a restriction degrades to "no chip" rather than a crash.
+ */
+class WearOngoingPlaybackService : Service() {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        when (intent?.action) {
+            ACTION_UPDATE -> {
+                val title = intent.getStringExtra(EXTRA_TITLE)?.ifBlank { null } ?: FALLBACK_TITLE
+                val subtitle = intent.getStringExtra(EXTRA_SUBTITLE)?.ifBlank { null }
+                startForegroundChip(title, subtitle)
+            }
+            ACTION_TOGGLE -> scope.launch { sendToggle() }
+            // ACTION_STOP or a redelivered null intent → tear the chip down.
+            else -> stopChip()
+        }
+        return START_NOT_STICKY
+    }
+
+    private fun startForegroundChip(title: String, subtitle: String?) {
+        ensureChannel()
+
+        val touchIntent = PendingIntent.getActivity(
+            this,
+            REQ_OPEN,
+            Intent(this, WearMainActivity::class.java)
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP),
+            PI_FLAGS,
+        )
+        val toggleIntent = PendingIntent.getService(
+            this,
+            REQ_TOGGLE,
+            Intent(this, WearOngoingPlaybackService::class.java).setAction(ACTION_TOGGLE),
+            PI_FLAGS,
+        )
+
+        val builder = NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(android.R.drawable.ic_media_play)
+            .setContentTitle(title)
+            .setContentText(subtitle ?: "Playing on phone")
+            .setOngoing(true)
+            .setCategory(NotificationCompat.CATEGORY_TRANSPORT)
+            .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+            .setContentIntent(touchIntent)
+            .addAction(android.R.drawable.ic_media_pause, "Pause", toggleIntent)
+
+        // Decorate as an Ongoing Activity so it surfaces as a watch-face chip.
+        OngoingActivity.Builder(applicationContext, NOTIF_ID, builder)
+            .setStaticIcon(android.R.drawable.ic_media_play)
+            .setTouchIntent(touchIntent)
+            .setStatus(Status.Builder().addTemplate(title).build())
+            .build()
+            .apply(applicationContext)
+
+        val notification = builder.build()
+        // Android 12+ can refuse a foreground start from a background data-layer
+        // event (BAL). Degrade to "no chip" instead of crashing if so — see the
+        // class VERIFICATION GAP note.
+        runCatching {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                startForeground(
+                    NOTIF_ID,
+                    notification,
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK,
+                )
+            } else {
+                startForeground(NOTIF_ID, notification)
+            }
+        }.onFailure { Log.w(TAG, "startForeground refused (FGS background-start restriction?)", it) }
+    }
+
+    private fun stopChip() {
+        stopForeground(STOP_FOREGROUND_REMOVE)
+        stopSelf()
+    }
+
+    /** Toggle phone playback from the chip's play/pause action. */
+    private suspend fun sendToggle() {
+        runCatching {
+            val ctx = this@WearOngoingPlaybackService
+            val nodes = Wearable.getNodeClient(ctx).connectedNodes.await()
+                .map { PhoneNode(id = it.id, isNearby = it.isNearby) }
+            val target = NodeSelection.preferredTarget(nodes) ?: return
+            Wearable.getMessageClient(ctx)
+                .sendMessage(target.id, PhoneWearBridge.CMD_TOGGLE, null)
+                .await()
+        }.onFailure { Log.w(TAG, "chip toggle send failed", it) }
+    }
+
+    private fun ensureChannel() {
+        val mgr = getSystemService(NotificationManager::class.java) ?: return
+        if (mgr.getNotificationChannel(CHANNEL_ID) == null) {
+            mgr.createNotificationChannel(
+                NotificationChannel(
+                    CHANNEL_ID,
+                    "Playback",
+                    NotificationManager.IMPORTANCE_LOW,
+                ).apply { setShowBadge(false) },
+            )
+        }
+    }
+
+    override fun onDestroy() {
+        scope.cancel()
+        super.onDestroy()
+    }
+
+    companion object {
+        private const val TAG = "WearOngoingPlayback"
+        private const val NOTIF_ID = 4201
+        private const val CHANNEL_ID = "wear_playback_ongoing"
+        private const val REQ_OPEN = 1
+        private const val REQ_TOGGLE = 2
+        private const val FALLBACK_TITLE = "storyvox"
+        private val PI_FLAGS =
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+
+        const val ACTION_UPDATE = "in.jphe.storyvox.wear.ongoing.UPDATE"
+        const val ACTION_TOGGLE = "in.jphe.storyvox.wear.ongoing.TOGGLE"
+        const val ACTION_STOP = "in.jphe.storyvox.wear.ongoing.STOP"
+        const val EXTRA_TITLE = "title"
+        const val EXTRA_SUBTITLE = "subtitle"
+
+        fun updateIntent(ctx: Context, title: String, subtitle: String?): Intent =
+            Intent(ctx, WearOngoingPlaybackService::class.java)
+                .setAction(ACTION_UPDATE)
+                .putExtra(EXTRA_TITLE, title)
+                .putExtra(EXTRA_SUBTITLE, subtitle)
+
+        fun stopIntent(ctx: Context): Intent =
+            Intent(ctx, WearOngoingPlaybackService::class.java).setAction(ACTION_STOP)
+    }
+}

--- a/wear/src/main/kotlin/in/jphe/storyvox/wear/playback/WearPlaybackBridge.kt
+++ b/wear/src/main/kotlin/in/jphe/storyvox/wear/playback/WearPlaybackBridge.kt
@@ -110,6 +110,14 @@ class WearPlaybackBridge(private val context: Context) : DataClient.OnDataChange
     suspend fun send(path: String): SendResult = dispatch(path, null)
 
     /**
+     * Wear companion — Retry after a surfaced playback error. Asks the phone to
+     * re-load the current chapter (clearing its error band). Payload-less; shares
+     * [dispatch] so a tap while disconnected flips [connected] and surfaces the
+     * same "Phone not connected" hint as the transport controls.
+     */
+    suspend fun sendRetry(): SendResult = send(PhoneWearBridge.CMD_RETRY)
+
+    /**
      * Issue #1031 — scrub from the wrist. Converts the 0..1 ring [fraction] to
      * an absolute position in ms against [durationMs] (the synced
      * `durationEstimateMs`) and sends it as a [SeekPayload] on

--- a/wear/src/main/kotlin/in/jphe/storyvox/wear/screens/NowPlayingScreen.kt
+++ b/wear/src/main/kotlin/in/jphe/storyvox/wear/screens/NowPlayingScreen.kt
@@ -18,6 +18,9 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.outlined.ErrorOutline
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
@@ -48,15 +51,20 @@ import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.LifecycleResumeEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.wear.compose.material.Chip
 import androidx.wear.compose.material.ChipDefaults
 import androidx.wear.compose.material.CompactChip
+import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Scaffold
 import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.TimeText
 import androidx.wear.tooling.preview.devices.WearDevices
+import `in`.jphe.storyvox.playback.PlaybackError
 import `in`.jphe.storyvox.playback.PlaybackState
+import `in`.jphe.storyvox.playback.isRetryable
 import `in`.jphe.storyvox.playback.scrubProgress
+import `in`.jphe.storyvox.playback.watchSummary
 import `in`.jphe.storyvox.playback.wear.PhoneWearBridge
 import `in`.jphe.storyvox.wear.R
 import `in`.jphe.storyvox.wear.components.ChapterCover
@@ -133,6 +141,8 @@ fun NowPlayingScreen(
         onNextChapter = { scope.launch { bridge.send(PhoneWearBridge.CMD_NEXT_CH) } },
         // #1031 — tap the ring to scrub; duration comes from the synced state.
         onScrub = { fraction -> scope.launch { bridge.sendSeek(fraction, state.durationEstimateMs) } },
+        // Wear error surfacing — ask the phone to re-load the current chapter.
+        onRetry = { scope.launch { bridge.sendRetry() } },
         onOpenTeleprompter = onOpenTeleprompter,
         // #1367 — recording remote. The phone gates these on `recordingArmed`
         // (only effective when it's on RecordingScreen); a Start sent otherwise
@@ -160,6 +170,7 @@ internal fun NowPlayingContent(
     onScrub: ((fraction: Float) -> Unit)? = null,
     onPrevChapter: () -> Unit = {},
     onNextChapter: () -> Unit = {},
+    onRetry: () -> Unit = {},
     onOpenTeleprompter: () -> Unit = {},
     onStartRecording: () -> Unit = {},
     onStopRecording: () -> Unit = {},
@@ -218,8 +229,18 @@ internal fun NowPlayingContent(
                 .background(MaterialTheme.colors.background),
             contentAlignment = Alignment.Center,
         ) {
-            if (isRound) {
-                RoundNowPlaying(
+            // Error takes precedence over the transport (mirrors the phone
+            // reader, where the error band wins). #1262/#1311 now emit a
+            // retryable error instead of a silent skip; without this the watch
+            // would sit on a frozen now-playing while the phone shows the error.
+            val err = state.error
+            when {
+                err != null -> PlaybackErrorContent(
+                    error = err,
+                    connected = connected,
+                    onRetry = onRetry,
+                )
+                isRound -> RoundNowPlaying(
                     state = state,
                     progress = progress,
                     connected = connected,
@@ -231,8 +252,7 @@ internal fun NowPlayingContent(
                     onNextChapter = onNextChapter,
                     onReconnect = onReconnect,
                 )
-            } else {
-                SquareNowPlaying(
+                else -> SquareNowPlaying(
                     state = state,
                     progress = progress,
                     connected = connected,
@@ -244,11 +264,13 @@ internal fun NowPlayingContent(
                     onReconnect = onReconnect,
                 )
             }
-            // Bottom-edge affordances, only when a phone is reachable: the
-            // #1367 recording control stacked above the #1308 teleprompter +
-            // sleep-timer entries. Anchored off the bottom bezel so they don't
-            // crowd the centered transport controls.
-            if (connected) {
+            // Bottom-edge affordances, only when a phone is reachable AND we're
+            // not showing the error recovery surface (#1262/#1311 — the error
+            // surface replaces the content, so these controls must not show
+            // underneath it): the #1367 recording control stacked above the
+            // #1308 teleprompter + sleep-timer entries. Anchored off the bottom
+            // bezel so they don't crowd the centered transport controls.
+            if (connected && err == null) {
                 Column(
                     modifier = Modifier
                         .align(Alignment.BottomCenter)
@@ -632,6 +654,70 @@ internal fun formatPlaybackTime(ms: Long): String {
     }
 }
 
+/**
+ * Error recovery surface — replaces the transport when the phone reports a
+ * [PlaybackError]. Shows a compact [watchSummary] and, for a transient error
+ * ([isRetryable]) with a reachable phone, a Retry chip that asks the phone to
+ * re-load the current chapter. Terminal errors (auth rejected, no engine) show
+ * the summary without a Retry — there's nothing the wrist can do about them.
+ * Without this surface a #1262/#1311 error would leave the watch on a frozen
+ * now-playing while the phone shows the failure.
+ */
+@Composable
+private fun PlaybackErrorContent(
+    error: PlaybackError,
+    connected: Boolean,
+    onRetry: () -> Unit,
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 16.dp),
+    ) {
+        Icon(
+            imageVector = Icons.Outlined.ErrorOutline,
+            contentDescription = "Playback error",
+            tint = BrassPrimary,
+            modifier = Modifier.size(24.dp),
+        )
+        Text(
+            text = error.watchSummary(),
+            style = MaterialTheme.typography.caption1,
+            color = ParchmentOnMuted,
+            maxLines = 3,
+            overflow = TextOverflow.Ellipsis,
+            textAlign = TextAlign.Center,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 8.dp),
+        )
+        when {
+            error.isRetryable() && connected -> Chip(
+                onClick = onRetry,
+                label = {
+                    Text(text = "Retry", maxLines = 1, overflow = TextOverflow.Ellipsis)
+                },
+                icon = {
+                    Icon(
+                        imageVector = Icons.Filled.Refresh,
+                        contentDescription = null,
+                        modifier = Modifier.size(ChipDefaults.IconSize),
+                    )
+                },
+                colors = ChipDefaults.primaryChipColors(),
+            )
+            !connected -> Text(
+                text = "Phone not connected",
+                style = MaterialTheme.typography.caption2,
+                color = ParchmentOnMuted,
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}
+
 // region --- Previews ---
 
 private fun samplePlaying() = PlaybackState(
@@ -670,6 +756,16 @@ private fun sampleRecording() = samplePlaying().copy(
     recordingElapsedMs = 75_000L,
 )
 
+private fun sampleError() = PlaybackState(
+    isPlaying = false,
+    bookTitle = "The Brass Compendium",
+    chapterTitle = "Chapter 7 · The Long Stair",
+    error = PlaybackError.ChapterFetchFailed(
+        "This chapter couldn't be read aloud — no audio was produced. " +
+            "Tap retry, or skip to the next chapter.",
+    ),
+)
+
 @Composable
 private fun NowPlayingPreview(state: PlaybackState, connected: Boolean = true) {
     WearLibraryNocturneTheme {
@@ -694,6 +790,10 @@ private fun PreviewRoundPaused() = NowPlayingPreview(samplePaused())
 @Preview(device = WearDevices.LARGE_ROUND, showSystemUi = true, name = "Round · Buffering")
 @Composable
 private fun PreviewRoundBuffering() = NowPlayingPreview(sampleBuffering())
+
+@Preview(device = WearDevices.LARGE_ROUND, showSystemUi = true, name = "Round · Error (retryable)")
+@Composable
+private fun PreviewRoundError() = NowPlayingPreview(sampleError())
 
 @Preview(device = WearDevices.LARGE_ROUND, showSystemUi = true, name = "Round · Disconnected")
 @Composable

--- a/wear/src/test/kotlin/in/jphe/storyvox/wear/ongoing/OngoingActionTest.kt
+++ b/wear/src/test/kotlin/in/jphe/storyvox/wear/ongoing/OngoingActionTest.kt
@@ -1,0 +1,68 @@
+package `in`.jphe.storyvox.wear.ongoing
+
+import `in`.jphe.storyvox.playback.PlaybackState
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Wear companion — pins the pure [ongoingActionFor] rule that decides whether
+ * the watch-face media chip ([WearOngoingPlaybackService]) should be shown for
+ * a given phone [PlaybackState]. Tested without GMS, mirroring the
+ * NodeSelection / WearStateDecode seam.
+ */
+class OngoingActionTest {
+
+    @Test
+    fun `shows the chip while playing a loaded chapter`() {
+        val action = ongoingActionFor(
+            PlaybackState(
+                isPlaying = true,
+                currentChapterId = "c1",
+                chapterTitle = "Chapter 7",
+                bookTitle = "The Brass Compendium",
+            ),
+        )
+        assertTrue(action is OngoingAction.Show)
+        action as OngoingAction.Show
+        assertEquals("Chapter 7", action.title)
+        assertEquals("The Brass Compendium", action.subtitle)
+    }
+
+    @Test
+    fun `hides the chip when paused`() {
+        assertEquals(
+            OngoingAction.Hide,
+            ongoingActionFor(
+                PlaybackState(isPlaying = false, currentChapterId = "c1", chapterTitle = "Chapter 7"),
+            ),
+        )
+    }
+
+    @Test
+    fun `hides the chip when no chapter is loaded, even if isPlaying is stale-true`() {
+        // The last /playback/state DataItem persists across reboots; gating on a
+        // loaded chapter keeps a stale isPlaying flag from resurrecting a chip.
+        assertEquals(
+            OngoingAction.Hide,
+            ongoingActionFor(PlaybackState(isPlaying = true, currentChapterId = null)),
+        )
+    }
+
+    @Test
+    fun `title falls back to book then app name, and book is not duplicated as subtitle`() {
+        val bookOnly = ongoingActionFor(
+            PlaybackState(isPlaying = true, currentChapterId = "c1", bookTitle = "Just A Book"),
+        ) as OngoingAction.Show
+        assertEquals("Just A Book", bookOnly.title)
+        // No chapter title → don't repeat the book as the subtitle.
+        assertNull(bookOnly.subtitle)
+
+        val nothing = ongoingActionFor(
+            PlaybackState(isPlaying = true, currentChapterId = "c1"),
+        ) as OngoingAction.Show
+        assertEquals("storyvox", nothing.title)
+        assertNull(nothing.subtitle)
+    }
+}


### PR DESCRIPTION
Two Wear companion items (assigned together).

## 1. Surface retryable playback errors on the watch (commit 1)

The phone already publishes the full `PlaybackState` (incl. the `error` band) over `/playback/state`, and the watch decodes it into the same class — but `NowPlayingScreen` ignored `state.error`, so a #1262/#1311 error left the watch on a **frozen now-playing** while the phone showed the failure.

- `NowPlayingScreen` now renders an error surface (icon + summary + **Retry** chip) that takes precedence over the transport, mirroring the phone reader banner.
- Retry sends a new payload-less `CMD_RETRY`; `PhoneWearBridge` re-loads the current chapter (`controller.play(...)` clears the error), mirroring the reader's `play()`-to-retry.
- Shared `PlaybackError.isRetryable()` / `watchSummary()` in `PlaybackState.kt` as the single source of truth; `PlaybackController.isRetryable` now delegates to it so the phone banner and the watch chip can't diverge.
- Pure-function unit test (`PlaybackErrorRetryableTest`).

## 2. Ongoing Activity media chip (commit 2)

Surfaces active phone playback on the **watch face + system ongoing strip** via `androidx.wear:wear-ongoing`, with chapter title + a play/pause control.

- `WearOngoingPlaybackService` — foreground service (type `mediaPlayback`) posting an ongoing notification decorated as an `OngoingActivity`. Play/pause → `CMD_TOGGLE`; chip touch → opens the app.
- `PlaybackStateListenerService` (`WearableListenerService`) — receives `/playback/state` even when the watch app is closed and starts/stops the chip via the pure `ongoingActionFor()` rule (show only while *actively playing a loaded chapter* — gating on `isPlaying` avoids a stale boot chip from the persisted DataItem).
- Manifest: `FOREGROUND_SERVICE`(+`_MEDIA_PLAYBACK`)/`POST_NOTIFICATIONS` + both services. `wear-ongoing` added to the version catalog.
- Pure-function unit test (`OngoingActionTest`).

## ⚠️ Verification gap (no watch in CI — compile-verified only)

The Ongoing Activity runtime needs **on-watch verification**, which I can't do here:
- the chip actually rendering on the watch face,
- the foreground-start from a background data-layer event (Android 12+ FGS/BAL rules),
- the `POST_NOTIFICATIONS` runtime grant on Wear 4.

Platform-uncertain calls (`startForeground`, the toggle send) are wrapped in `runCatching` so a restriction degrades to "no chip" rather than a crash. **Follow-up:** the `POST_NOTIFICATIONS` runtime request (Activity-side) is intentionally *not* included — it touches `WearApp.kt`, which the in-flight Wear speed-control work (#105) is also editing; better to add it once that lands to avoid a merge collision.

The error/Retry piece (commit 1) is fully exercisable and low-risk; it's reviewable/mergeable independently of the Ongoing Activity piece if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Wear OS ongoing playback chip that mirrors active playback on the watch.
  * Added a retry action on the watch “Now Playing” screen for eligible playback errors.
  * Added support for reloading the current chapter from the watch after a playback failure.

* **Bug Fixes**
  * Improved error handling so retry is shown only for recoverable issues.
  * Added clearer, shorter watch-friendly error messages.
  * The watch now hides playback controls when an error is being shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->