### PR TITLE
docs: update stale version refs to v1.6.3

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -5,6 +5,8 @@ A short-form list of shipped + in-flight + planned work. Detailed designs live u
 [`docs/compose-gotchas.md`](compose-gotchas.md) for known scope-shadowing
 and stability traps before searching the internet for confusing errors.
 
+> ⚠️ **Stale:** this roadmap was last refreshed for **v1.3.0**; the current release is **v1.6.3 / vc257**. Shipped/planned items below have not been reconciled since v1.3.0 and may be out of date. (Content intentionally left unrewritten — refreshing the roadmap is a product decision.)
+
 Last refreshed for **v1.3.0** (Reader intelligence — listening stats, tap-to-define dictionary, language auto-switch, in-app import). Prior refreshes: v1.2.x (Supertonic 3 voice family + polish), v1.1.5 (AGP 9 migration), v0.5.51.
 
 ---

--- a/docs/backend-test-results.md
+++ b/docs/backend-test-results.md
@@ -1,7 +1,7 @@
 # Candela — Backend Source Test Results
 
 **Device:** Samsung Galaxy Z Flip3 (SM-F711U), serial `R5CRB0W66MK`
-**Build:** Candela **v1.4.5** · versionCode **247** _(verified via `dumpsys package org.techempower.candela`)_
+**Build:** Candela **v1.4.5** · versionCode **247** _(verified via `dumpsys package org.techempower.candela`)_ · _historical record of a v1.4.5 test run; current release is now v1.6.3 / vc257_
 **App id:** `org.techempower.candela` · launcher `in.jphe.storyvox.MainActivity`
 **Screen:** 1080×2640 @ 480dpi · **Date:** 2026-06-29 · **Active voice during test:** Azure "Adam Multilingual"
 

--- a/docs/play-console-prerequisites.md
+++ b/docs/play-console-prerequisites.md
@@ -1,6 +1,6 @@
 # Play Console Upload Prerequisites
 
-_Assessed 2026-06-29 against `app/build.gradle.kts` (v1.4.5 / vc247), `app/src/main/play/`._
+_Assessed 2026-06-29 against `app/build.gradle.kts` (v1.4.5 / vc247), `app/src/main/play/`. Current release: **v1.6.3 / vc257** — re-verify if the build/publish config changed._
 
 ## TL;DR
 

--- a/docs/play-store-listing.md
+++ b/docs/play-store-listing.md
@@ -1,10 +1,10 @@
 ---
 layout: default
 title: Candela · Play Store Listing (Draft)
-description: Draft Play Store listing copy and assets for Candela v1.4.5.
+description: Draft Play Store listing copy and assets for Candela v1.6.3.
 ---
 
-# Play Store Listing — v1.4.5 (Draft)
+# Play Store Listing — v1.6.3 (Draft)
 
 This is the draft copy + asset inventory for Candela's Play Store
 submission. **All copy is draft.** JP reviews and picks final wording before
@@ -144,7 +144,7 @@ candela.techempower.org/privacy/
 ## What's new (500 char max)
 
 Shown in the "What's new" listing field; refresh every release to track the
-latest `versionName`. **v1.4.5:**
+latest `versionName`. **v1.4.5:** _(⚠️ stale — the copy below is the v1.4.5 what's-new; refresh for v1.6.3 before the next submission. Final wording is JP's call.)_
 
 ```text
 A stability release. Tapping a new chapter in your Inbox — or an entry in

--- a/docs/play-store-screenshots.md
+++ b/docs/play-store-screenshots.md
@@ -64,7 +64,7 @@ If trimming to fewer than 8, the minimum compelling set is **1, 2, 3, 4, 5** (he
 
 ## Execution checklist (once phone is free)
 
-1. Confirm Z Flip3 serial + `org.techempower.candela` (v1.4.1) installed.
+1. Confirm Z Flip3 serial + `org.techempower.candela` (v1.6.3) installed.
 2. Pre-stage content (above); dark theme; debug overlay off.
 3. Enter status-bar demo mode.
 4. Capture shots 1–8 (raw 1080×2640).

--- a/docs/play-store-signing.md
+++ b/docs/play-store-signing.md
@@ -1,6 +1,6 @@
 # App Signing — Play Store Readiness Assessment
 
-_Assessed 2026-06-29 against `app/build.gradle.kts` (versionCode 247 / v1.4.5) and `.github/workflows/android.yml`._
+_Assessed 2026-06-29 against `app/build.gradle.kts` (versionCode 247 / v1.4.5) and `.github/workflows/android.yml`. Current release: **v1.6.3 / vc257** — re-verify if the signing config changed._
 
 ## TL;DR
 

--- a/docs/play-store/listing/AUDIT.md
+++ b/docs/play-store/listing/AUDIT.md
@@ -6,7 +6,7 @@ description: Audit of existing Play Store listing copy and corrected, limit-comp
 
 # Play Store listing — audit + corrected drafts
 
-Audited 2026-06-26 against app **v1.1.5** (versionCode 233, `org.techempower.candela`).
+Audited 2026-06-26 against app **v1.1.5** (versionCode 233, `org.techempower.candela`). Current release: **v1.6.3 / vc257** — this audit predates it; copy may need a refresh.
 Drafts in this folder are **publish-ready text** for the gradle-play-publisher
 layout; ranked alternates + rationale live here.
 


### PR DESCRIPTION
## What

Refresh stale version references toward the current release (**v1.6.3 / vc257**, verified from `app/build.gradle.kts`) across `docs/`.

## Changes

- **play-store-listing.md** — title + description `v1.4.5 → v1.6.3` (current-state doc refs). The "What's new" **v1.4.5 copy is kept with a stale note** — final release-notes wording is JP's call, not a mechanical bump.
- **play-store-screenshots.md** — execution-checklist "confirm `<build>` installed" `v1.4.1 → v1.6.3` (a current-state instruction).
- **ROADMAP.md** — added a **stale marker** (last refreshed for v1.3.0 → current v1.6.3). Roadmap content intentionally **not rewritten** — that's a product decision.
- **play-console-prerequisites.md · play-store-signing.md · play-store/listing/AUDIT.md · backend-test-results.md** — these are **dated point-in-time assessments/records** ("assessed/tested/audited on `<date>` against `<version>`"). Bumping the version alone would falsely claim they cover v1.6.3, so the historical date+version is preserved and a **current-release note appended** instead.

## Judgment applied

Per "update current-state refs, leave historical ones ('as of vX, we did Y')": genuine current-state refs were bumped; dated snapshots got a current-release note rather than a false bump; versioned *content* (release notes, roadmap) was flagged stale but not rewritten. If you'd rather I hard-bump the version markers on the four dated docs (their config is stable across 1.4.5→1.6.3), say so and I'll amend — I erred toward not misrepresenting when/what was assessed.

The `v1.0` / `v1.3.0` refs elsewhere in these files are historical feature/planning attributions and were left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
