### PR TITLE
fix(notif): load the chapter before opening the reader from a new-chapter notification (#1455)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/MainActivity.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/MainActivity.kt
@@ -33,6 +33,7 @@ import dagger.Lazy
 import dagger.hilt.android.AndroidEntryPoint
 import `in`.jphe.storyvox.feature.api.CoverStyle
 import `in`.jphe.storyvox.feature.api.ImportFileResult
+import `in`.jphe.storyvox.feature.api.PlaybackControllerUi
 import `in`.jphe.storyvox.feature.api.ReadingDirection
 import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
 import `in`.jphe.storyvox.feature.api.SpeakChapterMode
@@ -128,6 +129,17 @@ class MainActivity : ComponentActivity() {
      * injection, only when an import intent actually arrives.
      */
     @Inject lateinit var documentImporter: Lazy<DocumentImporterUiImpl>
+
+    /**
+     * Issue #1455 — the new-chapter notification deep-links a brand-new
+     * chapter the PlaybackController has never loaded; the reader is a passive
+     * view of the controller, so the tap must `startListening` before
+     * navigating or the reader hangs on "loading chapter". [Lazy] for the same
+     * cold-launch reason as the other injects (#409): only resolved when a
+     * preload-carrying intent actually arrives, so a normal cold start never
+     * materialises the playback graph during activity injection.
+     */
+    @Inject lateinit var playback: Lazy<PlaybackControllerUi>
 
     // testTagsAsResourceId is experimental Compose UI API. We opt in at
     // the function holding setContent {} because that's where the flag is
@@ -280,6 +292,31 @@ class MainActivity : ComponentActivity() {
                                 // could swap it before importDocument reads it).
                                 ?.let { uri -> importDocument(uri, i.type) }
                         val route = importRoute ?: DeepLinkResolver.resolve(i)
+                        // Issue #1455 — the new-chapter notification deep-links
+                        // a brand-new chapter the PlaybackController has never
+                        // loaded. The reader is a passive view of the
+                        // controller, so navigating alone leaves it stuck on
+                        // "loading chapter" (then the 30s timeout) — the same
+                        // navigate-without-load bug fixed for the inbox (#1343)
+                        // and history (#1350) paths. Load it here BEFORE
+                        // navigating, mirroring those fixes. autoPlay=false: a
+                        // notification tap is a browse action, not "play now".
+                        // runCatching so a startForegroundService hiccup can't
+                        // swallow the navigation below. Only the new-chapter
+                        // notifier sets the preload extra — the playback
+                        // notification and now-playing widget carry the same
+                        // open_reader ids but point at the already-playing
+                        // chapter, so [readerPreload] returns null for them and
+                        // they stay navigate-only.
+                        DeepLinkResolver.readerPreload(i)?.let { preload ->
+                            runCatching {
+                                playback.get().startListening(
+                                    fictionId = preload.fictionId,
+                                    chapterId = preload.chapterId,
+                                    autoPlay = false,
+                                )
+                            }
+                        }
                         route?.let { navController.navigate(it) }
                         intentFlow.value = null
                     }

--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -1605,6 +1605,18 @@ object DeepLinkResolver {
     const val EXTRA_OPEN_READER_FICTION_ID = "storyvox.open_reader.fiction_id"
     const val EXTRA_OPEN_READER_CHAPTER_ID = "storyvox.open_reader.chapter_id"
 
+    /**
+     * Issue #1455 — set only by the new-chapter notification
+     * ([in.jphe.storyvox.data.work.NewChapterNotifier]), which deep-links a
+     * brand-new chapter the PlaybackController has never loaded. Signals
+     * MainActivity to `startListening` that chapter before navigating; the
+     * playback notification and now-playing widget carry the ids above but
+     * point at the already-playing chapter, so they omit this flag and stay
+     * navigate-only. Kept in sync by string with the mirror in
+     * NewChapterNotifier.
+     */
+    const val EXTRA_OPEN_READER_PRELOAD = "storyvox.open_reader.preload"
+
     /** Issue #472 — query-string carried on the Library route when a
      *  shared URL needs to land in the Magic-add sheet. The Library
      *  screen pulls this off the nav arguments on first composition
@@ -1651,7 +1663,12 @@ object DeepLinkResolver {
     }
 
     fun resolve(intent: Intent): String? {
-        // Notification tap → reader for the currently-playing chapter.
+        // open_reader deep link → the reader route. Three emitters share
+        // these extras: the playback notification and now-playing widget
+        // (the currently-playing chapter) and the new-chapter notification
+        // (#1455, a brand-new chapter — which additionally sets
+        // EXTRA_OPEN_READER_PRELOAD so MainActivity loads it first; see
+        // [readerPreload]).
         val rf = intent.getStringExtra(EXTRA_OPEN_READER_FICTION_ID)
         val rc = intent.getStringExtra(EXTRA_OPEN_READER_CHAPTER_ID)
         if (!rf.isNullOrBlank() && !rc.isNullOrBlank()) {
@@ -1692,6 +1709,46 @@ object DeepLinkResolver {
         val id = match.groupValues[1]
         return StoryvoxRoutes.fictionDetail(id)
     }
+
+    /** Issue #1455 — the (fictionId, chapterId) a deep link asks us to LOAD
+     *  into the PlaybackController before opening the reader. */
+    data class ReaderPreload(val fictionId: String, val chapterId: String)
+
+    /**
+     * Issue #1455 — pure decision (no Android types, so it runs as a plain
+     * JUnit test): should the deep-link handler preload a chapter into the
+     * PlaybackController before navigating?
+     *
+     * The reader is a passive view of the controller — navigating to
+     * `reader/{fid}/{cid}` without a matching *loaded* chapter leaves it stuck
+     * on "loading chapter" (then a 30s timeout). The playback notification and
+     * now-playing widget carry the open_reader ids for the *already-playing*
+     * chapter, so they must NOT preload — a `startListening(autoPlay=false)`
+     * there would pause the audio in progress. Only the new-chapter
+     * notification sets [preloadRequested] (it deep-links a brand-new,
+     * never-loaded chapter), and only then do we return a non-null target.
+     */
+    fun shouldPreloadReader(
+        fictionId: String?,
+        chapterId: String?,
+        preloadRequested: Boolean,
+    ): ReaderPreload? {
+        // Positive `&&` form mirrors resolve()'s proven smart-cast above:
+        // both ids narrow to non-null String inside the branch.
+        if (preloadRequested && !fictionId.isNullOrBlank() && !chapterId.isNullOrBlank()) {
+            return ReaderPreload(fictionId, chapterId)
+        }
+        return null
+    }
+
+    /** Intent-reading wrapper for [shouldPreloadReader] — the Android Intent
+     *  extraction isn't unit-testable without Robolectric, so MainActivity
+     *  calls this glue and the pure decision above carries the logic. */
+    fun readerPreload(intent: Intent): ReaderPreload? = shouldPreloadReader(
+        fictionId = intent.getStringExtra(EXTRA_OPEN_READER_FICTION_ID),
+        chapterId = intent.getStringExtra(EXTRA_OPEN_READER_CHAPTER_ID),
+        preloadRequested = intent.getBooleanExtra(EXTRA_OPEN_READER_PRELOAD, false),
+    )
 
     /** Lightweight URL sniffer — accepts http(s) URLs only. Apps that
      *  share plaintext frequently emit "title\nURL" or "URL extra

--- a/app/src/test/kotlin/in/jphe/storyvox/navigation/ReaderPreloadResolverTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/navigation/ReaderPreloadResolverTest.kt
@@ -1,0 +1,73 @@
+package `in`.jphe.storyvox.navigation
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Issue #1455 — the deep-link handler must LOAD a brand-new chapter into the
+ * PlaybackController before opening the reader (the reader is a passive view
+ * of the controller; navigating alone hangs it on "loading chapter"). Three
+ * emitters share the `storyvox.open_reader.*` extras — the playback
+ * notification and now-playing widget (already-playing chapter → navigate
+ * only) and the new-chapter notification (brand-new chapter → preload). The
+ * discriminator is [DeepLinkResolver.EXTRA_OPEN_READER_PRELOAD]; the pure
+ * decision below is what MainActivity keys on.
+ *
+ * Pure (no Android types), so it runs as a plain JUnit test — no Robolectric,
+ * mirroring [DocumentImportClassifierTest].
+ */
+class ReaderPreloadResolverTest {
+
+    private fun decide(fid: String?, cid: String?, requested: Boolean) =
+        DeepLinkResolver.shouldPreloadReader(fid, cid, requested)
+
+    // ── Preload requested (the new-chapter notification) ──────────────
+
+    @Test
+    fun preloadFlag_withBothIds_returnsTarget() {
+        assertEquals(
+            DeepLinkResolver.ReaderPreload("royalroad:12345", "royalroad:12345:67"),
+            decide("royalroad:12345", "royalroad:12345:67", requested = true),
+        )
+    }
+
+    // ── Preload NOT requested (playback notification / now-playing widget) ─
+
+    @Test
+    fun noPreloadFlag_withBothIds_isNull() {
+        // The playback notification + widget carry the ids for the
+        // already-playing chapter but must stay navigate-only — preloading
+        // there (autoPlay=false) would pause the audio in progress.
+        assertNull(decide("royalroad:12345", "royalroad:12345:67", requested = false))
+    }
+
+    // ── Preload requested but ids incomplete → refuse (no half-load) ──
+
+    @Test
+    fun preloadFlag_withMissingFictionId_isNull() {
+        assertNull(decide(null, "royalroad:12345:67", requested = true))
+        assertNull(decide("", "royalroad:12345:67", requested = true))
+        assertNull(decide("   ", "royalroad:12345:67", requested = true))
+    }
+
+    @Test
+    fun preloadFlag_withMissingChapterId_isNull() {
+        assertNull(decide("royalroad:12345", null, requested = true))
+        assertNull(decide("royalroad:12345", "", requested = true))
+        assertNull(decide("royalroad:12345", "   ", requested = true))
+    }
+
+    @Test
+    fun preloadFlag_withBothIdsMissing_isNull() {
+        assertNull(decide(null, null, requested = true))
+        assertNull(decide("", "", requested = true))
+    }
+
+    // ── No flag AND no ids (a non-reader deep link) → null ────────────
+
+    @Test
+    fun nothingToGoOn_isNull() {
+        assertNull(decide(null, null, requested = false))
+    }
+}

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/work/NewChapterNotifier.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/work/NewChapterNotifier.kt
@@ -24,7 +24,18 @@ import javax.inject.Singleton
  * `storyvox.open_reader.*` extras that
  * [`in`.jphe.storyvox.navigation.DeepLinkResolver] already decodes for the
  * playback notification — so the existing nav plumbing routes the tap to the
- * first new chapter with zero new navigation code.
+ * first new chapter.
+ *
+ * Issue #1455 — unlike the playback notification and now-playing widget
+ * (which point at the chapter already loaded in the PlaybackController), this
+ * deep-links a brand-new chapter the controller has never loaded. The reader
+ * is a passive view of the controller, so navigating alone would leave it
+ * stuck on "loading chapter" (until the 30s timeout). We therefore also set
+ * [EXTRA_OPEN_READER_PRELOAD]; MainActivity keys on it to `startListening`
+ * the chapter before navigating, mirroring the inbox (#1343) and history
+ * (#1350) navigate-without-load fixes. The playback notification / widget
+ * omit the flag, so their tap stays navigate-only (a preload there would
+ * pause the audio the user is actively listening to).
  *
  * One notification per fiction (notification id derived from the fiction id),
  * so a poll that finds chapters across several followed fictions surfaces one
@@ -100,6 +111,12 @@ class NewChapterNotifier @Inject constructor(
             flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
             putExtra(EXTRA_OPEN_READER_FICTION_ID, fictionId)
             putExtra(EXTRA_OPEN_READER_CHAPTER_ID, chapterId)
+            // Issue #1455 — load this (brand-new, never-played) chapter into
+            // the PlaybackController before navigating; without it the passive
+            // reader hangs on "loading chapter". The playback notification and
+            // now-playing widget omit this flag (their chapter is already the
+            // one playing).
+            putExtra(EXTRA_OPEN_READER_PRELOAD, true)
         }
         // FLAG_UPDATE_CURRENT so the per-fiction extras overwrite a prior
         // intent for the same request code (PendingIntent equality ignores
@@ -116,5 +133,6 @@ class NewChapterNotifier @Inject constructor(
         // Mirror DeepLinkResolver.EXTRA_OPEN_READER_* — kept in sync by string.
         private const val EXTRA_OPEN_READER_FICTION_ID = "storyvox.open_reader.fiction_id"
         private const val EXTRA_OPEN_READER_CHAPTER_ID = "storyvox.open_reader.chapter_id"
+        private const val EXTRA_OPEN_READER_PRELOAD = "storyvox.open_reader.preload"
     }
 }


### PR DESCRIPTION
Fixes #1455

## Symptom
Tapping the Android **"new chapter"** notification for a followed Royal Road fiction opens the app, but the reader hangs on **"loading chapter"** (until the 30s timeout → "Couldn't start this chapter"). The equivalent link from the in-app **inbox** works — that path was fixed in #1343.

## Root cause
The reader is a **passive view of the global `PlaybackController`** — it renders whatever chapter the controller currently holds and shows the "loading chapter" prompt whenever its nav args don't match the loaded `(fictionId, chapterId)`. Nothing on the deep-link path auto-loads from the nav args: `MainActivity` only does `DeepLinkResolver.resolve()` → `navController.navigate(reader/{fid}/{cid})`; it never calls `playback.startListening`.

That was fine while the only emitters of the `storyvox.open_reader.*` extras were:
1. the **playback notification** (`StoryvoxPlaybackService.setSessionActivity`), and
2. the **now-playing widget** (`NowPlayingWidgetRenderer`)

— both point at the **currently-playing, already-loaded** chapter, so the passive reader shows it immediately. The resolver comment literally read `// Notification tap → reader for the currently-playing chapter.`

Issue #907's `NewChapterNotifier` **reused those same extras** to deep-link a **brand-new, never-loaded** chapter, violating that assumption. Navigation fires but the controller never loads the chapter → the reader sits on "loading chapter". This is the **identical navigate-without-load bug** as inbox #1343 and history #1350, now on the notification deep-link path.

## Fix
Preload the chapter via `startListening(autoPlay = false)` **before** navigating — mirroring #1343 / #1350 — but **only for the new-chapter notification**. The playback notification and now-playing widget target the already-playing chapter and must stay navigate-only: a `startListening(autoPlay = false)` there would **pause the audio the user is actively listening to**.

`NewChapterNotifier` now sets a discriminator extra `storyvox.open_reader.preload=true`; `MainActivity` keys on it. The other two emitters omit it → their behavior is unchanged.

| File | Change |
|---|---|
| `NewChapterNotifier` | set `EXTRA_OPEN_READER_PRELOAD=true` on the tap intent |
| `DeepLinkResolver` | add the extra + a **pure, unit-tested** `shouldPreloadReader()` decision + `readerPreload(Intent)` glue wrapper (mirrors the existing `documentImportUri` / `DocumentImportClassifier` pure-decision split) |
| `MainActivity` | inject `Lazy<PlaybackControllerUi>`; preload (`runCatching`, `autoPlay=false`) before `navigate` when the intent requests it |
| `ReaderPreloadResolverTest` | covers the pure decision (plain JUnit, no Robolectric) |

`autoPlay = false`: a notification tap is a browse action, not "play now" (matches the inbox/history intent). `runCatching` so a `startForegroundService` hiccup can't swallow the navigation.

### Why not one shared helper across all three paths?
They already converge on the shared primitive `PlaybackControllerUi.startListening(autoPlay = false)`. The inbox/history fixes originate in a **ViewModel** (event-driven nav); this one is on the **Activity deep-link path** (`navController.navigate`) with a different navigation mechanism — folding them into one function would be artificial coupling. The genuinely reusable piece (the preload decision) *is* extracted as the pure `shouldPreloadReader`.

## Tests
- `ReaderPreloadResolverTest` — pure-decision coverage: preload flag + both ids → target; no flag (playback/widget) → null; missing/blank fid or cid → null.
- No local gradle (per project policy) — CI **Build APK** + **Test Compile** are the compile gate.

## Manual repro / verification
On a device with `org.techempower.candela` installed and a followed Royal Road fiction:

**Reproduce (pre-fix):** wait for (or trigger) the new-chapter poll to post a notification, tap it → reader stuck on "loading chapter".

**Simulate the notification's exact intent via adb** (replace ids with a real followed fiction/chapter):
```
adb -s R83W80CAFZB shell am start -n org.techempower.candela/in.jphe.storyvox.MainActivity \
  --es storyvox.open_reader.fiction_id "royalroad:<fid>" \
  --es storyvox.open_reader.chapter_id "royalroad:<fid>:<cid>" \
  --ez storyvox.open_reader.preload true
```
**Expected (post-fix):** the chapter body downloads, the reader resolves off "loading chapter" into the chapter text, audio stays **paused** (autoPlay=false) until the user taps play.

**Regression check (must stay navigate-only):** while a chapter is playing, tap the playback notification / now-playing widget → reader opens on the playing chapter and **audio keeps playing** (no pause). The same `am start` **without** `--ez ...preload true` must not pause playback.
