### PR TITLE
fix(royalroad): prevent chapter wipe from empty parse or CF challenge (#1433)

### DIFF
--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
@@ -326,7 +326,13 @@ class FictionRepositoryImpl @Inject constructor(
         // re-open. `now - fetchedAt` is robust to clock skew here — a future
         // fetchedAt yields a negative age (< TTL) and still skips, which is the
         // safe direction (don't hammer the source).
-        if (!force && existing != null && existing.metadataFetchedAt > 0L &&
+        // #1433 — a fiction that claims N chapters in its metadata but has 0
+        // rows in the chapter table is in an inconsistent state (process kill,
+        // Cloudflare 200 challenge, or empty-parse wipe). Bypass the TTL so the
+        // next open re-fetches and repopulates the chapter rows.
+        val chaptersOrphan = existing != null && existing.chapterCount > 0 &&
+            chapterDao.chapterIdsForFiction(id).isEmpty()
+        if (!force && !chaptersOrphan && existing != null && existing.metadataFetchedAt > 0L &&
             System.currentTimeMillis() - existing.metadataFetchedAt < METADATA_TTL_MS
         ) {
             return@withContext FictionResult.Success(Unit)
@@ -598,6 +604,15 @@ class FictionRepositoryImpl @Inject constructor(
         val existing = fictionDao.get(detail.summary.id)
         fictionDao.upsert(detail.toEntity(existing, now))
 
+        // #1433 — guard: an empty incoming chapter list from a Cloudflare
+        // challenge page (HTTP 200 with JS challenge), a truncated response,
+        // or a process kill mid-parse would wipe every existing chapter via
+        // the DELETE-then-INSERT in upsertChaptersForFiction. Skip the chapter
+        // upsert entirely when the parse returned nothing — the existing
+        // chapter rows (if any) are still valid and will be refreshed on the
+        // next successful detail fetch.
+        if (detail.chapters.isEmpty()) return
+
         // Upsert chapter rows; preserve body + download state for chapters we
         // already have, drop in fresh metadata for new ones.
         val incoming = detail.chapters.map { it.toEntity(detail.summary.id) }
@@ -616,19 +631,6 @@ class FictionRepositoryImpl @Inject constructor(
                 audioUrl = fresh.audioUrl ?: previous.audioUrl,
             )
         }
-        // Issues #349 / #652 — RSS feeds (and any future window-style
-        // backend) reorder rows across refreshes. Plain upsertAll trips
-        // the (fictionId, index) UNIQUE constraint mid-batch because
-        // Room's @Upsert is per-row and the constraint check is
-        // immediate. The original fix (parked-then-upsert) preserved
-        // orphan rows above PARK_OFFSET, but that buried a UNIQUE
-        // collision time-bomb when a chapter was permanently removed
-        // from a source (Notion EBT spending, v0.5.65 → #652 crash on
-        // tablet). upsertChaptersForFiction is now a transactional
-        // DELETE-then-INSERT — every refresh fully replaces the
-        // chapter list. Body / download state / read state for
-        // chapters that survive across refreshes are preserved here
-        // in [merged] via the per-PK lookup above.
         chapterDao.upsertChaptersForFiction(detail.summary.id, merged)
     }
 }
@@ -711,7 +713,7 @@ internal fun FictionDetail.toEntity(existing: Fiction?, now: Long): Fiction {
         genres = genres,
         tags = summary.tags.ifEmpty { base.tags },
         status = summary.status,
-        chapterCount = chapters.size,
+        chapterCount = if (chapters.isNotEmpty()) chapters.size else base.chapterCount,
         wordCount = wordCount ?: base.wordCount,
         rating = summary.rating ?: base.rating,
         views = views ?: base.views,

--- a/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/net/RoyalRoadChallengeFetcher.kt
+++ b/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/net/RoyalRoadChallengeFetcher.kt
@@ -44,16 +44,18 @@ internal class RoyalRoadChallengeFetcher @Inject constructor(
             return FetchOutcome.RateLimited(retry)
         }
         val body = resp.body?.string().orEmpty()
+        if (looksLikeCfChallenge(body)) {
+            return FetchOutcome.CloudflareChallenge(resp.request.url.toString())
+        }
         if (resp.code == 403 || resp.code == 503) {
-            if (body.contains("/cdn-cgi/challenge-platform/") ||
-                body.contains("Just a moment...") ||
-                body.contains("cf-mitigated")
-            ) {
-                return FetchOutcome.CloudflareChallenge(resp.request.url.toString())
-            }
             return FetchOutcome.HttpError(resp.code, resp.message)
         }
         if (!resp.isSuccessful) return FetchOutcome.HttpError(resp.code, resp.message)
         return FetchOutcome.Body(body, resp.request.url.toString())
     }
+
+    private fun looksLikeCfChallenge(body: String): Boolean =
+        body.contains("/cdn-cgi/challenge-platform/") ||
+            body.contains("Just a moment...") ||
+            body.contains("cf-mitigated")
 }


### PR DESCRIPTION
## Summary

Royal Road books stopped displaying chapters in Library and Follows views. Root cause: a non-transactional `upsertDetail` combined with `upsertChaptersForFiction`'s DELETE-then-INSERT pattern meant that any empty chapter parse (Cloudflare challenge page served as HTTP 200, truncated response, or process kill mid-parse) would wipe all existing chapters from the Room database.

Four defense-in-depth fixes:

- **Empty-chapter guard** in `upsertDetail`: skip chapter upsert entirely when the incoming parse returned zero chapters — existing rows remain intact
- **chapterCount protection** in `toEntity`: preserve the fiction's `chapterCount` when the incoming chapter list is empty, preventing the metadata from claiming "0 chapters"
- **SWR TTL bypass**: when a fiction claims N chapters in metadata but the chapter table has 0 rows, bypass the 5-minute stale-while-revalidate window to force an immediate re-fetch
- **Cloudflare HTTP 200 detection**: extract `looksLikeCfChallenge()` and check it before status-code branching, so managed challenges served on HTTP 200 (not just 403/503) are properly classified as `CloudflareChallenge` instead of passed through as valid HTML

Fixes #1433

## Test plan
- [ ] CI Build APK passes
- [ ] Open a Royal Road fiction in Library → chapters display
- [ ] Force-close app mid-detail-fetch → reopen → chapters still present
- [ ] Verify Cloudflare challenge page doesn't wipe chapters

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detail refresh behavior so missing chapter data is recovered automatically, even if cached metadata would normally still be considered fresh.
  * Prevented empty chapter updates from overwriting previously available chapters, reducing the chance of losing chapter lists after a partial fetch.
  * More reliably identifies challenge pages, helping the app distinguish blocked responses from general HTTP errors and recover more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->