### PR TITLE
fix(teleprompter): un-break main — cross-module smart-cast in TeleprompterOverlay (#1369)

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/recording/TeleprompterOverlay.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/recording/TeleprompterOverlay.kt
@@ -231,13 +231,17 @@ private fun CueCard(text: String, fontSize: Int, opacity: Float) {
 
 @Composable
 private fun ScriptLineRow(line: ScriptBlock.Line, fontSize: Int, opacity: Float) {
-    val speakerColor = line.speaker?.let {
+    // #1369 — `ScriptSpeaker` moved to :core-data, so `line.speaker` is now a
+    // public property declared in a different module; Kotlin won't smart-cast
+    // it. Bind it to a local val, which CAN be smart-cast after the null check.
+    val speaker = line.speaker
+    val speakerColor = speaker?.let {
         SpeakerPalette[it.colorIndex % SpeakerPalette.size].copy(alpha = opacity)
     }
     Column(modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)) {
-        if (line.showLabel && line.speaker != null && speakerColor != null) {
+        if (line.showLabel && speaker != null && speakerColor != null) {
             Text(
-                text = line.speaker.name,
+                text = speaker.name,
                 color = speakerColor,
                 fontSize = (fontSize * 0.5f).sp,
                 fontWeight = FontWeight.ExtraBold,


### PR DESCRIPTION
**Main is red** — un-break it.

PR #1413's parser dedup (moving `ScriptSpeaker` to `:core-data`) made `TeleprompterOverlay.ScriptLineRow` fail to compile: it smart-cast `line.speaker` after a null check, which Kotlin forbids for a public property declared in another module. The unify PR's 2nd-commit CI was **cancelled by the merge** before completing, so the error slipped onto main; `Build APK` has failed since 31b3a822 (wear PRs #1418/#1420/#1422 inherited it).

**Fix:** bind `line.speaker` to a local `val speaker` (a local val smart-casts fine across the null check). One-line-shaped change, no behavior change.

Verified the only nullable property among the moved types is `ScriptBlock.Line.speaker`, so this is the sole cross-module smart-cast site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)