### PR TITLE
fix(sync): attribute InstantDB param errors to the right field (#1452)

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -153,6 +153,22 @@ jobs:
               echo "::warning::INSTANTDB_APP_ID is unset on runner '$(hostname)' — this release APK will ship with cloud sync DISABLED. Set the INSTANTDB_APP_ID Actions secret, or run the tag build on katana."
             fi
           fi
+          # 4b. #1452 — a *malformed* app-id (present but not a UUID: quotes,
+          #     whitespace, or a wrong value) passes the app's `isConfigured`
+          #     gate, so sync isn't "disabled" — instead InstantDB rejects it
+          #     as "Malformed parameter: app-id", which the sign-in UI once
+          #     mislabeled as a bogus "email doesn't look right" error. Hard-
+          #     fail a tagged build so a corrupt secret can never ship again.
+          #     Mirrors the gradle read (value trimmed; PLACEHOLDER is the
+          #     disabled sentinel handled by the warn above).
+          if echo "${GITHUB_REF:-}" | grep -q '^refs/tags/v'; then
+            appid="$(grep -m1 '^INSTANTDB_APP_ID=' ./local.properties 2>/dev/null | sed 's/^INSTANTDB_APP_ID=//' | tr -d '[:space:]' || true)"
+            if [ -n "$appid" ] && [ "$appid" != "PLACEHOLDER" ] && \
+               ! printf '%s' "$appid" | grep -qiE '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'; then
+              echo "::error::INSTANTDB_APP_ID on runner '$(hostname)' is not a valid UUID. A malformed app-id ships broken Cloud Sync that surfaces as a false 'email doesn't look right' error (#1452). Fix the Actions secret — no quotes or whitespace."
+              exit 1
+            fi
+          fi
 
       - name: Assemble release APK
         # Issue #529 — was `:app:assembleDebug` through v0.5.57. Flipped

--- a/core-sync/src/main/kotlin/in/jphe/storyvox/sync/client/InstantClient.kt
+++ b/core-sync/src/main/kotlin/in/jphe/storyvox/sync/client/InstantClient.kt
@@ -114,9 +114,24 @@ class InstantClient internal constructor(
 
     /** Pull a server-readable error string out of a non-2xx body. The
      *  Instant runtime returns `{ message: "..." }` for errors; we fall
-     *  back to the raw body otherwise. */
+     *  back to the raw body otherwise.
+     *
+     *  #1452 — parameter errors also structure the offending field in
+     *  `hint.in`, e.g. `{"type":"param-malformed","hint":{"in":["body","app-id"]}}`.
+     *  The [MESSAGE_REGEX] extractor truncates the free-text message at the
+     *  first embedded quote (`Malformed parameter: [\`), which dropped the
+     *  field name and made a bad *app-id* (a shipped-config bug) look
+     *  identical to a bad *email* (the user's problem). So for parameter
+     *  errors we prefer the structured field and return `"<type>: <field>"`
+     *  (e.g. "param-malformed: app-id"); the UI's `sanitizeAuthError` keys
+     *  off that to avoid blaming the email for a config fault. */
     private fun parseError(res: TransportResult, op: String): String {
         if (res.body.isBlank()) return "$op failed (HTTP ${res.code})"
+        val type = TYPE_REGEX.find(res.body)?.groupValues?.get(1)
+        val field = PARAM_FIELD_REGEX.find(res.body)?.groupValues?.get(1)
+        if (type != null && field != null && type.startsWith("param-")) {
+            return "$type: $field"
+        }
         // Quick-extract `"message":"..."` without a full DTO — the
         // server's error shape isn't part of the documented contract so
         // we treat it as opaque.
@@ -132,6 +147,14 @@ class InstantClient internal constructor(
         const val DEFAULT_API_URI: String = "https://api.instantdb.com"
 
         private val MESSAGE_REGEX = """"message"\s*:\s*"([^"]*)"""".toRegex()
+
+        /** #1452 — InstantDB error discriminators: the error `"type"`
+         *  (`param-malformed` / `param-missing`) and the offending field as
+         *  the second element of `hint.in` (`"in":["body","app-id"]` →
+         *  `app-id`). Regex, not a DTO, since the error shape is undocumented. */
+        private val TYPE_REGEX = """"type"\s*:\s*"([^"]*)"""".toRegex()
+        private val PARAM_FIELD_REGEX =
+            """"in"\s*:\s*\[\s*"body"\s*,\s*"([^"]+)"""".toRegex()
 
         internal val DEFAULT_JSON: Json = Json {
             ignoreUnknownKeys = true

--- a/core-sync/src/test/kotlin/in/jphe/storyvox/sync/InstantClientTest.kt
+++ b/core-sync/src/test/kotlin/in/jphe/storyvox/sync/InstantClientTest.kt
@@ -6,6 +6,7 @@ import `in`.jphe.storyvox.sync.client.SyncAuthResult
 import `in`.jphe.storyvox.sync.client.TransportResult
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -95,5 +96,32 @@ class InstantClientTest {
         // than letting the UI advance to the code-entry screen with no
         // code in the user's inbox.
         check(r is SyncAuthResult.Err)
+    }
+
+    @Test fun `param-malformed surfaces the app-id field, not the truncated message`() = runTest {
+        // #1452 — InstantDB rejects a bad app-id with a param error whose
+        // free-text message truncates to "Malformed parameter: [\" at the
+        // first embedded quote. parseError must read the structured hint.in
+        // field so the UI can tell it's the app-id (a config fault), not the
+        // user's email.
+        val body = """{"type":"param-malformed","message":"Malformed parameter: [\"body\" \"app-id\"]","hint":{"in":["body","app-id"]}}"""
+        val transport = FakeTransport(mapOf(
+            "/runtime/auth/send_magic_code" to TransportResult(400, body),
+        ))
+        val r = InstantClient("test-app", transport).sendMagicCode("user@example.com")
+        check(r is SyncAuthResult.Err)
+        assertTrue("expected app-id field, got: ${r.message}", r.message.contains("app-id"))
+        assertTrue("expected param-malformed type, got: ${r.message}", r.message.contains("param-malformed"))
+    }
+
+    @Test fun `param-malformed surfaces the email field distinctly from app-id`() = runTest {
+        val body = """{"type":"param-malformed","message":"Malformed parameter: [\"body\" \"email\"]","hint":{"in":["body","email"]}}"""
+        val transport = FakeTransport(mapOf(
+            "/runtime/auth/send_magic_code" to TransportResult(400, body),
+        ))
+        val r = InstantClient("test-app", transport).sendMagicCode("bad")
+        check(r is SyncAuthResult.Err)
+        assertTrue("expected email field, got: ${r.message}", r.message.contains("email"))
+        assertFalse("must not report app-id, got: ${r.message}", r.message.contains("app-id"))
     }
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/sync/SyncAuthViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/sync/SyncAuthViewModel.kt
@@ -287,39 +287,50 @@ internal fun isLikelyEmail(raw: String): Boolean {
 }
 
 /**
- * Issue #583 — sanitize server-side auth errors before showing them
- * to the user. The InstantDB endpoint returns its parser error
- * verbatim on malformed payloads (e.g. `Malformed parameter: [\`),
- * and that raw string contains JSON-path tokens (`[`, `]`, `\`, `"`)
- * that confuse users and look like a bug, not a validation failure.
+ * Issue #583 / #1452 — sanitize server-side auth errors before showing
+ * them to the user. The InstantDB endpoint returns its parser error
+ * verbatim on malformed payloads (e.g. `Malformed parameter: [\`), full
+ * of JSON-path tokens (`[`, `]`, `\`, `"`) that look like a bug.
  *
- * Strategy:
- *  1. Drop trailing dangling JSON-path tokens (`[`, `]`, `\`, `,`).
- *  2. If the truncated string is now empty / all-punctuation / looks
- *     like a JSON fragment, fall back to a friendly generic message
- *     keyed off the most common cases (malformed parameter → email
- *     issue, otherwise generic).
- *  3. Cap length at 140 chars so a paragraph-long server message
- *     doesn't blow out the field caption row.
+ * #1452 — a *malformed parameter* can be the `app-id` OR the `email`.
+ * The old code mapped every "malformed parameter" to an email error, so a
+ * bad shipped `INSTANTDB_APP_ID` told users "your email doesn't look right"
+ * — sending them to fix a non-problem. `InstantClient.parseError` now
+ * surfaces parameter errors as `"<type>: <field>"` (e.g.
+ * "param-malformed: app-id"); we branch on the field:
+ *  - `app-id` → a build/config fault → tell the user to update, don't
+ *    blame the email.
+ *  - `email` (or an explicit "invalid email") → the user's to fix.
+ *  - any other / unattributable malformed param → stay neutral.
+ * Also drops trailing JSON-path tokens and caps length at 140 chars.
  *
  * Pure / no Android deps so the unit test can pin every branch
  * without a Robolectric harness.
  */
 internal fun sanitizeAuthError(raw: String?): String {
-    val fallback = "Couldn't send the sign-in code. Please check the email address and try again."
+    val fallback = "Couldn't send the sign-in code. Please try again in a moment."
     if (raw.isNullOrBlank()) return fallback
     var msg = raw.trim()
     // Trim trailing JSON-structure punctuation that leaks parser state.
     msg = msg.trimEnd(' ', '[', ']', '\\', ',', ':', '"', '\'')
-    // If the message is now empty or starts to look like JSON noise,
-    // map to a friendly equivalent.
     if (msg.isBlank()) return fallback
     val lower = msg.lowercase()
+    val isParamError = lower.startsWith("param-malformed") ||
+        lower.startsWith("param-missing") ||
+        lower.startsWith("malformed parameter")
     return when {
-        lower.startsWith("malformed parameter") ||
+        // A malformed/missing *app-id* means this build shipped a bad
+        // INSTANTDB_APP_ID (#1452) — a config fault, never the user's email.
+        isParamError && (lower.contains("app-id") || lower.contains("app_id")) ->
+            "Cloud Sync isn't set up correctly in this version of the app. " +
+                "Please update to the latest version — and let us know if it keeps happening."
+        // Only an actual email problem gets the email message.
+        (isParamError && lower.contains("email")) ||
             lower.contains("invalid email") ||
             lower.contains("not a valid email") ->
             "That email address doesn't look right. Please double-check and try again."
+        // Malformed some other/unattributable param — don't blame the email.
+        isParamError -> fallback
         lower.contains("rate limit") || lower.contains("too many requests") ->
             "Too many attempts. Wait a minute and try again."
         lower.contains("network") || lower.contains("unable to resolve") || lower.contains("timeout") ->

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/sync/SyncAuthValidationTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/sync/SyncAuthValidationTest.kt
@@ -141,16 +141,52 @@ class SyncAuthValidationTest {
     }
 
     @Test
-    fun `malformed parameter leaks are remapped to friendly message`() {
-        // The exact stress-test capture: the trailing `[\` is the JSON
-        // path leak the server forgot to filter. We sanitize → friendly.
+    fun `ambiguous malformed-parameter leak is sanitized without blaming the email`() {
+        // #1452 — a bare truncated leak (parseError couldn't extract the
+        // hint.in field) is ambiguous: it could be app-id or email. We must
+        // sanitize the JSON noise AND must NOT claim the email is wrong.
         val sanitized = sanitizeAuthError("Malformed parameter: [\\")
         assertFalse(sanitized.contains('['))
         assertFalse(sanitized.contains('\\'))
-        assertTrue(
-            "expected friendly email-shaped message, got: $sanitized",
-            sanitized.lowercase().contains("email"),
+        assertFalse(
+            "ambiguous param error must not blame the email, got: $sanitized",
+            sanitized.lowercase().contains("look right"),
         )
+    }
+
+    @Test
+    fun `malformed app-id is a config error, not an email error`() {
+        // #1452 root cause — a bad shipped INSTANTDB_APP_ID makes InstantDB
+        // reject the app-id; the user's email is fine.
+        val sanitized = sanitizeAuthError("param-malformed: app-id")
+        assertFalse(
+            "app-id error must not blame the email, got: $sanitized",
+            sanitized.lowercase().contains("look right"),
+        )
+        assertTrue(
+            "expected an update/config hint, got: $sanitized",
+            sanitized.lowercase().contains("update") || sanitized.lowercase().contains("set up"),
+        )
+    }
+
+    @Test
+    fun `missing app-id is also a config error, not an email error`() {
+        val sanitized = sanitizeAuthError("param-missing: app-id")
+        assertFalse(sanitized.lowercase().contains("look right"))
+    }
+
+    @Test
+    fun `malformed email parameter still maps to the email message`() {
+        val sanitized = sanitizeAuthError("param-malformed: email")
+        assertTrue(
+            "expected email guidance, got: $sanitized",
+            sanitized.lowercase().contains("look right"),
+        )
+    }
+
+    @Test
+    fun `explicit invalid-email server message maps to the email message`() {
+        assertTrue(sanitizeAuthError("Invalid email address").lowercase().contains("look right"))
     }
 
     @Test


### PR DESCRIPTION
## Problem

Cloud Sync sign-in (v1.6.1+) shows **"That email address doesn't look right"** for a perfectly valid email. Reproduced on the test phone with `test@example.com`.

## Root cause — two compounding bugs

1. **`sanitizeAuthError()` misattribution.** It mapped *any* server message starting with `"malformed parameter"` to the email error — but InstantDB returns `Malformed parameter: ["body" "app-id"]` for a bad **app-id** too. A build shipped with a malformed `INSTANTDB_APP_ID` therefore told users to fix their (fine) email. Its own comment admitted the flawed assumption: *"malformed parameter → email issue."*
2. **`parseError()` lost the field.** It extracted only the free-text `message`, and `MESSAGE_REGEX` truncates at the first embedded quote → `Malformed parameter: [\`. The field name (`app-id` vs `email`) was gone before `sanitizeAuthError` ever saw it, so the two cases were indistinguishable.

Verified against the live API: a malformed app-id (`PLACEHOLDER`/`abc123`) → `Malformed parameter: [body app-id]`; a bad email → `[body email]`; a valid-but-nonexistent UUID → `record-not-found`. The structured `hint.in` field is the reliable discriminator.

## Fix (this PR — code + CI; #2 and #3 of the plan)

- **`parseError`** reads the structured `hint.in` field and returns `"<type>: <field>"` (e.g. `param-malformed: app-id`) for parameter errors, falling back to the old message extraction otherwise.
- **`sanitizeAuthError`** branches on the field:
  - `app-id` → *"Cloud Sync isn't set up correctly in this version… please update"* (config fault, never blame the email)
  - `email` (or explicit "invalid email") → the email message
  - any other / unattributable malformed param → neutral fallback
- **CI guard**: a tagged build now **hard-fails** when `INSTANTDB_APP_ID` isn't a valid UUID (catches quotes/whitespace/wrong values), so a corrupt secret can't silently ship broken sync again.

## Tests

- `InstantClientTest` — pins field extraction: an `app-id` param error surfaces `app-id`/`param-malformed`; an `email` param error surfaces `email` and **not** `app-id`.
- `SyncAuthValidationTest` — pins the new mapping: `app-id` → config message (never "look right"); `email` → email message; a bare ambiguous leak is sanitized without blaming the email. Existing branches (rate-limit, network, cap, passthrough) unchanged.

## Not in this PR

**Fix #1 — the malformed repo Actions secret itself** — is being handled separately with JP. This PR makes the failure *honest* (correct message + a distinct log) and *prevents recurrence* (CI gate), but the shipped build still needs the corrected secret to actually sign in.

Closes #1452 (pending the secret fix landing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages during sign-in and sync setup so malformed server responses are clearer and point to the right field.
  * App ID-related configuration issues are now surfaced as setup problems instead of being mistaken for email errors.
  * Added stricter validation in Android release builds to stop shipping malformed app configuration.
* **Tests**
  * Expanded coverage for malformed parameter and invalid email error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->