### PR TITLE
chore(wear): rebrand applicationId → org.techempower.candela.wear (#1403)

### DIFF
--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -28,11 +28,25 @@ val phoneVersionName: String =
         ?: error("wear/build.gradle.kts (#1405): could not read versionName from app/build.gradle.kts")
 
 android {
+    // #1403 — `namespace` (the frozen CODE package: R class, BuildConfig,
+    // source tree, and the target of the manifest's relative component names
+    // like `.WearMainActivity`) stays `in.jphe.storyvox.wear`. Only the
+    // `applicationId` (install identity on the device) is rebranded below.
+    // This mirrors :app, which kept namespace `in.jphe.storyvox` while its
+    // applicationId became `org.techempower.candela`.
     namespace = "in.jphe.storyvox.wear"
     compileSdk = 37
 
     defaultConfig {
-        applicationId = "in.jphe.storyvox.wear"
+        // #1403 — install identity rebranded to match the phone app
+        // (org.techempower.candela). The watch app is now
+        // org.techempower.candela.wear (debug: .wear.debug). The phone↔watch
+        // Wearable Data Layer bridge pairs by capability string
+        // (`storyvox_playback_controller`, see wear.xml + PhoneWearBridge) and
+        // shared signing cert, NOT by package name, so this rename does not
+        // touch pairing. Install side-effect: the old in.jphe.storyvox.wear
+        // install is a distinct app that lingers until manually uninstalled.
+        applicationId = "org.techempower.candela.wear"
         minSdk = 26
         targetSdk = 36   // #1406 — match :app's targetSdk (Android 16); compileSdk 37 ≥ 36.
         versionCode = phoneVersionCode   // #1405 — shared with :app (see top of file)


### PR DESCRIPTION
Closes #1403.

Finishes the candela rebrand for the Wear OS companion module. The watch app's **install identity** still carried the pre-rebrand `in.jphe.storyvox.wear`; the phone app moved to `org.techempower.candela` long ago.

## Change
`wear/build.gradle.kts` — one line:
- `applicationId`: `in.jphe.storyvox.wear` → **`org.techempower.candela.wear`** (debug variant: `org.techempower.candela.wear.debug`)

`namespace` stays **`in.jphe.storyvox.wear`** (frozen). This mirrors `:app`, which kept `namespace = in.jphe.storyvox` while `applicationId` became `org.techempower.candela`. Per project convention the `in.jphe.storyvox` **code** namespace/package tree is frozen — only the install identity is rebranded.

## Investigation — no pairing breakage (why this is safe to ship)
An applicationId change makes the watch a **new app identity** and can break phone↔watch plumbing, so I mapped every place the wear package identity could matter:

| Surface | Finding | Impact |
|---|---|---|
| **Data Layer pairing** | Phone discovers the watch via `CapabilityClient` on capability string `storyvox_playback_controller` (advertised in `wear/src/main/res/values/wear.xml`, mirrored in `PhoneWearBridge.CAPABILITY_PLAYBACK_CONTROLLER`). Routing is by literal capability + `PATH_*`/`CMD_*` match — **no package-name matching, no `RemoteActivityHelper`, no node filtering by package.** | ✅ None |
| **Manifest components** | All component names are relative (`.WearMainActivity`, `.complication.*`, `.tile.*`) → resolve against `namespace` (frozen). | ✅ None |
| **Tile launch action** (`PlaybackTileService.launchActivity`) | Uses `.setPackageName(packageName)` (runtime) + `.setClassName("in.jphe.storyvox.wear.WearMainActivity")` (frozen class). Runtime package resolves to the new id; class lives under the frozen namespace. Same pattern as the phone's shipped `StoryvoxPlaybackService` (`ComponentName(packageName, "in.jphe.storyvox.MainActivity")`). | ✅ None |
| **Signing** | Wear reuses `app/storyvox-debug.keystore` by **file reference**, not keyed off applicationId. Phone + watch keep the shared cert the Data Layer requires. | ✅ None |
| **CI** (`android.yml`) | Wear APK output is fixed `wear-release.apk` → copied to `candela-wear-${TAG}.apk`. Filename does not derive from applicationId ("`:wear` has no applicationVariants rename"). | ✅ None |
| Class-name constants (`WEAR_MAIN_ACTIVITY`, `COMMAND_ACTIVITY`, `EXTRA_CMD`) | Reference the frozen code namespace, not install identity — left unchanged. | ✅ None |

Grep for any hardcoded `in.jphe.storyvox*` used as a *package* in `setPackageName`/`setClassName`/node-filter: **none**.

## ⚠️ Install-side effect (expected, documented)
Changing the applicationId makes `org.techempower.candela.wear` a **distinct app** from the old `in.jphe.storyvox.wear`. On upgrade the watch does a **fresh install**; the old app is orphaned and **lingers on the watch until manually uninstalled** (no auto-replace across differing package names).

**Blast radius: sideload-only.** The wear app has never shipped to Play, so there are no store users to migrate — only sideloaded dev/test watches.

## Not compiled locally
Per project convention (no local gradle on katana), CI's `Build APK` / `:wear:assembleRelease` is the compile gate. This is a build-config-only change; code is untouched, so compile risk is minimal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Wear app’s install identity to match the rebranded phone app, helping keep the watch and phone versions aligned.
  * Added clearer notes about how the app’s namespace and install identity differ, without changing app behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->