### PR TITLE
fix(source-librivox): detect Cloudflare challenges before storing chapter text

### DIFF
--- a/source-librivox/src/main/kotlin/in/jphe/storyvox/source/librivox/net/GutenbergTextApi.kt
+++ b/source-librivox/src/main/kotlin/in/jphe/storyvox/source/librivox/net/GutenbergTextApi.kt
@@ -182,10 +182,20 @@ internal class GutenbergTextApi @Inject constructor(
          * as HTTP 200. Without this check the challenge HTML would be
          * stored as chapter text and narrated by TTS — the worst failure
          * mode. Inlined per #1438 (no shared utility yet).
+         *
+         * The `/cdn-cgi/challenge-platform/` marker is NOT checked: it
+         * appears on every legitimate Cloudflare Turnstile-instrumented
+         * page (false-positive confirmed in #1453). Instead: `cf-mitigated`
+         * is definitive, and "Just a moment" in `<title>` plus a small
+         * body size distinguishes an interstitial from a real ebook
+         * (Gutenberg texts are typically 100K+ characters).
          */
-        private fun looksLikeCfChallenge(body: String): Boolean =
-            body.contains("/cdn-cgi/challenge-platform/") ||
-                body.contains("Just a moment...") ||
-                body.contains("cf-mitigated")
+        private fun looksLikeCfChallenge(body: String): Boolean {
+            if (body.contains("cf-mitigated")) return true
+            val hasChallengeTitle = "<title>" in body &&
+                body.substringAfter("<title>").substringBefore("</title>")
+                    .contains("Just a moment", ignoreCase = true)
+            return hasChallengeTitle && body.length < 20_000
+        }
     }
 }

--- a/source-librivox/src/main/kotlin/in/jphe/storyvox/source/librivox/net/GutenbergTextApi.kt
+++ b/source-librivox/src/main/kotlin/in/jphe/storyvox/source/librivox/net/GutenbergTextApi.kt
@@ -84,6 +84,15 @@ internal class GutenbergTextApi @Inject constructor(
                             "Empty Project Gutenberg response for ebook $bookId",
                             IOException("empty body"),
                         )
+                    // #1442 — a Cloudflare challenge page served as
+                    // HTTP 200 would be silently stored as chapter text
+                    // and narrated by TTS. Detect it before it reaches
+                    // the text pipeline.
+                    looksLikeCfChallenge(body) ->
+                        FictionResult.Cloudflare(
+                            challengeUrl = url,
+                            message = "Cloudflare challenge on Gutenberg ebook $bookId",
+                        )
                     else -> FictionResult.Success(stripGutenbergBoilerplate(body))
                 }
             }
@@ -167,5 +176,16 @@ internal class GutenbergTextApi @Inject constructor(
             """\*\*\*\s*END OF (?:THE|THIS) PROJECT GUTENBERG EBOOK.*""",
             RegexOption.IGNORE_CASE,
         )
+
+        /**
+         * Issue #1442 — detect a Cloudflare challenge page that arrived
+         * as HTTP 200. Without this check the challenge HTML would be
+         * stored as chapter text and narrated by TTS — the worst failure
+         * mode. Inlined per #1438 (no shared utility yet).
+         */
+        private fun looksLikeCfChallenge(body: String): Boolean =
+            body.contains("/cdn-cgi/challenge-platform/") ||
+                body.contains("Just a moment...") ||
+                body.contains("cf-mitigated")
     }
 }


### PR DESCRIPTION
## Summary

- Adds `looksLikeCfChallenge` guard to `GutenbergTextApi.fetchPlainText()` that detects Cloudflare challenge pages served as HTTP 200 before they reach the text pipeline
- Returns `FictionResult.Cloudflare` (existing sealed variant) so callers handle it like any other CF interception
- Without this check, a challenge page would be stored as chapter text and narrated by TTS — the worst failure mode

Closes #1442

## Test plan

- [ ] CI compiles cleanly (`Build APK`)
- [ ] Existing `GutenbergChapterSplitterTest` and `LibriVoxSourceTest` still pass
- [ ] Manual: confirm normal Gutenberg text fetch still works (no false positives on real book text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)