### PR TITLE
fix(pdf): reflow soft line breaks from PDF text extraction (#1428)

### DIFF
--- a/source-pdf/src/main/kotlin/in/jphe/storyvox/source/pdf/parse/PdfChapterBuilder.kt
+++ b/source-pdf/src/main/kotlin/in/jphe/storyvox/source/pdf/parse/PdfChapterBuilder.kt
@@ -130,9 +130,13 @@ object PdfChapterBuilder {
 
     /** Join a chapter's pages into one plain-text body, separating
      *  pages with a blank line and dropping blank (image-only/no-OCR)
-     *  pages from the body. */
+     *  pages from the body. Each page is [reflowPdfText]-reflowed first
+     *  (#1428) so PdfBox's per-visual-line newlines don't survive as bad
+     *  mid-paragraph breaks in the narration / reader. Page boundaries
+     *  stay paragraph breaks — a paragraph that spills across a page
+     *  break is split there, matching the pre-existing page-join contract. */
     private fun joinPages(pages: List<PdfPage>): String =
-        pages.map { it.text.trim() }
+        pages.map { reflowPdfText(it.text) }
             .filter { it.isNotEmpty() }
             .joinToString("\n\n")
 
@@ -142,4 +146,104 @@ object PdfChapterBuilder {
     private fun List<PdfChapter>.filterBlankBodies(): List<PdfChapter> =
         filter { it.plainBody.isNotBlank() }
             .mapIndexed { idx, ch -> ch.copy(index = idx) }
+}
+
+/**
+ * Issue #1428 — reflow one PDF page's extracted text so that *soft* line
+ * breaks (the per-visual-line `\n`s PdfBox emits for every wrapped line of
+ * a paragraph) merge back into spaces, while *real* structural breaks are
+ * preserved.
+ *
+ * The app-side [PdfTextProvider] runs PdfBox's `PDFTextStripper` with
+ * default settings, which ends every laid-out line with `\n` — so a
+ * paragraph wrapped over five lines arrives as five lines glued by hard
+ * newlines. Fed straight to TTS (via `plainBody`) that narrates with broken
+ * cadence, and `toParagraphHtml` only splits on blank lines so the stray
+ * newlines linger inside each `<p>`. Reflowing here — the one place page
+ * text becomes a chapter body — fixes narration and reader in a single
+ * pure, unit-testable step.
+ *
+ * Breaks PRESERVED as paragraph boundaries:
+ *  - a blank line (PdfBox emits one where there's extra vertical leading,
+ *    i.e. between paragraphs);
+ *  - a line beginning a bullet / numbered list item;
+ *  - an indented line that follows a completed sentence (first-line-indent
+ *    paragraph style).
+ *
+ * Breaks MERGED to a single space: every other newline between two
+ * non-blank lines. A line ending in `-` after a letter is rejoined with the
+ * next line — the hyphen dropped when the next line starts lowercase
+ * (justified-wrap hyphenation), kept when it starts upper/digit (a real
+ * compound such as "Anglo-Saxon"). The rare compound that wraps exactly at
+ * its hyphen with a lowercase tail (e.g. "well-known") loses the hyphen —
+ * an accepted trade for fixing the common justified-wrap case.
+ *
+ * Prose-optimized: meaningful line breaks in poetry / tables / addresses
+ * are reflowed too. That is the intended direction for a TTS audiobook
+ * source where the reported defect is *too many* breaks, and the blank-line
+ * + list heuristics still preserve coarse structure.
+ */
+internal fun reflowPdfText(raw: String): String {
+    if (raw.isBlank()) return ""
+    val lines = raw.replace("\r\n", "\n").replace('\r', '\n').split('\n')
+    val paragraphs = mutableListOf<String>()
+    val buf = StringBuilder()
+
+    fun flush() {
+        if (buf.isNotBlank()) paragraphs += buf.toString()
+        buf.setLength(0)
+    }
+
+    for (rawLine in lines) {
+        val line = rawLine.trim()
+        if (line.isEmpty()) {
+            flush() // blank line → paragraph boundary (collapses runs of blanks)
+            continue
+        }
+        if (buf.isNotEmpty() && startsNewParagraph(rawLine, line, buf)) flush()
+        if (buf.isEmpty()) buf.append(line) else appendWrapped(buf, line)
+    }
+    flush()
+
+    return paragraphs.joinToString("\n\n") { it.replace(MULTI_SPACE, " ").trim() }
+}
+
+private val MULTI_SPACE = Regex("[ \\t]+")
+
+/** Bullet (•, ◦, ▪, ‣, *) or dash/en/em-dash list marker, or a numbered
+ *  item ("1.", "12)") at the very start of a (trimmed) line. */
+private val LIST_START = Regex("^([\\u2022\\u25E6\\u25AA\\u2023*]\\s*|[-\\u2013\\u2014]\\s+|\\d{1,3}[.)]\\s+)")
+
+/** A non-blank line begins a new paragraph (despite no preceding blank
+ *  line) when it opens a list item, or when it is indented and the text so
+ *  far ended a sentence — the first-line-indent paragraph convention. */
+private fun startsNewParagraph(rawLine: String, trimmed: String, buf: StringBuilder): Boolean {
+    if (LIST_START.containsMatchIn(trimmed)) return true
+    val indent = rawLine.length - rawLine.trimStart().length
+    return indent >= 2 && endsSentence(buf)
+}
+
+/** True when the buffered text's last visible character is sentence-final
+ *  (`.`/`!`/`?`), allowing one trailing closing quote or paren. */
+private fun endsSentence(buf: CharSequence): Boolean {
+    var i = buf.length - 1
+    while (i >= 0 && buf[i].isWhitespace()) i--
+    if (i >= 0 && (buf[i] == '"' || buf[i] == '\'' || buf[i] == '”' || buf[i] == '’' || buf[i] == ')' || buf[i] == ']')) i--
+    if (i < 0) return false
+    return buf[i] == '.' || buf[i] == '!' || buf[i] == '?'
+}
+
+/** Append a wrapped continuation line to the paragraph buffer, handling
+ *  end-of-line hyphenation (see [reflowPdfText] kdoc). */
+private fun appendWrapped(buf: StringBuilder, next: String) {
+    val n = buf.length
+    val endsHyphen = n >= 2 && buf[n - 1] == '-' && buf[n - 2].isLetter()
+    when {
+        endsHyphen && next.firstOrNull()?.isLowerCase() == true -> {
+            buf.setLength(n - 1) // soft hyphen from a line-wrap → de-hyphenate
+            buf.append(next)
+        }
+        endsHyphen -> buf.append(next) // keep the hyphen (compound/dash), no inserted space
+        else -> buf.append(' ').append(next)
+    }
 }

--- a/source-pdf/src/test/kotlin/in/jphe/storyvox/source/pdf/PdfChapterBuilderTest.kt
+++ b/source-pdf/src/test/kotlin/in/jphe/storyvox/source/pdf/PdfChapterBuilderTest.kt
@@ -109,6 +109,23 @@ class PdfChapterBuilderTest {
     }
 
     @Test
+    fun `page bodies are reflowed so wrapped lines do not survive as breaks`() {
+        // #1428 — a single page whose paragraph PdfBox split across visual
+        // lines must come back as flowing text, with the real (blank-line)
+        // paragraph break preserved.
+        val input = pages(
+            "This sentence was wrapped\nacross three visual lines\nby the PDF layout.\n\nThis is a separate paragraph.",
+        )
+        val chapters = PdfChapterBuilder.build(input, pagesPerChapter = 5)
+        assertEquals(1, chapters.size)
+        assertEquals(
+            "This sentence was wrapped across three visual lines by the PDF layout.\n\n" +
+                "This is a separate paragraph.",
+            chapters[0].plainBody,
+        )
+    }
+
+    @Test
     fun `chapter ids are stable and unique by first page`() {
         // 2 heading pages out of 4 (fraction 0.5 <= 0.6) -> heading split.
         val input = pages(

--- a/source-pdf/src/test/kotlin/in/jphe/storyvox/source/pdf/parse/ReflowPdfTextTest.kt
+++ b/source-pdf/src/test/kotlin/in/jphe/storyvox/source/pdf/parse/ReflowPdfTextTest.kt
@@ -1,0 +1,123 @@
+package `in`.jphe.storyvox.source.pdf.parse
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1428 — tests for [reflowPdfText]. PdfBox's `PDFTextStripper`
+ * emits one `\n` per laid-out line, so a wrapped paragraph arrives as
+ * several hard-broken lines. These pin the soft-break → space reflow while
+ * proving real structure (blank lines, lists, indented paragraph starts) is
+ * preserved.
+ */
+class ReflowPdfTextTest {
+
+    @Test
+    fun `soft line wrap within a paragraph merges into spaces`() {
+        val input = "The quick brown fox\njumps over the lazy\ndog near the riverbank."
+        assertEquals(
+            "The quick brown fox jumps over the lazy dog near the riverbank.",
+            reflowPdfText(input),
+        )
+    }
+
+    @Test
+    fun `blank line separates paragraphs`() {
+        val input = "First paragraph wraps\nover two lines.\n\nSecond paragraph\nalso wraps."
+        assertEquals(
+            "First paragraph wraps over two lines.\n\nSecond paragraph also wraps.",
+            reflowPdfText(input),
+        )
+    }
+
+    @Test
+    fun `runs of blank lines collapse to one break`() {
+        assertEquals("A line\n\nB line", reflowPdfText("A line\n\n\n\nB line"))
+    }
+
+    @Test
+    fun `end of line hyphen with lowercase tail is de-hyphenated`() {
+        assertEquals("international law applies", reflowPdfText("inter-\nnational law applies"))
+    }
+
+    @Test
+    fun `end of line hyphen before a capital keeps the hyphen`() {
+        assertEquals("Anglo-Saxon kings ruled", reflowPdfText("Anglo-\nSaxon kings ruled"))
+    }
+
+    @Test
+    fun `carriage returns are normalized`() {
+        assertEquals("line one line two", reflowPdfText("line one\r\nline two"))
+        assertEquals("a\n\nb", reflowPdfText("a\r\n\r\nb"))
+    }
+
+    @Test
+    fun `bullet list items are not merged together`() {
+        val out = reflowPdfText("Shopping list\n- milk\n- eggs\n- bread")
+        // Each item survives as its own block — never run together.
+        assertTrue(out.contains("- milk"))
+        assertTrue(out.contains("- eggs"))
+        assertFalse(out.contains("milk - eggs"))
+        assertEquals(4, out.split("\n\n").size)
+    }
+
+    @Test
+    fun `numbered list items stay separate`() {
+        val out = reflowPdfText("1. First item\n2. Second item\n3. Third item")
+        assertEquals(3, out.split("\n\n").size)
+        assertFalse(out.contains("item 2"))
+    }
+
+    @Test
+    fun `indented line after a sentence starts a new paragraph`() {
+        val input = "End of the first paragraph here.\n   The next paragraph is indented."
+        assertEquals(
+            "End of the first paragraph here.\n\nThe next paragraph is indented.",
+            reflowPdfText(input),
+        )
+    }
+
+    @Test
+    fun `indented continuation without a sentence end still merges`() {
+        // Indent alone must NOT split — only indent + a completed sentence.
+        val input = "a wrapped clause ending mid\n   thought continues here"
+        assertEquals("a wrapped clause ending mid thought continues here", reflowPdfText(input))
+    }
+
+    @Test
+    fun `blank or whitespace input yields empty string`() {
+        assertEquals("", reflowPdfText(""))
+        assertEquals("", reflowPdfText("   \n\n  \t "))
+    }
+
+    @Test
+    fun `repeated spaces and tabs collapse to one space`() {
+        assertEquals("word1 word2 word3", reflowPdfText("word1    word2\tword3"))
+    }
+
+    @Test
+    fun `leading and trailing blank lines are trimmed`() {
+        assertEquals("Hello world", reflowPdfText("\n\n  Hello world  \n\n"))
+    }
+
+    @Test
+    fun `a realistic multi-line paragraph reflows to flowing prose`() {
+        val extracted = buildString {
+            append("Dear applicant,\n")
+            append("we are writing to inform you that your\n")
+            append("benefits have been approved effective\n")
+            append("the first of next month.\n")
+            append("\n")
+            append("Please retain this letter for your\n")
+            append("records.")
+        }
+        assertEquals(
+            "Dear applicant, we are writing to inform you that your benefits have been " +
+                "approved effective the first of next month.\n\n" +
+                "Please retain this letter for your records.",
+            reflowPdfText(extracted),
+        )
+    }
+}


### PR DESCRIPTION
## Issue

#1428 — "import PDF worked, but there were bad line breaks."

## Root cause

The `:app` provider runs PdfBox's `PDFTextStripper` with default settings, which terminates **every laid-out visual line** with `\n`. So a paragraph wrapped over N lines arrives as N hard-broken lines. Nothing in `:source-pdf` reflowed them, so they flowed:

- verbatim into `plainBody` → **TTS narrates with broken cadence**, and
- into each `<p>` of `toParagraphHtml` (which only splits on *blank* lines) → stray mid-paragraph newlines **lingered in the reader**.

## Fix

Add a pure, Android-free `reflowPdfText()` in the `parse/` layer and apply it per page in `PdfChapterBuilder.joinPages()` — the single point where page text becomes a chapter body, so **both** the narration (`plainBody`) and reader (`htmlBody`) paths are fixed at once.

**Merged → space:** soft (within-paragraph) line breaks.
**Preserved as paragraph boundaries:** blank lines, bullet/numbered list items, and indented first-lines that follow a completed sentence.
**De-hyphenation:** an end-of-line `-` is rejoined — hyphen dropped when the next line starts lowercase (`inter-\nnational` → `international`), kept when it starts upper/digit (`Anglo-\nSaxon` → `Anglo-Saxon`).

Prose-optimized by design: this is a TTS audiobook source and the reported defect is *too many* breaks, so the reflow leans toward merging while the blank-line/list heuristics keep coarse structure. Heading detection is unchanged (it reads raw page text before reflow). Page boundaries remain paragraph breaks, matching the prior page-join contract.

## Tests

- `ReflowPdfTextTest` — soft-wrap merge, blank-line separation, blank-run collapse, de-hyphenation (both directions), CRLF, bullet + numbered lists, indent-after-sentence, indent-without-sentence (must still merge), whitespace/empty, space/tab collapse, and a realistic benefit-letter reflow.
- `PdfChapterBuilderTest` — integration case proving `joinPages` reflows while preserving the real paragraph break.

Logic was additionally validated against all expected outputs via a faithful out-of-band port (no local Android compile; CI is the compile gate).