### PR TITLE
feat(offline): per-chapter download status + cancel bulk download (#1461)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -675,20 +675,29 @@ private class RealFictionRepositoryUi(
         // a cached body, so the map is empty until the user reads/downloads
         // and grows from there; a chapter absent from the map renders with
         // no preview line.
+        // Issue #1461 — fold in a fourth sibling flow: per-chapter download
+        // state (chapterId → ChapterDownloadState). Room-backed like the others;
+        // drives both the accurate `isDownloaded` flag (was hard-coded false) and
+        // the new in-progress/failed badge on the chapter row.
         kotlinx.coroutines.flow.combine(
             repo.observeFiction(fictionId),
             chapters.observePlayedChapterIds(fictionId),
             chapters.observeChapterPreviews(fictionId),
-        ) { detail, playedIds, previews ->
+            chapters.observeDownloadState(fictionId),
+        ) { detail, playedIds, previews, downloadStates ->
             detail?.chapters.orEmpty().map { ch ->
+                val downloadState = downloadStates[ch.id]
+                    ?: `in`.jphe.storyvox.data.db.entity.ChapterDownloadState.NOT_DOWNLOADED
                 UiChapter(
                     id = ch.id,
                     number = ch.index + 1,
                     title = ch.title,
                     publishedRelative = relativeTime(ch.publishedAt),
                     durationLabel = ch.wordCount?.let { "${(it / 250).coerceAtLeast(1)} min" } ?: "",
-                    isDownloaded = false,
+                    isDownloaded =
+                        downloadState == `in`.jphe.storyvox.data.db.entity.ChapterDownloadState.DOWNLOADED,
                     isFinished = ch.id in playedIds,
+                    downloadState = downloadState,
                     preview = previews[ch.id],
                 )
             }
@@ -705,6 +714,13 @@ private class RealFictionRepositoryUi(
      *  the WorkManager `NetworkType` constraint. */
     override suspend fun downloadWholeBook(fictionId: String, requireUnmetered: Boolean) {
         chapters.queueAllMissing(fictionId, requireUnmetered)
+    }
+
+    /** Issue #1461 — cancel an in-flight bulk download; forwards to
+     *  [ChapterRepository.cancelDownloads] (cancels WorkManager jobs + resets
+     *  QUEUED/DOWNLOADING rows). */
+    override suspend fun cancelDownloads(fictionId: String) {
+        chapters.cancelDownloads(fictionId)
     }
 
     override suspend fun follow(fictionId: String, follow: Boolean) {

--- a/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/di/RealPlaybackControllerUiTest.kt
@@ -371,6 +371,7 @@ class RealPlaybackControllerUiTest {
             requireUnmetered: Boolean,
         ) = Unit
         override suspend fun queueAllMissing(fictionId: String, requireUnmetered: Boolean) = Unit
+        override suspend fun cancelDownloads(fictionId: String) = Unit
         override suspend fun markRead(chapterId: String, read: Boolean) = Unit
         override suspend fun markChapterPlayed(chapterId: String) = Unit
         override suspend fun trimDownloadedBodies(fictionId: String, keepLast: Int) = Unit

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/ChapterDao.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/ChapterDao.kt
@@ -376,6 +376,28 @@ interface ChapterDao {
     )
     suspend fun reapStuckDownloads(now: Long, cutoff: Long): Int
 
+    /**
+     * Issue #1461 — cancel-bulk-download reset. Flips this fiction's
+     * still-pending rows (QUEUED or DOWNLOADING) back to NOT_DOWNLOADED and
+     * clears the error tag, so a cancelled bulk download disappears from the
+     * per-chapter status UI immediately. Already-DOWNLOADED and FAILED rows are
+     * left untouched — cancel stops pending work, it doesn't discard finished
+     * bodies or hide prior failures. Paired with
+     * [`ChapterDownloadScheduler.cancelForFiction`][in.jphe.storyvox.data.repository.ChapterDownloadScheduler.cancelForFiction],
+     * which stops the WorkManager side; WorkManager cancel doesn't touch Room,
+     * hence this companion write. Returns the number of rows reset.
+     */
+    @Query(
+        """
+        UPDATE chapter
+           SET downloadState = 'NOT_DOWNLOADED',
+               lastDownloadError = NULL
+         WHERE fictionId = :fictionId
+           AND downloadState IN ('QUEUED', 'DOWNLOADING')
+        """,
+    )
+    suspend fun resetActiveDownloadsForFiction(fictionId: String): Int
+
     @Query(
         """
         UPDATE chapter

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/ChapterDownloadScheduler.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/ChapterDownloadScheduler.kt
@@ -29,6 +29,14 @@ import javax.inject.Singleton
  */
 interface ChapterDownloadScheduler {
     fun schedule(fictionId: String, chapterId: String, requireUnmetered: Boolean)
+
+    /**
+     * Issue #1461 — cancel every not-yet-finished chapter download for one
+     * fiction (bulk-download cancel). Cancels the WorkManager side only; the
+     * caller ([ChapterRepository.cancelDownloads]) resets the DB rows so the
+     * UI reflects the cancellation (WorkManager cancel doesn't touch Room).
+     */
+    fun cancelForFiction(fictionId: String)
 }
 
 @Singleton
@@ -54,6 +62,9 @@ class WorkManagerChapterDownloadScheduler @Inject constructor(
             .setInputData(input)
             .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, Duration.ofSeconds(30))
             .addTag(ChapterDownloadWorker.TAG)
+            // Issue #1461 — per-fiction tag so a bulk download can be cancelled
+            // fiction-at-a-time via cancelForFiction below.
+            .addTag(ChapterDownloadWorker.fictionTag(fictionId))
             .build()
 
         android.util.Log.i("ChapterDownload", "schedule: chapter=$chapterId fiction=$fictionId unmetered=$requireUnmetered")
@@ -65,5 +76,10 @@ class WorkManagerChapterDownloadScheduler @Inject constructor(
             ExistingWorkPolicy.REPLACE,
             request,
         )
+    }
+
+    override fun cancelForFiction(fictionId: String) {
+        DebugLog.i("ChapterDownloadScheduler") { "cancelForFiction fiction=$fictionId" }
+        workManager.cancelAllWorkByTag(ChapterDownloadWorker.fictionTag(fictionId))
     }
 }

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/ChapterRepository.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/ChapterRepository.kt
@@ -65,6 +65,14 @@ interface ChapterRepository {
         requireUnmetered: Boolean = true,
     )
 
+    /**
+     * Issue #1461 — cancel an in-flight bulk download for [fictionId]. Cancels
+     * the fiction's pending WorkManager chapter jobs and resets its QUEUED /
+     * DOWNLOADING rows back to NOT_DOWNLOADED so the per-chapter status UI
+     * clears. Already-downloaded bodies and prior FAILED rows are left intact.
+     */
+    suspend fun cancelDownloads(fictionId: String)
+
     suspend fun markRead(chapterId: String, read: Boolean = true)
 
     /** Courtesy alias for the playback layer. Same effect as `markRead(true)`. */
@@ -215,6 +223,16 @@ class ChapterRepositoryImpl @Inject constructor(
         for (chapter in missing) {
             queueChapterDownload(fictionId, chapter.id, requireUnmetered)
         }
+    }
+
+    override suspend fun cancelDownloads(fictionId: String) {
+        // Stop the WorkManager side first, then reset the DB rows. Order matters
+        // only loosely: a chapter that slips from QUEUED into DOWNLOADING between
+        // these two calls is caught either by the reset's IN ('QUEUED',
+        // 'DOWNLOADING') filter or by the worker's own stuck-reaper — never left
+        // dangling in the UI as "downloading" after a cancel.
+        scheduler.cancelForFiction(fictionId)
+        dao.resetActiveDownloadsForFiction(fictionId)
     }
 
     override suspend fun markRead(chapterId: String, read: Boolean) {

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/work/ChapterDownloadWorker.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/work/ChapterDownloadWorker.kt
@@ -236,5 +236,13 @@ class ChapterDownloadWorker @AssistedInject constructor(
         const val STUCK_CUTOFF_MS: Long = 5 * 60 * 1000L
 
         fun uniqueName(chapterId: String): String = "download:$chapterId"
+
+        /**
+         * Issue #1461 — per-fiction WorkManager tag applied to every chapter
+         * download so a bulk download can be cancelled fiction-at-a-time via
+         * [androidx.work.WorkManager.cancelAllWorkByTag]. Distinct from [TAG]
+         * (which spans all fictions and backs the app-wide [WorkScheduler.cancelAll]).
+         */
+        fun fictionTag(fictionId: String): String = "download:fiction:$fictionId"
     }
 }

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/db/dao/ChapterDaoTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/db/dao/ChapterDaoTest.kt
@@ -353,6 +353,52 @@ class ChapterDaoTest {
         assertEquals(1L, row.lastDownloadAttemptAt)
     }
 
+    // ----- resetActiveDownloadsForFiction (issue #1461) ------------------------
+
+    @Test
+    fun resetActiveDownloads_flipsQueuedAndDownloadingToNotDownloaded() = runTest {
+        fictionDao.upsert(fiction)
+        dao.upsertAll(
+            listOf(
+                chapter("c1", index = 0, downloadState = ChapterDownloadState.QUEUED),
+                chapter("c2", index = 1, downloadState = ChapterDownloadState.DOWNLOADING),
+                chapter("c3", index = 2, downloadState = ChapterDownloadState.DOWNLOADED),
+                chapter("c4", index = 3, downloadState = ChapterDownloadState.FAILED),
+            ),
+        )
+        dao.setDownloadState("c4", ChapterDownloadState.FAILED, now = 1L, error = "boom")
+
+        val reset = dao.resetActiveDownloadsForFiction("f1")
+
+        assertEquals(2, reset)
+        assertEquals(ChapterDownloadState.NOT_DOWNLOADED, dao.get("c1")!!.downloadState)
+        assertEquals(ChapterDownloadState.NOT_DOWNLOADED, dao.get("c2")!!.downloadState)
+        // DOWNLOADED body kept; FAILED row + its error tag preserved.
+        assertEquals(ChapterDownloadState.DOWNLOADED, dao.get("c3")!!.downloadState)
+        assertEquals(ChapterDownloadState.FAILED, dao.get("c4")!!.downloadState)
+        assertEquals("boom", dao.get("c4")!!.lastDownloadError)
+    }
+
+    @Test
+    fun resetActiveDownloads_scopesToTheGivenFiction() = runTest {
+        val other = fiction.copy(id = "f2", title = "Other Book")
+        fictionDao.upsert(fiction)
+        fictionDao.upsert(other)
+        dao.upsertAll(
+            listOf(
+                chapter("a1", index = 0, downloadState = ChapterDownloadState.QUEUED, fictionId = "f1"),
+                chapter("b1", index = 0, downloadState = ChapterDownloadState.QUEUED, fictionId = "f2"),
+            ),
+        )
+
+        val reset = dao.resetActiveDownloadsForFiction("f1")
+
+        assertEquals(1, reset)
+        assertEquals(ChapterDownloadState.NOT_DOWNLOADED, dao.get("a1")!!.downloadState)
+        // Sibling fiction's queued download is untouched.
+        assertEquals(ChapterDownloadState.QUEUED, dao.get("b1")!!.downloadState)
+    }
+
     // ----- reapStuckDownloads (issue #705) -------------------------------------
 
     @Test

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/ChapterRepositoryImplTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/ChapterRepositoryImplTest.kt
@@ -198,6 +198,26 @@ class ChapterRepositoryImplTest {
             return stuck.size
         }
 
+        // Issue #1461 — cancel-bulk-download reset. Mirror the live SQL: flip
+        // this fiction's QUEUED/DOWNLOADING rows back to NOT_DOWNLOADED and clear
+        // the error tag, publishing so the download-state feed re-emits.
+        override suspend fun resetActiveDownloadsForFiction(fictionId: String): Int {
+            callLog += "resetActiveDownloadsForFiction($fictionId)"
+            val active = rows.values.filter {
+                it.fictionId == fictionId &&
+                    (it.downloadState == ChapterDownloadState.QUEUED ||
+                        it.downloadState == ChapterDownloadState.DOWNLOADING)
+            }
+            active.forEach { r ->
+                rows[r.id] = r.copy(
+                    downloadState = ChapterDownloadState.NOT_DOWNLOADED,
+                    lastDownloadError = null,
+                )
+                publishRow(r.id)
+            }
+            return active.size
+        }
+
         override suspend fun setBody(
             id: String,
             html: String,
@@ -329,8 +349,15 @@ class ChapterRepositoryImplTest {
 
         val calls = mutableListOf<ScheduleCall>()
 
+        /** Issue #1461 — fictionIds passed to [cancelForFiction], in call order. */
+        val cancelledFictions = mutableListOf<String>()
+
         override fun schedule(fictionId: String, chapterId: String, requireUnmetered: Boolean) {
             calls += ScheduleCall(fictionId, chapterId, requireUnmetered)
+        }
+
+        override fun cancelForFiction(fictionId: String) {
+            cancelledFictions += fictionId
         }
     }
 
@@ -544,6 +571,39 @@ class ChapterRepositoryImplTest {
         assertEquals(ChapterDownloadState.QUEUED, dao.rows["c0"]?.downloadState)
         assertEquals(ChapterDownloadState.QUEUED, dao.rows["c1"]?.downloadState)
         assertEquals(2, sched.calls.size)
+    }
+
+    // -- cancelDownloads --------------------------------------------------------
+
+    @Test fun `cancelDownloads cancels the fiction's WorkManager jobs`() = runTest {
+        val (r, dao, sched) = repo()
+        dao.upsert(chapter("c0", index = 0, downloadState = ChapterDownloadState.QUEUED))
+
+        r.cancelDownloads("f1")
+
+        assertEquals(listOf("f1"), sched.cancelledFictions)
+    }
+
+    @Test fun `cancelDownloads resets QUEUED and DOWNLOADING rows to NOT_DOWNLOADED`() = runTest {
+        val (r, dao, _) = repo()
+        dao.upsert(chapter("c0", index = 0, downloadState = ChapterDownloadState.QUEUED))
+        dao.upsert(chapter("c1", index = 1, downloadState = ChapterDownloadState.DOWNLOADING))
+
+        r.cancelDownloads("f1")
+
+        assertEquals(ChapterDownloadState.NOT_DOWNLOADED, dao.rows["c0"]?.downloadState)
+        assertEquals(ChapterDownloadState.NOT_DOWNLOADED, dao.rows["c1"]?.downloadState)
+    }
+
+    @Test fun `cancelDownloads leaves DOWNLOADED and FAILED rows untouched`() = runTest {
+        val (r, dao, _) = repo()
+        dao.upsert(chapter("c0", index = 0, downloadState = ChapterDownloadState.DOWNLOADED))
+        dao.upsert(chapter("c1", index = 1, downloadState = ChapterDownloadState.FAILED))
+
+        r.cancelDownloads("f1")
+
+        assertEquals(ChapterDownloadState.DOWNLOADED, dao.rows["c0"]?.downloadState)
+        assertEquals(ChapterDownloadState.FAILED, dao.rows["c1"]?.downloadState)
     }
 
     // -- markRead / markChapterPlayed ------------------------------------------

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/FictionRepositoryImplTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/FictionRepositoryImplTest.kt
@@ -361,6 +361,7 @@ class FictionRepositoryImplTest {
         // Issue #705 — DAO interface adds a reaper; this test fake
         // doesn't exercise downloads so a no-op is sufficient.
         override suspend fun reapStuckDownloads(now: Long, cutoff: Long): Int = 0
+        override suspend fun resetActiveDownloadsForFiction(fictionId: String): Int = 0
         override suspend fun setBody(
             id: String,
             html: String,

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/cache/PrerenderTriggersTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/cache/PrerenderTriggersTest.kt
@@ -111,6 +111,7 @@ class PrerenderTriggersTest {
             downloadsQueued += Triple(fictionId, chapterId, requireUnmetered)
         }
         override suspend fun queueAllMissing(fictionId: String, requireUnmetered: Boolean) = Unit
+        override suspend fun cancelDownloads(fictionId: String) = Unit
         override suspend fun markRead(chapterId: String, read: Boolean) = Unit
         override suspend fun markChapterPlayed(chapterId: String) = Unit
         override suspend fun trimDownloadedBodies(fictionId: String, keepLast: Int) = Unit

--- a/core-sync/src/test/kotlin/in/jphe/storyvox/sync/BookmarksSyncerTest.kt
+++ b/core-sync/src/test/kotlin/in/jphe/storyvox/sync/BookmarksSyncerTest.kt
@@ -255,6 +255,7 @@ class BookmarksSyncerTest {
         override suspend fun insertAll(chapters: List<Chapter>) = error("not used")
         override suspend fun setDownloadState(id: String, state: ChapterDownloadState, now: Long, error: String?) = error("not used")
         override suspend fun reapStuckDownloads(now: Long, cutoff: Long): Int = error("not used")
+        override suspend fun resetActiveDownloadsForFiction(fictionId: String): Int = error("not used")
         override suspend fun setBody(
             id: String, html: String, plain: String, checksum: String,
             notesAuthor: String?, notesAuthorPosition: String?, now: Long,

--- a/core-sync/src/test/kotlin/in/jphe/storyvox/sync/PlaybackPositionSyncerTest.kt
+++ b/core-sync/src/test/kotlin/in/jphe/storyvox/sync/PlaybackPositionSyncerTest.kt
@@ -256,6 +256,7 @@ class PlaybackPositionSyncerTest {
         override suspend fun insertAll(chapters: List<Chapter>) = error("not used")
         override suspend fun setDownloadState(id: String, state: ChapterDownloadState, now: Long, error: String?) = error("not used")
         override suspend fun reapStuckDownloads(now: Long, cutoff: Long): Int = error("not used")
+        override suspend fun resetActiveDownloadsForFiction(fictionId: String): Int = error("not used")
         override suspend fun setBody(
             id: String, html: String, plain: String, checksum: String,
             notesAuthor: String?, notesAuthorPosition: String?, now: Long,

--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/ChapterCard.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/ChapterCard.kt
@@ -11,9 +11,12 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.OfflineBolt
+import androidx.compose.material.icons.outlined.ErrorOutline
 import androidx.compose.material.icons.outlined.RadioButtonUnchecked
+import androidx.compose.material.icons.outlined.Schedule
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -35,6 +38,20 @@ import `in`.jphe.storyvox.ui.a11y.LocalA11ySpeakChapterMode
 import `in`.jphe.storyvox.ui.a11y.LocalAccessibleTouchTargets
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
 
+/**
+ * Issue #1461 — per-chapter *body-download* status for the ChapterCard badge.
+ * Distinct from [ChapterCacheState] (which is PCM/TTS audio-cache state) and from
+ * [ChapterCardState.isDownloaded] (the terminal "body is on disk" flag, rendered
+ * as the OfflineBolt icon). This enum covers only the in-progress / failed
+ * download states so the card can show a spinner while a bulk download runs and
+ * an error affordance when a chapter fails.
+ *
+ * A UI-local enum rather than core-data's `ChapterDownloadState` because `:core-ui`
+ * deliberately doesn't depend on `:core-data`; the feature layer maps between them.
+ * [Downloaded] has no entry here — it's already expressed by `isDownloaded`.
+ */
+enum class ChapterDownloadBadge { None, Queued, Downloading, Failed }
+
 @Immutable
 data class ChapterCardState(
     val number: Int,
@@ -52,6 +69,11 @@ data class ChapterCardState(
      *  `FictionDetailScreen.toCardState` forwards the real value from
      *  the view-model's per-fiction cache-state flow. */
     val cacheState: ChapterCacheState = ChapterCacheState.None,
+    /** Issue #1461 — in-progress / failed body-download status. Defaults to
+     *  [ChapterDownloadBadge.None] so every existing call site (previews, tests,
+     *  Library card path) renders exactly as before; `FictionDetailScreen.
+     *  toCardState` forwards the real value mapped from the download-state flow. */
+    val downloadBadge: ChapterDownloadBadge = ChapterDownloadBadge.None,
     /** Issue #1189 — ~100-char snippet of the chapter's opening prose,
      *  rendered under the title to disambiguate generically-numbered
      *  chapters. Null / blank hides the line entirely (the common case for
@@ -105,6 +127,14 @@ fun ChapterCard(
             ChapterCacheState.Complete -> ", cached, plays instantly"
             ChapterCacheState.Partial -> ", caching in progress"
             ChapterCacheState.None -> ""
+        } +
+        // Issue #1461 — download-status segment, ordered between cache and
+        // downloaded to match the visual sweep. None reads as no clause.
+        when (state.downloadBadge) {
+            ChapterDownloadBadge.Queued -> ", download queued"
+            ChapterDownloadBadge.Downloading -> ", downloading"
+            ChapterDownloadBadge.Failed -> ", download failed"
+            ChapterDownloadBadge.None -> ""
         } +
         if (state.isDownloaded) ", downloaded" else ""
 
@@ -215,6 +245,12 @@ fun ChapterCard(
             // parent Row.spacedBy) so the layout matches the pre-PR-H
             // card for the common-case empty-cache chapter.
             ChapterCacheBadge(state = state.cacheState)
+            // Issue #1461 — in-progress / failed download badge. Sits between
+            // the cache badge and the downloaded (OfflineBolt) icon. Invisible
+            // for None so a not-downloading chapter is visually unchanged; the
+            // terminal Downloaded state is shown by the OfflineBolt below, not
+            // here, so the two never render at once.
+            DownloadStatusBadge(badge = state.downloadBadge)
             if (state.isDownloaded) {
                 Icon(
                     imageVector = Icons.Filled.OfflineBolt,

--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/DownloadStatusBadge.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/DownloadStatusBadge.kt
@@ -1,0 +1,83 @@
+package `in`.jphe.storyvox.ui.component
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ErrorOutline
+import androidx.compose.material.icons.outlined.Schedule
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+
+/**
+ * Issue #1461 — small badge inside a [ChapterCard] showing a chapter's
+ * in-progress / failed body-download status. Sibling of [ChapterCacheBadge]
+ * (PCM cache) but a different axis: this tracks the text/HTML download that
+ * bulk "Download all chapters" and EAGER auto-download drive.
+ *
+ * Four visual states keyed off [ChapterDownloadBadge]:
+ *  - [ChapterDownloadBadge.None]: renders nothing — zero footprint inside the
+ *    parent `Row(spacedBy)`, so a not-downloading chapter looks identical to
+ *    before #1461.
+ *  - [ChapterDownloadBadge.Queued]: [Icons.Outlined.Schedule], muted
+ *    `onSurfaceVariant` tint — "waiting its turn (or for Wi-Fi)".
+ *  - [ChapterDownloadBadge.Downloading]: a small indeterminate
+ *    [CircularProgressIndicator], primary (brass) tint — "fetching now".
+ *  - [ChapterDownloadBadge.Failed]: [Icons.Outlined.ErrorOutline], `error`
+ *    tint — "this chapter didn't download".
+ *
+ * The terminal *Downloaded* state is NOT shown here — [ChapterCard] renders the
+ * OfflineBolt icon for `isDownloaded`, so the two never appear at once.
+ *
+ * Material Icons + Material3 primitives only. Accessibility mirrors
+ * [ChapterCacheBadge]: each state sets a `contentDescription` on the Icon slot
+ * AND via a `semantics` block, and [ChapterCard] appends the same clause to the
+ * merged row description.
+ */
+@Composable
+fun DownloadStatusBadge(
+    badge: ChapterDownloadBadge,
+    modifier: Modifier = Modifier,
+) {
+    when (badge) {
+        // Render nothing — parent Row's spacedBy won't budget space for an
+        // absent composable, so a not-downloading row keeps its prior width.
+        ChapterDownloadBadge.None -> Unit
+
+        ChapterDownloadBadge.Queued -> {
+            Icon(
+                imageVector = Icons.Outlined.Schedule,
+                contentDescription = "Download queued",
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = modifier
+                    .size(20.dp)
+                    .semantics { contentDescription = "Download queued" },
+            )
+        }
+
+        ChapterDownloadBadge.Downloading -> {
+            CircularProgressIndicator(
+                strokeWidth = 2.dp,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = modifier
+                    .size(18.dp)
+                    .semantics { contentDescription = "Downloading" },
+            )
+        }
+
+        ChapterDownloadBadge.Failed -> {
+            Icon(
+                imageVector = Icons.Outlined.ErrorOutline,
+                contentDescription = "Download failed",
+                tint = MaterialTheme.colorScheme.error,
+                modifier = modifier
+                    .size(20.dp)
+                    .semantics { contentDescription = "Download failed" },
+            )
+        }
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -1,5 +1,6 @@
 package `in`.jphe.storyvox.feature.api
 
+import `in`.jphe.storyvox.data.db.entity.ChapterDownloadState
 import `in`.jphe.storyvox.playback.cache.ChapterCacheState
 import `in`.jphe.storyvox.ui.theme.ReaderColors
 import `in`.jphe.storyvox.ui.theme.ReaderTheme
@@ -54,6 +55,13 @@ data class UiChapter(
     val durationLabel: String,
     val isDownloaded: Boolean,
     val isFinished: Boolean,
+    /** Issue #1461 — body-download state for this chapter (queued / downloading
+     *  / downloaded / failed). Composed in `AppBindings.chaptersFor` from
+     *  `ChapterRepository.observeDownloadState`. Defaults to `NOT_DOWNLOADED` so
+     *  the many lightweight `UiChapter` construction sites (tests, previews) stay
+     *  source-compatible; `FictionDetailScreen.toCardState` maps it to the
+     *  `ChapterCard`'s in-progress/failed badge. */
+    val downloadState: ChapterDownloadState = ChapterDownloadState.NOT_DOWNLOADED,
     /** PR-H (#86) — PCM cache state for this chapter under the user's
      *  currently-active voice at 1.0× speed / 1.0× pitch. Default
      *  `None` keeps every UiChapter construction site (today only
@@ -195,6 +203,16 @@ interface FictionRepositoryUi {
      * / [setPlaybackSpeed] above); the real adapter overrides it.
      */
     suspend fun downloadWholeBook(fictionId: String, requireUnmetered: Boolean) {}
+    /**
+     * Issue #1461 — cancel an in-flight bulk download for [fictionId]: stops the
+     * pending WorkManager chapter jobs and resets QUEUED/DOWNLOADING chapters so
+     * the per-chapter status UI clears. Downloaded bodies + prior failures stay.
+     *
+     * Defaulted to a no-op (same rationale as [downloadWholeBook]) so lightweight
+     * [FictionRepositoryUi] test fakes don't have to implement it; the real
+     * adapter overrides it.
+     */
+    suspend fun cancelDownloads(fictionId: String) {}
     suspend fun follow(fictionId: String, follow: Boolean)
     /**
      * Issue #211 — push a follow/unfollow to the *source* (Royal Road's

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
@@ -76,6 +76,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import `in`.jphe.storyvox.data.annotation.AnnotationExportFormatter
+import `in`.jphe.storyvox.data.db.entity.ChapterDownloadState
 import `in`.jphe.storyvox.data.share.FictionShareLink
 import `in`.jphe.storyvox.data.source.companion.CompanionMatch
 import `in`.jphe.storyvox.feature.R
@@ -91,6 +92,7 @@ import `in`.jphe.storyvox.ui.component.BrassButtonVariant
 import `in`.jphe.storyvox.ui.component.TestTags
 import `in`.jphe.storyvox.ui.component.ChapterCard
 import `in`.jphe.storyvox.ui.component.ChapterCardState
+import `in`.jphe.storyvox.ui.component.ChapterDownloadBadge
 import `in`.jphe.storyvox.ui.component.MagicCircularProgress
 import `in`.jphe.storyvox.ui.component.coverSourceFamilyFor
 import `in`.jphe.storyvox.ui.component.ErrorBlock
@@ -360,6 +362,39 @@ fun FictionDetailScreen(
                     // export until the detail row exists. The skeleton
                     // / first-load error states render no overflow.
                     if (fiction != null) {
+                        // Issue #1461 — how many chapters are mid-download right
+                        // now (queued or actively fetching). Drives the inline
+                        // "Downloading N…" chip below and gates the "Cancel
+                        // downloads" overflow item. Derived from the same
+                        // download-state flow the per-chapter badges read, so it
+                        // clears automatically when the bulk download finishes or
+                        // is cancelled.
+                        val activeDownloadCount = state.chapters.count {
+                            it.downloadState == ChapterDownloadState.QUEUED ||
+                                it.downloadState == ChapterDownloadState.DOWNLOADING
+                        }
+                        if (activeDownloadCount > 0) {
+                            val downloadingCd = stringResource(
+                                R.string.fiction_downloading_count,
+                                activeDownloadCount,
+                            )
+                            Row(
+                                modifier = Modifier
+                                    .padding(end = 4.dp)
+                                    .semantics(mergeDescendants = true) {
+                                        contentDescription = downloadingCd
+                                        liveRegion = LiveRegionMode.Polite
+                                    },
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                            ) {
+                                MagicCircularProgress(modifier = Modifier.size(16.dp))
+                                Text(
+                                    text = downloadingCd,
+                                    style = MaterialTheme.typography.labelSmall,
+                                )
+                            }
+                        }
                         if (state.isExportingEpub) {
                             // Inline progress chip replaces the More icon
                             // while the export runs — gives the user a
@@ -440,6 +475,19 @@ fun FictionDetailScreen(
                                         viewModel.downloadWholeBook()
                                     },
                                 )
+                                // Issue #1461 — cancel an in-flight bulk download.
+                                // Only shown while chapters are actually queued /
+                                // downloading, so the menu isn't cluttered with a
+                                // dead action the rest of the time.
+                                if (activeDownloadCount > 0) {
+                                    DropdownMenuItem(
+                                        text = { Text(stringResource(R.string.fiction_cancel_downloads)) },
+                                        onClick = {
+                                            menuOpen = false
+                                            viewModel.cancelDownloads()
+                                        },
+                                    )
+                                }
                                 // Issue #1313 — share a deep link to this
                                 // fiction (candela://fiction/<id>); the
                                 // recipient's app opens straight to detail.
@@ -1738,6 +1786,17 @@ private fun UiChapter.toCardState(currentId: String?) = ChapterCardState(
     // flow's first emission), so the badge silently no-ops in that
     // window instead of flickering bogus state.
     cacheState = cacheState,
+    // Issue #1461 — map the body-download state onto the card's in-progress /
+    // failed badge. DOWNLOADED + NOT_DOWNLOADED map to None: DOWNLOADED is shown
+    // by the card's OfflineBolt (isDownloaded), and NOT_DOWNLOADED is the resting
+    // state with no badge.
+    downloadBadge = when (downloadState) {
+        ChapterDownloadState.QUEUED -> ChapterDownloadBadge.Queued
+        ChapterDownloadState.DOWNLOADING -> ChapterDownloadBadge.Downloading
+        ChapterDownloadState.FAILED -> ChapterDownloadBadge.Failed
+        ChapterDownloadState.NOT_DOWNLOADED,
+        ChapterDownloadState.DOWNLOADED -> ChapterDownloadBadge.None
+    },
     // Issue #1189 — content-preview snippet (null until the body is
     // cached); the card hides the line when absent.
     preview = preview,

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailViewModel.kt
@@ -552,6 +552,17 @@ class FictionDetailViewModel @Inject constructor(
     }
 
     /**
+     * Issue #1461 — cancel an in-flight bulk download for this fiction. Wired to
+     * the "Cancel downloads" affordance the screen shows while any chapter is
+     * QUEUED/DOWNLOADING. Stops the WorkManager jobs and resets those rows; the
+     * per-chapter badges + the "Downloading N…" chip clear via the observed
+     * download-state flow, so no explicit UI event is needed.
+     */
+    fun cancelDownloads() {
+        viewModelScope.launch { repo.cancelDownloads(fictionId) }
+    }
+
+    /**
      * Issue #117 — build a `.epub` of the current fiction in the cache dir
      * and emit [FictionDetailUiEvent.EpubExported] so the screen can fire
      * the share-sheet / SAF flow. Takes [context] because the use case

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -414,6 +414,9 @@
     <string name="fiction_download_book">Download all chapters</string>
     <string name="fiction_download_queued_wifi">Downloading all chapters — will wait for Wi-Fi</string>
     <string name="fiction_download_queued_any">Downloading all chapters</string>
+    <!-- Issue #1461 — download-management UI: live progress chip + cancel action. -->
+    <string name="fiction_downloading_count">Downloading %1$d…</string>
+    <string name="fiction_cancel_downloads">Cancel downloads</string>
     <string name="fiction_clear_cache">Clear fiction cache…</string>
     <!-- Issue #999 — highlights + notes list + export. -->
     <string name="fiction_highlights_title">Highlights &amp; notes</string>

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/tools/ChatToolHandlersTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/chat/tools/ChatToolHandlersTest.kt
@@ -376,6 +376,7 @@ private class FakeChapterRepo : ChapterRepository {
     override fun observeChapterPreviews(fictionId: String): Flow<Map<String, String>> = flowOf(emptyMap())
     override suspend fun queueChapterDownload(fictionId: String, chapterId: String, requireUnmetered: Boolean) = Unit
     override suspend fun queueAllMissing(fictionId: String, requireUnmetered: Boolean) = Unit
+    override suspend fun cancelDownloads(fictionId: String) = Unit
     override suspend fun markRead(chapterId: String, read: Boolean) {
         readMarks += chapterId to read
     }

--- a/source-epub-writer/src/test/kotlin/in/jphe/storyvox/source/epub/writer/NoopDaos.kt
+++ b/source-epub-writer/src/test/kotlin/in/jphe/storyvox/source/epub/writer/NoopDaos.kt
@@ -81,6 +81,7 @@ internal class NoopChapterDao : ChapterDao {
     override suspend fun insertAll(chapters: List<Chapter>) = Unit
     override suspend fun setDownloadState(id: String, state: ChapterDownloadState, now: Long, error: String?) = Unit
     override suspend fun reapStuckDownloads(now: Long, cutoff: Long): Int = 0
+    override suspend fun resetActiveDownloadsForFiction(fictionId: String): Int = 0
     override suspend fun setBody(
         id: String,
         html: String,


### PR DESCRIPTION
Follow-ups to #1473 (issue #1461), built on the download machinery now on main: `queueAllMissing`, `DownloadNetworkConfig`, and the WorkManager per-chapter pipeline. Ships items **1 + 2** of the download-management UX; item 3 is deferred (below).

## Item 1 — per-chapter download status on FictionDetail
- Fold the **existing** `ChapterRepository.observeDownloadState` (Room-backed) into `UiChapter.downloadState` in `AppBindings.chaptersFor` — no new store. Also derives the real `isDownloaded` (was hard-coded `false`).
- New core-ui `ChapterDownloadBadge` enum + `DownloadStatusBadge` composable — queued (clock) / downloading (spinner) / failed (error icon) — rendered on `ChapterCard` between the cache badge and the OfflineBolt, with matching TalkBack readout. It's a **UI-local enum** because `:core-ui` doesn't depend on `:core-data`; the feature layer maps `ChapterDownloadState` → badge.
- A **"Downloading N…" chip** in the FictionDetail app bar (single location, mirrors the epub-building chip), derived from the same flow.

## Item 2 — cancel an in-flight bulk download
- Per-fiction WorkManager **tag** (`download:fiction:<id>`) added at schedule time; `ChapterDownloadScheduler.cancelForFiction` cancels by tag — mirrors the existing `cancelAllWorkByTag` / `AudiobookExportScheduler.cancel(fictionId)` patterns.
- `ChapterDao.resetActiveDownloadsForFiction` atomically flips **QUEUED/DOWNLOADING → NOT_DOWNLOADED** (WorkManager cancel doesn't touch Room), leaving DOWNLOADED bodies and prior FAILED rows intact.
- `ChapterRepository.cancelDownloads` = cancel-by-tag + reset; surfaced via a **conditional "Cancel downloads" overflow item** shown only while downloads are running.

## Deferred (item 3) — noted intentionally
- A **per-book WiFi-only/any-network override** is a *new per-fiction axis* (new `Fiction` column) that doesn't compose cleanly with the global data-saver pref from #1473.
- Surfacing the existing `DownloadMode` (Lazy/Eager/Subscribe) selector on FictionDetail is a separable UI concern (it lives on Library today).

Both are follow-ups, not this slice.

## Fake-trap handling
Interface additions that pass Build APK but fail Test Compile — every hand-rolled fake updated:
- Abstract: `ChapterRepository.cancelDownloads`, `ChapterDownloadScheduler.cancelForFiction`, `ChapterDao.resetActiveDownloadsForFiction` → updated `ChapterRepositoryImplTest`, `FictionRepositoryImplTest`, `PrerenderTriggersTest`, `RealPlaybackControllerUiTest`, `ChatToolHandlersTest`, `NoopDaos`, and both core-sync syncer tests.
- Default no-op: `FictionRepositoryUi.cancelDownloads`; new `UiChapter`/`ChapterCardState` fields are defaulted → UI fakes/previews unaffected.

## Tests
- `ChapterRepositoryImplTest` — cancel forwards to the scheduler + resets QUEUED/DOWNLOADING, leaves DOWNLOADED/FAILED.
- `ChapterDaoTest` — real-Room reset query: state filter + per-fiction scoping.

## Blast radius
20 files across :core-ui (new badge), :core-data (DAO + scheduler + repo + worker tag), :app (chaptersFor fold + adapter), :feature (UiChapter, VM, screen, strings). `ChapterCard` is only used on FictionDetail; the new fields are defaulted so Library/Follows/previews are unchanged. Compile gate is CI Build APK (no local gradle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-chapter download status indicators and updated chapter cards to show queued, downloading, failed, or downloaded states.
  * Added a new option to cancel in-progress bulk downloads for a fiction.
  * Added a live download count label and cancel action in the fiction detail screen.

* **Bug Fixes**
  * Download state now updates correctly after cancellation, clearing active download indicators while preserving completed and failed chapters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->