### PR TITLE
fix(royalroad): false-positive Cloudflare detection on Turnstile pages

### DIFF
--- a/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/net/RoyalRoadChallengeFetcher.kt
+++ b/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/net/RoyalRoadChallengeFetcher.kt
@@ -54,8 +54,11 @@ internal class RoyalRoadChallengeFetcher @Inject constructor(
         return FetchOutcome.Body(body, resp.request.url.toString())
     }
 
-    private fun looksLikeCfChallenge(body: String): Boolean =
-        body.contains("/cdn-cgi/challenge-platform/") ||
-            body.contains("Just a moment...") ||
-            body.contains("cf-mitigated")
+    private fun looksLikeCfChallenge(body: String): Boolean {
+        if (body.contains("cf-mitigated")) return true
+        val hasChallengeTitle = "<title>" in body &&
+            body.substringAfter("<title>").substringBefore("</title>")
+                .contains("Just a moment", ignoreCase = true)
+        return hasChallengeTitle && !body.contains("chapter-row")
+    }
 }


### PR DESCRIPTION
## Summary

v1.6.1's Cloudflare HTTP 200 detection (#1433, PR #1435) caused a **regression**: every Royal Road page was classified as a Cloudflare challenge, making the entire source unreachable.

**Root cause:** The `/cdn-cgi/challenge-platform/` marker appears on every legitimate Royal Road page as part of Cloudflare Turnstile (a passive 1x1 iframe bot-detection widget). The substring check matched the Turnstile script URL, not an actual interstitial challenge.

**Fix:** Tighten `looksLikeCfChallenge()` to only match actual challenge pages:
- `cf-mitigated` header → always a challenge (server-side flag)
- `<title>` contains "Just a moment" AND page lacks `chapter-row` content → interstitial challenge page, not a real fiction page with Turnstile embedded

**Verified:** `curl` against live RR fiction 146388 returns 200 with 65 chapters and a Turnstile script — new detection correctly passes it through.

## Test plan
- [ ] CI Build APK passes
- [ ] Open any Royal Road fiction → chapters load (not "unreachable")
- [ ] Actual CF challenge pages still detected (title-based check)

Generated with [Claude Code](https://claude.com/claude-code)