### PR TITLE
fix(sync): route Cloud Sync sign-in to InstantDB, not Royal Road (#1434)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -1391,7 +1391,8 @@ private fun StoryvoxNavHostContent(
                 val ctx = androidx.compose.ui.platform.LocalContext.current
                 AccountSettingsScreen(
                     onBack = { navController.popBackStack() },
-                    onOpenSignIn = { navController.navigate(StoryvoxRoutes.authWebView(SourceIds.ROYAL_ROAD)) },
+                    onOpenSyncSignIn = { navController.navigate(StoryvoxRoutes.SYNC) },
+                    onOpenRoyalRoadSignIn = { navController.navigate(StoryvoxRoutes.authWebView(SourceIds.ROYAL_ROAD)) },
                     onOpenGitHubSignIn = { navController.navigate(StoryvoxRoutes.GITHUB_SIGN_IN) },
                     onOpenGitHubRevoke = {
                         // Mirrors the SETTINGS legacy page's revoke handler:

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/AccountSettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/AccountSettingsScreen.kt
@@ -45,7 +45,8 @@ import `in`.jphe.storyvox.ui.theme.LocalSpacing
 @Composable
 fun AccountSettingsScreen(
     onBack: () -> Unit,
-    onOpenSignIn: () -> Unit,
+    onOpenSyncSignIn: () -> Unit,
+    onOpenRoyalRoadSignIn: () -> Unit,
     onOpenGitHubSignIn: () -> Unit,
     onOpenGitHubRevoke: () -> Unit,
     viewModel: SettingsViewModel = hiltViewModel(),
@@ -126,7 +127,7 @@ fun AccountSettingsScreen(
                         trailing = {
                             BrassButton(
                                 label = stringResource(R.string.settings_sign_in),
-                                onClick = onOpenSignIn,
+                                onClick = onOpenSyncSignIn,
                                 variant = BrassButtonVariant.Primary,
                             )
                         },
@@ -160,7 +161,7 @@ fun AccountSettingsScreen(
                         trailing = {
                             BrassButton(
                                 label = stringResource(R.string.settings_sign_in),
-                                onClick = onOpenSignIn,
+                                onClick = onOpenRoyalRoadSignIn,
                                 variant = BrassButtonVariant.Primary,
                             )
                         },


### PR DESCRIPTION
## Summary

Cloud Sync's "Sign in" button on the Account settings screen was navigating to Royal Road's WebView auth instead of the InstantDB sync auth screen. Root cause: `AccountSettingsScreen` had a single `onOpenSignIn` callback shared by both the Cloud Sync and Royal Road sign-in buttons, and it was wired to `authWebView(SourceIds.ROYAL_ROAD)`.

Split into two callbacks:
- `onOpenSyncSignIn` → `StoryvoxRoutes.SYNC` (InstantDB auth)
- `onOpenRoyalRoadSignIn` → `StoryvoxRoutes.authWebView(SourceIds.ROYAL_ROAD)`

The legacy `SettingsScreen` is unaffected — its `onOpenSignIn` is only used for Royal Road (no Cloud Sync button on that screen).

Fixes #1434

## Test plan
- [ ] CI Build APK passes
- [ ] Settings → Account → Cloud Sync "Sign in" opens InstantDB email flow
- [ ] Settings → Account → Royal Road "Sign in" opens RR WebView auth
- [ ] Legacy Settings scroll page RR sign-in still works

Generated with [Claude Code](https://claude.com/claude-code)