### PR TITLE
fix(wear): build-config bundle — version, targetSdk, release docs, drop unused Hilt (#1405 #1406 #1407 #1408)

### DIFF
--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -56,6 +56,18 @@ android {
             applicationIdSuffix = ".debug"
         }
         release {
+            // #1407 — this is an INTENTIONAL sideload/companion config, NOT a
+            // Play-Store-ready release build. Two deliberate choices:
+            //   • minify OFF — the watch APK is sideloaded, not shrunk. R8 is
+            //     deferred until a real Wear Play listing exists (it needs
+            //     baseline testing first). proguardFiles is declared so turning
+            //     R8 on later is a one-line flip, but it's inert while minify is off.
+            //   • signed with :app's checked-in DEBUG keystore (see signingConfigs
+            //     below) — the Wearable Data Layer bridge only pairs when phone +
+            //     watch share a signing cert, and an unsigned release APK can't be
+            //     adb-installed for sideload.
+            // Before any Play Store Wear submission: switch to a real upload key
+            // and evaluate enabling R8/minify. Until then this state is by design.
             isMinifyEnabled = false
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
             // An unsigned release APK can't be adb-installed; sign the

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -1,8 +1,11 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.compose)
-    alias(libs.plugins.ksp)
-    alias(libs.plugins.hilt)
+    // #1408 — Hilt + KSP removed: :wear had the Hilt plugin, ksp(hilt.compiler)
+    // and hilt-android applied but used NONE of it (no @HiltAndroidApp /
+    // @AndroidEntryPoint / @Inject anywhere in wear/src). KSP had no other
+    // processor, so it goes too. See the dependencies block for why wear can't
+    // simply be made a Hilt root today.
     alias(libs.plugins.kotlin.serialization)
 }
 
@@ -151,9 +154,15 @@ dependencies {
     implementation(libs.androidx.wear.protolayout)
     implementation(libs.androidx.concurrent.futures)
 
-    // Hilt (optional in v1; wired so Hypnos can use @AndroidEntryPoint)
-    implementation(libs.hilt.android)
-    ksp(libs.hilt.compiler)
+    // #1408 — Hilt intentionally NOT applied here. It was wired but unused, so
+    // it ran on every build for zero benefit and was a latent footgun (adding
+    // @AndroidEntryPoint without a @HiltAndroidApp Application crashes at runtime).
+    // Re-adding it is not just a plugin flip: :wear depends on :core-playback,
+    // whose @AndroidEntryPoint services (e.g. StoryvoxPlaybackService) inject
+    // bindings provided only in :app (SleepTimerExtendConfig, BedtimeSleepConfig…).
+    // Rooting a Hilt graph here aggregates those entry points and fails to compile
+    // because wear can't supply :app's bindings. Decouple core-playback's entry
+    // points first, then re-introduce Hilt in :wear.
 
     // Media3 session controller — Wear connects to phone's MediaSession
     implementation(libs.androidx.media3.session)

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -31,7 +31,7 @@ android {
     defaultConfig {
         applicationId = "in.jphe.storyvox.wear"
         minSdk = 26
-        targetSdk = 34   // Wear OS targets sdk 34 in 2026; bump alongside Wear platform support.
+        targetSdk = 36   // #1406 — match :app's targetSdk (Android 16); compileSdk 37 ≥ 36.
         versionCode = phoneVersionCode   // #1405 — shared with :app (see top of file)
         versionName = phoneVersionName   // #1405 — shared with :app (see top of file)
     }

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -6,6 +6,24 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
 }
 
+// ── #1405: the watch APK tracks the phone app's version ─────────────────────
+// Library Nocturne is a wear-focused release, and a paired sideload must upgrade
+// phone + watch in lockstep — a version skew across the Wearable Data Layer
+// bridge is exactly the kind of mismatch that strands the watch on a stale
+// protocol. So rather than carry a second version literal here (which silently
+// drifted to 0.1.0 / versionCode 1 while :app advanced to 1.6.0 / 254), read
+// :app's version straight from its build file — the single place the release
+// pipeline bumps. A configuration-time file read is tracked as a build input,
+// so this stays configuration-cache correct (cache is on; see gradle.properties)
+// and a phone bump invalidates + refreshes this automatically.
+val appBuildScript = rootProject.file("app/build.gradle.kts").readText()
+val phoneVersionCode: Int =
+    Regex("""\bversionCode\s*=\s*(\d+)""").find(appBuildScript)?.groupValues?.get(1)?.toInt()
+        ?: error("wear/build.gradle.kts (#1405): could not read versionCode from app/build.gradle.kts")
+val phoneVersionName: String =
+    Regex("""\bversionName\s*=\s*"([^"]+)"""").find(appBuildScript)?.groupValues?.get(1)
+        ?: error("wear/build.gradle.kts (#1405): could not read versionName from app/build.gradle.kts")
+
 android {
     namespace = "in.jphe.storyvox.wear"
     compileSdk = 37
@@ -14,8 +32,8 @@ android {
         applicationId = "in.jphe.storyvox.wear"
         minSdk = 26
         targetSdk = 34   // Wear OS targets sdk 34 in 2026; bump alongside Wear platform support.
-        versionCode = 1
-        versionName = "0.1.0"
+        versionCode = phoneVersionCode   // #1405 — shared with :app (see top of file)
+        versionName = phoneVersionName   // #1405 — shared with :app (see top of file)
     }
 
     signingConfigs {


### PR DESCRIPTION
## wear: build-config cleanup bundle

Fixes a bundle of `:wear` build-config findings from the Wear-module review (PR #1396). Four separate commits, all touching `wear/` only.

### Closes #1405 — version tied to the phone app
`:wear` was pinned at `versionName "0.1.0"` / `versionCode 1` while `:app` is at `1.6.0` / `254`. A version skew across the Wearable Data Layer bridge can strand a paired watch on a stale protocol, and `versionCode 1` can never receive an update if the watch APK is ever version-tracked.

Now `:wear` reads `versionCode`/`versionName` straight from `app/build.gradle.kts` — the single file the release pipeline bumps — so the two stay in lockstep with no second literal to drift. The configuration-time file read is a tracked build input, so it stays configuration-cache correct (cache is enabled).

### Closes #1406 — targetSdk 34 → 36
`:app` targets SDK 36 (Android 16); `:wear` lagged at 34. `compileSdk` is already 37, so 36 compiles cleanly. Brings the modules into alignment.

> Note: issue #1406 leaned toward *holding* until the Wear platform + AGP fully support 35/36 for Wear submissions. This PR follows the explicit direction to align with the phone now. The bump only affects targeted platform *behavior*; it doesn't change what compiles. Worth a quick on-device sanity check of the foreground playback/ongoing-activity services on a watch before a Wear release, since higher targetSdk tightens FGS rules.

### Closes #1407 — documents the intentional sideload release config (no code change)
The `release` buildType keeps minify off and signs with `:app`'s checked-in debug keystore. Both are deliberate for the sideload/companion flow: the Data Layer bridge requires phone + watch to share a signing cert, and an unsigned release APK can't be `adb`-installed. Added an explicit comment so the state reads as intentional, with the "switch to a real upload key + evaluate R8 before any Play Store Wear release" caveat.

### Closes #1408 — drop unused Hilt + KSP wiring (chose option **b**)
`:wear` applied the Hilt plugin, `ksp(hilt.compiler)`, and `hilt-android` but used none of it (no `@HiltAndroidApp` / `@AndroidEntryPoint` / `@Inject` anywhere in `wear/src`). The processors ran every build for zero benefit, and it was a latent footgun.

**Why option (b) and not (a):** option (a) — add a `@HiltAndroidApp` Application — **does not compile**. `:wear` depends on `:core-playback`, whose `@AndroidEntryPoint` services (e.g. `StoryvoxPlaybackService`) inject bindings provided only in `:app` (`SleepTimerExtendConfig`, `BedtimeSleepConfig`, …). Rooting a Hilt graph in `:wear` aggregates those entry points into wear's component and fails Dagger graph validation because wear can't supply `:app`'s bindings. Today wear builds *precisely because it has no Hilt root*. Removing the wiring is the only non-breaking fix, and it removes the footgun more cleanly than (a) would: without the plugin, adding `@AndroidEntryPoint` is a compile error, not a runtime crash. KSP had no other processor, so it's removed too.

Re-introducing Hilt in `:wear` later requires decoupling `core-playback`'s entry points from `:app`-only bindings first (separate, larger work).

### Verification
- Four conventional commits, `wear/` only; no secrets/debug artifacts.
- Not compiled locally (per repo policy — CI `Build APK` is the compile gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
