### PR TITLE
fix(source-rss): detect Cloudflare challenges before feed parsing

### DIFF
--- a/source-rss/src/main/kotlin/in/jphe/storyvox/source/rss/net/RssFetcher.kt
+++ b/source-rss/src/main/kotlin/in/jphe/storyvox/source/rss/net/RssFetcher.kt
@@ -54,6 +54,13 @@ class RssFetcher @Inject constructor(
                     else -> {
                         val body = response.body?.string()
                             ?: return@use FictionResult.NetworkError("empty body", IOException("empty body from $url"))
+                        // #1443 — Cloudflare challenge pages return 200
+                        // with an HTML interstitial instead of XML. Detect
+                        // before the XML parser sees it (inline check; a
+                        // shared utility is tracked in #1438).
+                        if (looksLikeCfChallenge(body)) {
+                            return@use FictionResult.Cloudflare(url)
+                        }
                         FictionResult.Success(
                             FetchResult.Body(
                                 xml = body,
@@ -68,6 +75,17 @@ class RssFetcher @Inject constructor(
             FictionResult.NetworkError(e.message ?: "fetch failed", e)
         }
     }
+
+    /**
+     * #1443 — heuristic: does the response body look like a Cloudflare
+     * challenge interstitial rather than XML? Same three markers used
+     * by [source-royalroad]'s `RoyalRoadChallengeFetcher`; inlined
+     * here pending a shared utility (#1438).
+     */
+    private fun looksLikeCfChallenge(body: String): Boolean =
+        body.contains("/cdn-cgi/challenge-platform/") ||
+            body.contains("Just a moment...") ||
+            body.contains("cf-mitigated")
 
     companion object {
         // Identifies storyvox in feed-server logs so feed authors can


### PR DESCRIPTION
## Summary
- Adds Cloudflare challenge detection to `RssFetcher.fetch()` in `source-rss`, preventing HTML interstitial pages from being passed to the XML parser as corrupt feed data
- Checks for three known CF markers (`/cdn-cgi/challenge-platform/`, `"Just a moment..."`, `cf-mitigated`) immediately after reading the response body
- Returns `FictionResult.Cloudflare(url)` when detected, matching the established pattern from `source-royalroad`
- Inline check pending shared utility (#1438)

Closes #1443

## Test plan
- [ ] CI compiles clean
- [ ] Existing `source-rss` tests pass (no behavioral change for non-CF responses)
- [ ] Manual: subscribe to a CF-fronted feed URL and verify the Cloudflare error surfaces in the UI instead of empty/corrupt feed data

🤖 Generated with [Claude Code](https://claude.com/claude-code)