### PR TITLE
ci(release): build and attach AAB for Play Store on tag (#1456)

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -181,6 +181,25 @@ jobs:
         # existing sideload installs upgrade in place).
         run: PATH="$JAVA_HOME/bin:$PATH" ./gradlew :app:assembleRelease --no-daemon --stacktrace
 
+      - name: Bundle release AAB (Play Store)
+        # Issue #1456 — Android App Bundle for Play Store distribution.
+        # Tag-only: the AAB is a release artifact; PR / main pushes stay
+        # APK-only so PR CI stays fast (assembleRelease above is the compile
+        # gate, and bundleRelease shares its compile graph — a bundle-only
+        # break is near-impossible if the APK assembled).
+        #
+        # MUST stay a SEPARATE gradle invocation from assembleRelease above —
+        # never `./gradlew :app:assembleRelease :app:bundleRelease`. The
+        # signing split in app/build.gradle.kts (#952, isBundleOrPublishBuild)
+        # release-signs any invocation whose task graph contains "bundle";
+        # a combined call would release-sign the *APK* too and break sideload
+        # upgrade continuity (INSTALL_FAILED_UPDATE_INCOMPATIBLE). Separate
+        # steps = separate task graphs → the APK stays debug-signed and the
+        # AAB gets the Play release keystore (on a runner with the
+        # storyvox.release* props; otherwise a harmless debug-signed AAB).
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: PATH="$JAVA_HOME/bin:$PATH" ./gradlew :app:bundleRelease --no-daemon --stacktrace
+
       - name: Assemble Wear release APK
         # Companion watch app ("Library Nocturne"). Signed with the same
         # checked-in keystore as :app (see wear/build.gradle.kts) so the
@@ -206,7 +225,7 @@ jobs:
         # itself is skipped without a device.
         run: ./scripts/check-cold-launch.sh
 
-      - name: Rename APKs with tag
+      - name: Rename release artifacts with tag
         # Only runs on tag builds — for PR / main pushes we just
         # verify the build compiles and stop. The local-build path
         # in `app/build.gradle.kts` (applicationVariants.all) already
@@ -237,6 +256,19 @@ jobs:
           # its output is always wear-release.apk. Copy to the tag name.
           WEAR_DIR=wear/build/outputs/apk/release
           cp "$WEAR_DIR/wear-release.apk" "$WEAR_DIR/candela-wear-${TAG}.apk"
+          # AAB (#1456): the applicationVariants rename fires for APK outputs
+          # only, so the bundle output stays app-release.aab. Copy it to the
+          # git-tag name for the Play Store upload asset (prefer a branded
+          # name if a bundle rename ever starts firing, else app-release.aab).
+          AAB_DIR=app/build/outputs/bundle/release
+          AAB_SRC=$(ls "$AAB_DIR"/candela-v*.aab 2>/dev/null | head -1)
+          if [ -z "$AAB_SRC" ]; then
+            AAB_SRC="$AAB_DIR/app-release.aab"
+          fi
+          AAB_DST="$AAB_DIR/candela-${TAG}.aab"
+          if [ "$AAB_SRC" != "$AAB_DST" ]; then
+            cp "$AAB_SRC" "$AAB_DST"
+          fi
 
       - name: Create GitHub release
         # Used to be a separate `release:` job that pulled the APK
@@ -255,12 +287,14 @@ jobs:
           name: ${{ github.ref_name }}
           generate_release_notes: true
           body: |
-            Release APK build for `${{ github.ref_name }}`.
+            Release build for `${{ github.ref_name }}`.
 
-            - `candela-${{ github.ref_name }}.apk` — phone / tablet
+            - `candela-${{ github.ref_name }}.apk` — phone / tablet (sideload)
             - `candela-wear-${{ github.ref_name }}.apk` — Wear OS companion ("Library Nocturne"), sideload to the watch
+            - `candela-${{ github.ref_name }}.aab` — Android App Bundle for Play Store upload (#1456)
 
-            > Both signed with the project's checked-in keystore (stable since v0.4.15) so the watch ↔ phone Data Layer bridge pairs. Sideload-only distribution today.
+            > The two APKs are signed with the project's checked-in keystore (stable since v0.4.15) so the watch ↔ phone Data Layer bridge pairs — sideload-only distribution today. The `.aab` is release-signed for Play upload **only when built on a runner that has the `storyvox.release*` keystore props** (katana); on any other runner it is debug-signed and Play will reject it. Upload to Play Console is still manual (no publisher automation yet).
           files: |
             app/build/outputs/apk/release/candela-${{ github.ref_name }}.apk
             wear/build/outputs/apk/release/candela-wear-${{ github.ref_name }}.apk
+            app/build/outputs/bundle/release/candela-${{ github.ref_name }}.aab

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -141,9 +141,12 @@ val hasReleaseKeystore: Boolean = releaseStoreFilePath != null &&
  * task-graph check ships the same fix in one place. The cost is that a
  * mixed invocation like `./gradlew :app:assembleRelease :app:bundleRelease`
  * signs BOTH artifacts with the release keystore, but no automation
- * (CI, release runbook) issues that pair — CI only runs
- * `:app:assembleRelease` (see .github/workflows/android.yml), and the
- * Play path runs `:app:publishReleaseBundle` separately.
+ * (CI, release runbook) issues that pair in ONE invocation — CI runs
+ * `:app:assembleRelease` and (on tag builds) `:app:bundleRelease` as
+ * SEPARATE steps / gradle invocations (#1456; see
+ * .github/workflows/android.yml), so each keeps its own task graph and
+ * the APK is never release-signed, and the Play path runs
+ * `:app:publishReleaseBundle` separately.
  *
  * When [hasReleaseKeystore] is false (fresh checkout, contributor without
  * the Play keystore configured), the bundle path falls back to the debug


### PR DESCRIPTION
## Issue

#1456 — add Android App Bundle (AAB) output to CI for Play Store distribution.

## What this does

On **tag builds** (`v*`), the Android workflow now also runs `:app:bundleRelease` and attaches the resulting bundle to the GitHub Release as **`candela-v<tag>.aab`**, next to the existing phone + wear APKs.

- New tag-only step **Bundle release AAB (Play Store)** after `Assemble release APK`.
- The rename step (now **Rename release artifacts with tag**) copies `app-release.aab` → `candela-${TAG}.aab` (mirrors the APK rename; no `applicationVariants` rename fires for bundles).
- The release step attaches the `.aab` and documents it in the release notes.

## The load-bearing detail: separate gradle invocation

`bundleRelease` is a **separate `run:` invocation** from `assembleRelease` — deliberately *not* `./gradlew :app:assembleRelease :app:bundleRelease`. The #952 signing split (`isBundleOrPublishBuild` in `app/build.gradle.kts`) release-signs **any** invocation whose task graph contains `"bundle"`. A combined call would release-sign the **sideload APK** too, breaking upgrade continuity (`INSTALL_FAILED_UPDATE_INCOMPATIBLE`). Separate steps → separate task graphs → APK stays debug-signed, AAB gets the Play release keystore (or a harmless debug-signed fallback on a runner without the `storyvox.release*` props). I also refreshed the build.gradle.kts comment that previously claimed "CI only runs `:app:assembleRelease`".

## Scope / constraints honored

- **AAB build + release attachment only** — no gradle-play-publisher / upload automation (release notes say upload to Play Console is still manual).
- **Existing APK + wear flow unchanged** — `assembleRelease`, the APK rename, and wear steps are untouched; the AAB is purely additive and tag-gated, so PR/main CI stays APK-only and fast.

## Testing

- Workflow YAML parses cleanly; the two gradle invocations are confirmed separate.
- ⚠️ The new bundle + attach path is **tag-gated**, so **this PR's `pull_request` CI does not exercise it** — it only re-verifies the unchanged compile gate. The AAB step first runs on the **next tagged release** (or a throwaway test tag). On a non-katana runner the AAB will be debug-signed (documented in the release notes) — Play-signing needs the release keystore, which katana has.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tag builds now generate and publish an Android App Bundle (AAB) alongside the existing release APKs.
  * The GitHub release now includes the tag-branded AAB as a downloadable asset.

* **Bug Fixes**
  * Improved release packaging so tag builds consistently rename and attach the correct Android artifacts.
  * Release notes now clarify when an AAB is Play Store–ready versus debug-signed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->