### PR TITLE
docs(wear): document storyvox_playback_controller as a Data Layer contract id (#1409)

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/wear/PhoneWearBridge.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/wear/PhoneWearBridge.kt
@@ -253,11 +253,40 @@ class PhoneWearBridge @Inject constructor(
     }
 
     companion object {
+        /**
+         * **Wear Data Layer contract — DO NOT RENAME the identifiers below.**
+         *
+         * [CAPABILITY_PLAYBACK_CONTROLLER] plus the `PATH_*` / `CMD_*` paths form the wire
+         * contract between the phone ([PhoneWearBridge]) and the watch
+         * ([in.jphe.storyvox.wear.playback.WearPlaybackBridge]). Both installs hardcode the
+         * exact same strings and the Google Wearable Data Layer routes purely by literal
+         * match — there is no negotiation, versioning, or alias layer. Renaming any of them
+         * silently breaks phone↔watch communication for every user whose two installs
+         * disagree (e.g. updated phone, not-yet-updated watch).
+         *
+         * The `storyvox_` prefix predates the candela rebrand and is **deliberately frozen**:
+         * it is an opaque routing token, never shown to users, so it carries no branding cost
+         * — while changing it would split old/new installs. See issue #1409.
+         */
+
+        /**
+         * Wear Data Layer **capability** the watch advertises so the phone can discover the
+         * playback-controller node. Its source of truth is the literal in
+         * `wear/src/main/res/values/wear.xml` (`<string-array name="android_wear_capabilities">`),
+         * which the Google Wearable service reads to advertise the capability; a resource
+         * array cannot reference this constant, so the two MUST be kept byte-identical. This
+         * constant is the documented home + the value any phone-side `CapabilityClient`
+         * lookup must use. **DO NOT RENAME** — see the contract note above and issue #1409.
+         */
+        const val CAPABILITY_PLAYBACK_CONTROLLER = "storyvox_playback_controller"
+
         /** Minimum gap between position beacons while playing (~1Hz). Discrete
          *  state changes still publish immediately; this only rate-limits the
          *  position-drift refresh the watch extrapolates between. */
         const val BEACON_INTERVAL_MS = 1_000L
 
+        /** DataItem path the watch reads to hydrate playback state on boot.
+         *  Wire contract (see the DO-NOT-RENAME note above) — #1409. */
         const val PATH_STATE = "/playback/state"
 
         /** DataItem path for the Wear Listening Stats complication —

--- a/wear/src/main/res/values/wear.xml
+++ b/wear/src/main/res/values/wear.xml
@@ -1,5 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <!--
+      Wear Data Layer capability advertised by the watch app. The Google Wearable
+      service reads `android_wear_capabilities` automatically to advertise each item,
+      so the phone can discover this node via CapabilityClient.
+
+      ⚠ DO NOT RENAME "storyvox_playback_controller" — it is a phone↔watch wire
+      contract, matched by literal string with no negotiation/alias layer. The
+      `storyvox_` prefix predates the candela rebrand and is deliberately frozen: it is
+      an opaque routing token (never shown to users), and renaming it would break
+      communication for any user whose phone and watch installs disagree.
+
+      Mirrored (and documented) in code as
+      PhoneWearBridge.CAPABILITY_PLAYBACK_CONTROLLER — keep the two byte-identical.
+      See issue #1409.
+    -->
     <string-array name="android_wear_capabilities">
         <item>storyvox_playback_controller</item>
     </string-array>


### PR DESCRIPTION
Closes #1409.

## What
Documents `storyvox_playback_controller` (and the broader phone↔watch Data Layer contract) as a **DO-NOT-RENAME** wire identifier at its canonical sites. Docs-only — no behavior change.

## Why
The Wear capability `storyvox_playback_controller` (declared in `wear/src/main/res/values/wear.xml` → `android_wear_capabilities`) and the `PATH_*` / `CMD_*` message paths in `PhoneWearBridge` are a **wire contract**: phone and watch both hardcode the identical literals, and the Google Wearable Data Layer routes purely by string match — there is no negotiation, versioning, or alias layer. Renaming any of them silently breaks communication for any user whose phone and watch installs disagree (e.g. updated phone, not-yet-updated watch).

The `storyvox_` prefix predates the candela rebrand. It is an **opaque routing token, never shown to users**, so it carries no branding cost — and changing it would split old/new installs. It must survive the rebrand untouched.

## Changes
- **`wear.xml`** — XML comment on the capability declaration (the framework-read source of truth) explaining the contract + the freeze.
- **`PhoneWearBridge`** — companion-level DO-NOT-RENAME contract note covering the capability **and** all `PATH_*`/`CMD_*` paths, plus a documented `CAPABILITY_PLAYBACK_CONTROLLER` constant that mirrors `wear.xml` so any phone-side `CapabilityClient` lookup has a single documented home (kept byte-identical to the resource array, which can't reference a constant).

## Contract surface (audited)
- Capability: `storyvox_playback_controller` (1 declaration, `wear.xml`).
- Paths: `PATH_STATE`, `PATH_STATS_TODAY`, ~20 `CMD_*` — all defined once in `PhoneWearBridge`.
- Verified **single source of truth**: every consumer (incl. `WearPlaybackBridge`) references the `PhoneWearBridge` constants — no duplicate hardcoded literals to drift.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clearer guidance around the phone-to-watch data layer contract.
  * Highlighted that several playback-related identifiers must not be renamed to keep phone and watch communication working.
  * Clarified that the shared capability token is intentionally kept identical across both sides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->