### PR TITLE
feat(offline): WiFi-only data-saver + bulk "download whole book" (#1461)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
@@ -1130,6 +1130,7 @@ class SettingsRepositoryUiImpl(
     AutoBrowserConfig,
     GoogleNewsConfig,
     NetworkPatienceConfig,
+    `in`.jphe.storyvox.data.repository.DownloadNetworkConfig,
     PronunciationDictRepository,
     LlmConfigProvider,
     GitHubScopePreferences,
@@ -1731,6 +1732,14 @@ class SettingsRepositoryUiImpl(
     override suspend fun setDownloadOnWifiOnly(enabled: Boolean) {
         store.edit { it[Keys.DOWNLOAD_WIFI_ONLY] = enabled }
     }
+
+    /** Issue #1461 — [`in`.jphe.storyvox.data.repository.DownloadNetworkConfig]
+     *  bridge: expose the same `pref_download_wifi_only` key that backs the
+     *  Settings toggle to `:core-data`'s download plumbing. Defaults to `true`
+     *  (Wi-Fi only) when unset, matching the [UiSettings.downloadOnWifiOnly]
+     *  default read in the settings flow. */
+    override suspend fun requireUnmeteredForDownloads(): Boolean =
+        store.data.first()[Keys.DOWNLOAD_WIFI_ONLY] ?: true
 
     override suspend fun setPollIntervalHours(hours: Int) {
         store.edit { it[Keys.POLL_INTERVAL_HOURS] = hours.coerceIn(1, 24) }

--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -406,6 +406,14 @@ object AppBindings {
     fun provideNetworkPatienceConfig(impl: SettingsRepositoryUiImpl):
         `in`.jphe.storyvox.data.repository.net.NetworkPatienceConfig = impl
 
+    /** Issue #1461 — "download over Wi-Fi only" data-saver bridge. Same
+     *  singleton; consumed by `:core-data`'s `NewChapterPollWorker` so EAGER
+     *  auto-downloads honour the toggle instead of a hardcoded unmetered
+     *  constraint. */
+    @Provides @Singleton
+    fun provideDownloadNetworkConfig(impl: SettingsRepositoryUiImpl):
+        `in`.jphe.storyvox.data.repository.DownloadNetworkConfig = impl
+
     /**
      * Issue #135 — pronunciation dictionary contract for `core-playback`'s
      * EnginePlayer + the Settings UI. Same singleton instance as the rest;
@@ -688,6 +696,15 @@ private class RealFictionRepositoryUi(
 
     override suspend fun setDownloadMode(fictionId: String, mode: DownloadMode) {
         repo.setDownloadMode(fictionId, mode.toData())
+    }
+
+    /** Issue #1461 — bulk "download this whole book". Forwards to the existing
+     *  [ChapterRepository.queueAllMissing] pipeline (WorkManager, one job per
+     *  chapter into the shared offline cache). [requireUnmetered] is read from
+     *  the data-saver setting by the ViewModel and passed straight through as
+     *  the WorkManager `NetworkType` constraint. */
+    override suspend fun downloadWholeBook(fictionId: String, requireUnmetered: Boolean) {
+        chapters.queueAllMissing(fictionId, requireUnmetered)
     }
 
     override suspend fun follow(fictionId: String, follow: Boolean) {

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/DownloadNetworkConfig.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/DownloadNetworkConfig.kt
@@ -1,0 +1,33 @@
+package `in`.jphe.storyvox.data.repository
+
+/**
+ * Issue #1461 — bridges the user's "download over Wi-Fi only" / data-saver
+ * preference into `:core-data`'s chapter-download plumbing without dragging
+ * the feature-layer `SettingsRepositoryUi` into this module.
+ *
+ * Mirrors the [`in`.jphe.storyvox.data.repository.playback.ParallelSynthConfig]
+ * / [GoogleNewsConfig] pattern: this interface lives in `:core-data`, and
+ * `SettingsRepositoryUiImpl` in `:app` implements it against the same DataStore
+ * key (`pref_download_wifi_only`) that backs the Settings toggle.
+ *
+ * The value maps straight onto `requireUnmetered` in
+ * [ChapterRepository.queueChapterDownload] / [ChapterRepository.queueAllMissing]:
+ * `true` ⇒ downloads carry a `NetworkType.UNMETERED` WorkManager constraint and
+ * defer until the device is on an unmetered (typically Wi-Fi) transport; `false`
+ * ⇒ `NetworkType.CONNECTED`, so the user has opted in to spending mobile data.
+ *
+ * Before #1461 the toggle was persisted + cloud-synced but read by nothing —
+ * every download call site hardcoded its `requireUnmetered` value. This is the
+ * seam that makes the preference actually govern background (EAGER auto-poll)
+ * downloads. Foreground "user tapped Listen / is actively listening" prefetch
+ * paths deliberately stay `requireUnmetered = false` and do NOT consult this —
+ * an explicit play intent overrides the data-saver default.
+ */
+interface DownloadNetworkConfig {
+    /**
+     * Snapshot of whether chapter downloads should require an unmetered
+     * network. Defaults to `true` (Wi-Fi only) when unset — the
+     * data-conscious default for the app's digital-divide audience.
+     */
+    suspend fun requireUnmeteredForDownloads(): Boolean
+}

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/work/NewChapterPollWorker.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/work/NewChapterPollWorker.kt
@@ -13,6 +13,7 @@ import `in`.jphe.storyvox.data.db.dao.FictionDao
 import `in`.jphe.storyvox.data.db.entity.ChapterDownloadState
 import `in`.jphe.storyvox.data.db.entity.DownloadMode
 import `in`.jphe.storyvox.data.repository.ChapterRepository
+import `in`.jphe.storyvox.data.repository.DownloadNetworkConfig
 import `in`.jphe.storyvox.data.repository.FictionRepository
 import `in`.jphe.storyvox.data.repository.InboxNotificationGate
 import `in`.jphe.storyvox.data.repository.InboxRepository
@@ -56,6 +57,12 @@ class NewChapterPollWorker @AssistedInject constructor(
      *  chapters land on a followed fiction. Gated by the same per-source
      *  [inboxGate] toggle as the Inbox feed write. */
     private val newChapterNotifier: NewChapterNotifier,
+    /** Issue #1461 — the user's "download over Wi-Fi only" preference.
+     *  Governs whether EAGER auto-downloads queued below carry a
+     *  `NetworkType.UNMETERED` constraint. Before #1461 this path
+     *  hardcoded `requireUnmetered = true`, so a user who turned the
+     *  data-saver toggle OFF still couldn't auto-download on mobile data. */
+    private val downloadNetworkConfig: DownloadNetworkConfig,
 ) : CoroutineWorker(appContext, params) {
 
     override suspend fun doWork(): Result {
@@ -65,6 +72,13 @@ class NewChapterPollWorker @AssistedInject constructor(
         // NOT_DOWNLOADED backlog. This is the count the user is told
         // about, and what KEY_NEW_CHAPTERS reports.
         var newChapterDelta = 0
+
+        // Issue #1461 — snapshot the data-saver preference once for the whole
+        // poll. EAGER auto-downloads below inherit it: Wi-Fi-only (the default)
+        // pins them to an unmetered transport; turning the toggle off lets them
+        // run on mobile data. The preference can't meaningfully change mid-poll,
+        // so a single read keeps every fiction in this pass consistent.
+        val requireUnmetered = downloadNetworkConfig.requireUnmeteredForDownloads()
 
         // Issue #907 — poll every fiction the user follows on the source
         // (followedRemotely) as well as the in-library subscribe/eager set.
@@ -198,7 +212,9 @@ class NewChapterPollWorker @AssistedInject constructor(
                             chapterRepository.queueChapterDownload(
                                 fictionId = fiction.id,
                                 chapterId = m.id,
-                                requireUnmetered = true,
+                                // Issue #1461 — honour the data-saver toggle
+                                // instead of the old hardcoded `true`.
+                                requireUnmetered = requireUnmetered,
                             )
                         }
                     } else {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -182,6 +182,19 @@ interface FictionRepositoryUi {
      */
     suspend fun chapterTextById(chapterId: String): String?
     suspend fun setDownloadMode(fictionId: String, mode: DownloadMode)
+    /**
+     * Issue #1461 — bulk "download this whole book". Queues every
+     * not-yet-downloaded chapter of [fictionId] into the existing offline
+     * cache via the WorkManager per-chapter download pipeline. When
+     * [requireUnmetered] is true (the data-saver default) each job carries a
+     * `NetworkType.UNMETERED` constraint and defers until the device is on an
+     * unmetered (typically Wi-Fi) transport; false lets it run on mobile data.
+     *
+     * Defaulted to a no-op so the many lightweight [FictionRepositoryUi] fakes
+     * in tests don't have to implement it (same pattern as [observePlaybackSpeed]
+     * / [setPlaybackSpeed] above); the real adapter overrides it.
+     */
+    suspend fun downloadWholeBook(fictionId: String, requireUnmetered: Boolean) {}
     suspend fun follow(fictionId: String, follow: Boolean)
     /**
      * Issue #211 — push a follow/unfollow to the *source* (Royal Road's

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
@@ -230,6 +230,16 @@ fun FictionDetailScreen(
                 FictionDetailUiEvent.OpenRoyalRoadSignIn -> onOpenRoyalRoadSignIn()
                 is FictionDetailUiEvent.FollowFailed ->
                     snackbarHostState.showSnackbar(event.message)
+                // Issue #1461 — confirm the bulk download, and (crucially)
+                // tell the user whether it will wait for Wi-Fi. Resolved in
+                // the composable so the message is localizable.
+                is FictionDetailUiEvent.DownloadQueued ->
+                    snackbarHostState.showSnackbar(
+                        context.getString(
+                            if (event.wifiOnly) R.string.fiction_download_queued_wifi
+                            else R.string.fiction_download_queued_any,
+                        ),
+                    )
             }
         }
     }
@@ -416,6 +426,18 @@ fun FictionDetailScreen(
                                     onClick = {
                                         menuOpen = false
                                         viewModel.exportToAudiobook()
+                                    },
+                                )
+                                // Issue #1461 — bulk "download this whole book"
+                                // for offline listening. Queues every missing
+                                // chapter into the offline cache, honouring the
+                                // "download over Wi-Fi only" data-saver setting
+                                // (the VM reads it and the snackbar reports it).
+                                DropdownMenuItem(
+                                    text = { Text(stringResource(R.string.fiction_download_book)) },
+                                    onClick = {
+                                        menuOpen = false
+                                        viewModel.downloadWholeBook()
                                     },
                                 )
                                 // Issue #1313 — share a deep link to this

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailViewModel.kt
@@ -139,6 +139,15 @@ sealed interface FictionDetailUiEvent {
 
     /** Issue #999 — non-fatal export failure (disk write error). Toasted. */
     data class AnnotationsExportFailed(val message: String) : FictionDetailUiEvent
+
+    /**
+     * Issue #1461 — fired after a bulk "Download all chapters" tap queues the
+     * download jobs. [wifiOnly] carries the data-saver decision so the screen
+     * can surface the WiFi-only-vs-any-network behaviour in a snackbar (the
+     * whole point of the feature — the user needs to know downloads will wait
+     * for Wi-Fi). One-shot via the event channel, like the export events.
+     */
+    data class DownloadQueued(val wifiOnly: Boolean) : FictionDetailUiEvent
 }
 
 /** Issue #1208 — identity key that re-triggers a companion resolve only when
@@ -156,7 +165,7 @@ class FictionDetailViewModel @Inject constructor(
     private val repo: FictionRepositoryUi,
     private val playback: PlaybackControllerUi,
     private val exportEpub: ExportFictionToEpubUseCase,
-    settings: SettingsRepositoryUi,
+    private val settings: SettingsRepositoryUi,
     /** Issue #217 — cross-fiction memory repo. Backs the Notebook
      *  sub-section showing which characters/places/concepts the AI
      *  has recorded for this book, plus the user's manual notes. */
@@ -520,6 +529,26 @@ class FictionDetailViewModel @Inject constructor(
 
     fun setMode(mode: DownloadMode) {
         viewModelScope.launch { repo.setDownloadMode(fictionId, mode) }
+    }
+
+    /**
+     * Issue #1461 — bulk "Download all chapters" for offline listening. Reads
+     * the user's "download over Wi-Fi only" data-saver preference and queues
+     * every not-yet-downloaded chapter into the existing offline cache via
+     * [FictionRepositoryUi.downloadWholeBook], which carries the WiFi-only
+     * decision through to the WorkManager `NetworkType` constraint.
+     *
+     * The highest-ROI move for the app's digital-divide audience: a user on a
+     * library/public Wi-Fi can pull a whole book down for the metered ride home.
+     * We emit [FictionDetailUiEvent.DownloadQueued] with the WiFi-only flag so
+     * the screen can tell the user whether downloads will wait for Wi-Fi.
+     */
+    fun downloadWholeBook() {
+        viewModelScope.launch {
+            val wifiOnly = settings.settings.first().downloadOnWifiOnly
+            repo.downloadWholeBook(fictionId, requireUnmetered = wifiOnly)
+            _events.send(FictionDetailUiEvent.DownloadQueued(wifiOnly))
+        }
     }
 
     /**

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -409,6 +409,11 @@
     <string name="fiction_export_audiobook">Export as audiobook…</string>
     <!-- #1313 — share a deep link (candela://fiction/<id>) to this fiction -->
     <string name="fiction_share_link">Share link</string>
+    <!-- Issue #1461 — bulk offline download of every chapter, respecting the
+         "download over Wi-Fi only" data-saver setting. -->
+    <string name="fiction_download_book">Download all chapters</string>
+    <string name="fiction_download_queued_wifi">Downloading all chapters — will wait for Wi-Fi</string>
+    <string name="fiction_download_queued_any">Downloading all chapters</string>
     <string name="fiction_clear_cache">Clear fiction cache…</string>
     <!-- Issue #999 — highlights + notes list + export. -->
     <string name="fiction_highlights_title">Highlights &amp; notes</string>


### PR DESCRIPTION
Closes #1461 (first slice).

## The gap
The **"download over Wi-Fi only" setting already existed end-to-end** — DataStore key `pref_download_wifi_only` (default `true`), `UiSettings.downloadOnWifiOnly`, `setDownloadOnWifiOnly`, a rendered toggle in `SettingsScreen`, cloud-synced — but it was a **dead toggle**: nothing read it to drive `requireUnmetered`, so every download call site hardcoded the value. Separately, `ChapterRepository.queueAllMissing` (bulk download) existed but had **zero production callers**. This slice makes the toggle govern real behaviour and adds the bulk action, building entirely on the existing WorkManager per-chapter pipeline + offline cache (#1314) — **no new cache entity**.

## What's in this slice
**Make the data-saver toggle actually govern downloads**
- New `:core-data` `DownloadNetworkConfig` bridge (mirrors the established `ParallelSynthConfig`/`GoogleNewsConfig` pattern) — exposes the Wi-Fi-only pref to the download layer without dragging the feature-layer `SettingsRepositoryUi` into `:core-data`.
- `SettingsRepositoryUiImpl` implements it (reads the same `pref_download_wifi_only` key); `AppBindings` `@Provides` it into the `SingletonComponent` graph.
- `NewChapterPollWorker`'s EAGER auto-download now reads the pref instead of hardcoded `requireUnmetered = true` → toggling data-saver **off** lets auto-downloads run on mobile data; **on** defers them to Wi-Fi.

**Bulk "Download all chapters"**
- `FictionRepositoryUi.downloadWholeBook(fictionId, requireUnmetered)` — **default no-op** so the hand-rolled `FictionRepositoryUi` fakes in tests don't break (same pattern as `observePlaybackSpeed`); real adapter forwards to `queueAllMissing`.
- `FictionDetailViewModel.downloadWholeBook()` reads the Wi-Fi-only pref and passes it through.
- "Download all chapters" overflow-menu item on FictionDetail; a snackbar tells the user **whether downloads will wait for Wi-Fi** (the whole point for metered-data users).

## Design notes (no architecture forks — existing conventions decided them)
- **WorkManager vs coroutine for the bulk job:** reuse `queueAllMissing` → per-chapter `OneTimeWorkRequest` with the `NetworkType.UNMETERED`/`CONNECTED` constraint. No new job type.
- **Where the guard lives:** the WorkManager network constraint (already there). Only open question was *who reads the setting* — feature layer via the VM's `SettingsRepositoryUi`, core-data via the new `DownloadNetworkConfig` bridge.
- **Foreground prefetch stays `requireUnmetered = false`** (active-listen / "user tapped Listen") — an explicit play intent overrides data-saver, unchanged and intentional.
- **Hilt:** the new `@HiltWorker` ctor dep resolves at `:app` via the `SingletonComponent` `@Provides`, mirroring the worker's existing app-graph deps (`InboxRepository` etc.). Only truly verified at `:app:assembleDebug` (the compile gate here).

## Deferred (follow-ups)
- Per-chapter download-progress UI / "N of M downloaded" indicator on FictionDetail.
- Surfacing the `DownloadMode` (Lazy/Eager/Subscribe) selector on FictionDetail (lives in Library today).
- Storage-quota interplay + a "pause/cancel all downloads" control.
- Deriving `requireUnmetered` live from `ConnectivityState` (skip-now) rather than relying on the WorkManager constraint to defer.

## Testing
- Existing `ChapterRepositoryImplTest` already covers `queueAllMissing` + `requireUnmetered` forwarding (kept green).
- New surfaces are thin adapters / an Android `CoroutineWorker` (the suite has no Robolectric), so they rely on the existing repo test + the CI Build APK compile gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
