### PR TITLE
fix(playback): guard loadAndPlay against uncaught crashes on play (#1382)

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/tts/EnginePlayer.kt
@@ -1918,6 +1918,17 @@ class EnginePlayer @AssistedInject constructor(
         charOffset: Int,
         autoPlay: Boolean = true,
     ) = loadAndPlayMutex.withLock {
+        // Issue #1382 ("app crashes on play") — defense-in-depth. This is the
+        // single chokepoint every play path funnels through, and it touches
+        // throw-capable surfaces that the guards below do NOT anticipate: Room
+        // reads (chapterRepo/fictionRepo), the native sherpa-onnx loadModel in
+        // startPlaybackPipeline, and the sentence chunker. `scope` is a
+        // SupervisorJob with NO CoroutineExceptionHandler, and SupervisorJob
+        // does not swallow exceptions — so pre-fix an unanticipated throw here
+        // reached the thread's default uncaught handler = hard crash on play.
+        // Wrap the body: log the full stacktrace (instruments the real trigger
+        // for the next occurrence) and surface a recoverable error instead.
+        try {
         DebugLog.i("EnginePlayer") { "loadAndPlay fiction=$fictionId chapter=$chapterId charOffset=$charOffset autoPlay=$autoPlay" }
         // Issue #944 / #956 — dedup double-fire (the second of a rapid
         // handleChapterDone + watchdog or user-tap + MediaSession-Next
@@ -2674,6 +2685,33 @@ class EnginePlayer @AssistedInject constructor(
             startPlaybackPipeline()
         }
         invalidateState()
+        } catch (t: Throwable) {
+            // #1382 — Cancellation MUST propagate: a newer loadAndPlay(), a
+            // stop, or a voice/speed rebuild cancels this coroutine via
+            // CancellationException; swallowing it would break structured
+            // concurrency. Rethrow before the catch-all.
+            if (t is kotlinx.coroutines.CancellationException) throw t
+            android.util.Log.e(
+                "EnginePlayer",
+                "loadAndPlay crashed (fiction=$fictionId chapter=$chapterId " +
+                    "charOffset=$charOffset) — surfacing a recoverable error " +
+                    "instead of crashing the app (#1382)",
+                t,
+            )
+            // Tear down any half-built pipeline so no orphan producer/consumer
+            // streams under a dead UI surface. Best-effort.
+            runCatching { stopPlaybackPipeline() }
+            _observableState.update {
+                it.copy(
+                    isPlaying = false,
+                    isBuffering = false,
+                    error = PlaybackError.ChapterFetchFailed(
+                        "Couldn't start playback — please try again.",
+                    ),
+                )
+            }
+            invalidateState()
+        }
     }
 
     /**


### PR DESCRIPTION
## What

Wrap `EnginePlayer.loadAndPlay` — the single chokepoint every play path funnels through — in `try/catch(Throwable)` so an unexpected exception during playback start can no longer crash the app.

## Why (the confirmed defect)

`EnginePlayer.scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)` has **no `CoroutineExceptionHandler`** (grep-verified: zero handlers anywhere in `core-playback`). A `SupervisorJob` isolates sibling cancellation but **does not swallow exceptions** — so any throw inside `scope.launch { loadAndPlay(...) }` (auto-advance) or propagating up the suspend `play()` path reached the thread's default uncaught handler → **hard crash on play**.

`loadAndPlay` guards its *anticipated* failures (null chapter → `ChapterFetchFailed`, null voice → `EngineUnavailable`, empty chunk → typed error) but had **no catch-all** for *unanticipated* throws on its risky surfaces: Room reads (`chapterRepo`/`fictionRepo`), the native sherpa-onnx `loadModel` in `startPlaybackPipeline`, and the sentence chunker. This is precisely the "crashes on play" symptom class.

## The fix

A minimal two-point wrap of the `loadAndPlay` body (body intentionally not re-indented to keep the diff reviewable on this 6.2k-line file):

1. **Rethrow `CancellationException`** before the catch-all — a newer `loadAndPlay` / stop / voice-or-speed rebuild cancels this coroutine; swallowing it would break structured concurrency.
2. **`Log.e` the full stacktrace** — instruments the real trigger for the next occurrence (the original report had none).
3. **Tear down any half-built pipeline** (`runCatching { stopPlaybackPipeline() }`).
4. **Surface a recoverable `PlaybackError`** (`isPlaying=false` + error banner + Retry) instead of crashing.

## Honest scope note

`#1382` is **bodyless — no stacktrace, no repro**, so the specific triggering exception is not confirmed. The Samsung crash/loop wave (#1384–#1392) landed within ~2h of #1382 being filed and likely already addressed the original report (issue is being closed as a probable dup). This PR is **defense-in-depth**: it does not target one bug — it makes the entire crash-on-play class impossible *and* logs the stacktrace so any future occurrence is finally diagnosable. Crashing the app on any playback-start throwable is itself a defect worth fixing.

## Testing

No unit test added: `EnginePlayer` can't be JVM-instantiated (Hilt + sherpa native AARs — see the project's pure-decision-fn test pattern), and the change is exception-control-flow with no extractable pure decision beyond the trivial `CancellationException` rethrow. CI `Build APK` is the compile gate (no local compile per project policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
