### PR TITLE
feat(wear): transient volume indicator + ≥48dp Teleprompter/Sleep targets (#1401, #1402)

### DIFF
--- a/wear/src/main/kotlin/in/jphe/storyvox/wear/screens/NowPlayingScreen.kt
+++ b/wear/src/main/kotlin/in/jphe/storyvox/wear/screens/NowPlayingScreen.kt
@@ -18,11 +18,13 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.outlined.ErrorOutline
@@ -369,35 +371,29 @@ internal fun NowPlayingContent(
                     // length; the Sleep label doubles as the live countdown when
                     // a duration timer is running.
                     if (!state.recording) {
-                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                            Text(
-                                text = stringResource(R.string.wear_teleprompter),
+                        // #1402 — Teleprompter/Sleep rendered as ≥48dp touch
+                        // targets (the Wear/Material minimum) on a subtle brass
+                        // surface, so they're easy to hit and hard to fat-finger
+                        // against the transport row above. Previously sub-48dp
+                        // bottom-edge text (#1398 improved the padding; this makes
+                        // the target itself compliant).
+                        val sleepRemaining = state.sleepTimerRemainingMs
+                        Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                            SecondaryAction(
+                                label = stringResource(R.string.wear_teleprompter),
                                 color = BrassPrimary,
-                                textAlign = TextAlign.Center,
-                                style = MaterialTheme.typography.caption1,
-                                // #a11y — announce as an actionable button with a
-                                // descriptive double-tap label, not bare text.
-                                modifier = Modifier
-                                    .clickable(
-                                        onClickLabel = stringResource(R.string.wear_cd_open_teleprompter),
-                                        role = Role.Button,
-                                        onClick = onOpenTeleprompter,
-                                    )
-                                    .padding(horizontal = 12.dp, vertical = 6.dp),
+                                onClick = onOpenTeleprompter,
+                                onClickLabel = stringResource(R.string.wear_cd_open_teleprompter),
                             )
-                            val sleepRemaining = state.sleepTimerRemainingMs
-                            Text(
-                                text = if (sleepRemaining != null) {
+                            SecondaryAction(
+                                label = if (sleepRemaining != null) {
                                     "Sleep ${formatSleepRemaining(sleepRemaining)}"
                                 } else {
                                     "Sleep"
                                 },
                                 color = if (sleepRemaining != null) BrassTint else BrassPrimary,
-                                textAlign = TextAlign.Center,
-                                style = MaterialTheme.typography.caption1,
-                                modifier = Modifier
-                                    .clickable(onClick = onOpenSleepTimer)
-                                    .padding(horizontal = 12.dp, vertical = 6.dp),
+                                onClick = onOpenSleepTimer,
+                                onClickLabel = stringResource(R.string.wear_cd_open_sleep_timer),
                             )
                         }
                     }
@@ -860,6 +856,43 @@ private fun SpeedStep(symbol: String, enabled: Boolean, onClick: () -> Unit) {
 private fun formatSpeed(speed: Float): String {
     val tenths = (speed * 10f).roundToInt()
     return "${tenths / 10}.${tenths % 10}×"
+}
+
+/**
+ * #1402 — a bottom-edge secondary action (Teleprompter / Sleep timer). Keeps the
+ * light brass-label look but wraps it in a ≥48dp touch target (the Wear/Material
+ * minimum) with a subtle rounded surface, so the tappable area is visible and
+ * hard to fat-finger against the transport row above — a motor-accessibility fix.
+ *
+ * Modifier order is deliberate: `defaultMinSize` and `padding` sit *inside* the
+ * `clickable`, so the ripple and background fill the whole 48dp target rather
+ * than just the text glyphs. Announced to TalkBack as a button via [onClickLabel].
+ */
+@Composable
+private fun SecondaryAction(
+    label: String,
+    color: Color,
+    onClick: () -> Unit,
+    onClickLabel: String? = null,
+) {
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(24.dp))
+            .background(MaterialTheme.colors.surface)
+            .clickable(onClickLabel = onClickLabel, role = Role.Button, onClick = onClick)
+            .defaultMinSize(minWidth = 48.dp, minHeight = 48.dp)
+            .padding(horizontal = 14.dp, vertical = 8.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = label,
+            color = color,
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.caption1,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
 }
 
 /**

--- a/wear/src/main/kotlin/in/jphe/storyvox/wear/screens/NowPlayingScreen.kt
+++ b/wear/src/main/kotlin/in/jphe/storyvox/wear/screens/NowPlayingScreen.kt
@@ -4,9 +4,11 @@ import android.content.Context
 import android.media.AudioManager
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusable
@@ -24,10 +26,12 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.outlined.ErrorOutline
+import androidx.compose.material.icons.outlined.VolumeUp
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -38,7 +42,11 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.input.rotary.onRotaryScrollEvent
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
@@ -50,6 +58,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import android.view.HapticFeedbackConstants
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.semantics
@@ -79,16 +88,22 @@ import `in`.jphe.storyvox.wear.components.LinearScrubber
 import `in`.jphe.storyvox.wear.components.TransportRow
 import `in`.jphe.storyvox.wear.playback.WearPlaybackBridge
 import `in`.jphe.storyvox.wear.theme.BrassPrimary
+import `in`.jphe.storyvox.wear.theme.BrassRingTrack
 import `in`.jphe.storyvox.wear.theme.BrassTint
 import `in`.jphe.storyvox.wear.theme.ParchmentOnMuted
 import `in`.jphe.storyvox.wear.theme.WearLibraryNocturneTheme
 import kotlin.math.roundToInt
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 /** Scroll-pixels per volume step — ~one Galaxy Watch4 bezel detent. Tuned in
  *  the 30–50px detent range so a single physical click steps volume once, while
  *  a smooth touch-ring spin accumulates to the same threshold. */
 private const val ROTARY_VOLUME_STEP_PX = 48f
+
+/** How long the transient volume indicator (#1401) lingers after the last
+ *  bezel/touch-ring step before it fades away. */
+private const val VOLUME_INDICATOR_TIMEOUT_MS = 1_500L
 
 /**
  * Now-playing surface — Library Nocturne styled, circular scrubber on round
@@ -211,6 +226,30 @@ internal fun NowPlayingContent(
     var rotaryAccumPx by remember { mutableFloatStateOf(0f) }
     LaunchedEffect(Unit) { runCatching { rotaryFocus.requestFocus() } }
 
+    // #1401 — transient on-screen feedback for the bezel/touch-ring volume
+    // control added in #1397. `volumeLevel`/`volumeMax` mirror STREAM_MUSIC; each
+    // rotary step bumps `volumeNudge`, which (re)arms the show-then-fade timer so
+    // the brass arc stays up while turning and fades ~1.5s after the last change.
+    val volumeMax = remember(audioManager) {
+        audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC).coerceAtLeast(1)
+    }
+    var volumeLevel by remember {
+        mutableIntStateOf(audioManager.getStreamVolume(AudioManager.STREAM_MUSIC))
+    }
+    var volumeNudge by remember { mutableIntStateOf(0) }
+    var volumeVisible by remember { mutableStateOf(false) }
+    LaunchedEffect(volumeNudge) {
+        if (volumeNudge == 0) return@LaunchedEffect
+        volumeVisible = true
+        delay(VOLUME_INDICATOR_TIMEOUT_MS)
+        volumeVisible = false
+    }
+    val volumeAlpha by animateFloatAsState(
+        targetValue = if (volumeVisible) 1f else 0f,
+        animationSpec = tween(durationMillis = if (volumeVisible) 120 else 480),
+        label = "volumeIndicatorAlpha",
+    )
+
     Scaffold(
         timeText = { TimeText() },
         modifier = Modifier.fillMaxSize(),
@@ -223,12 +262,14 @@ internal fun NowPlayingContent(
                     // while-loops so a fast spin (one large delta) steps more than
                     // once; the sub-detent remainder carries to the next event.
                     rotaryAccumPx += event.verticalScrollPixels
+                    var stepped = false
                     while (rotaryAccumPx >= ROTARY_VOLUME_STEP_PX) {
                         audioManager.adjustStreamVolume(
                             AudioManager.STREAM_MUSIC, AudioManager.ADJUST_RAISE, 0,
                         )
                         view.performHapticFeedback(HapticFeedbackConstants.CLOCK_TICK)
                         rotaryAccumPx -= ROTARY_VOLUME_STEP_PX
+                        stepped = true
                     }
                     while (rotaryAccumPx <= -ROTARY_VOLUME_STEP_PX) {
                         audioManager.adjustStreamVolume(
@@ -236,6 +277,13 @@ internal fun NowPlayingContent(
                         )
                         view.performHapticFeedback(HapticFeedbackConstants.CLOCK_TICK)
                         rotaryAccumPx += ROTARY_VOLUME_STEP_PX
+                        stepped = true
+                    }
+                    if (stepped) {
+                        // #1401 — reflect the level the system actually settled on
+                        // (it clamps at 0/max) and (re)arm the fade-out timer.
+                        volumeLevel = audioManager.getStreamVolume(AudioManager.STREAM_MUSIC)
+                        volumeNudge++
                     }
                     true
                 }
@@ -277,6 +325,18 @@ internal fun NowPlayingContent(
                     onPrevChapter = onPrevChapter,
                     onNextChapter = onNextChapter,
                     onReconnect = onReconnect,
+                )
+            }
+            // #1401 — transient volume arc, painted above the now-playing/error
+            // content and below the bottom controls. Non-interactive (no pointer
+            // modifiers), so taps fall through to whatever sits beneath it.
+            if (volumeAlpha > 0.01f) {
+                VolumeIndicator(
+                    level = volumeLevel,
+                    max = volumeMax,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .alpha(volumeAlpha),
                 )
             }
             if (connected && err == null) {
@@ -801,6 +861,78 @@ private fun formatSpeed(speed: Float): String {
     val tenths = (speed * 10f).roundToInt()
     return "${tenths / 10}.${tenths % 10}×"
 }
+
+/**
+ * #1401 — transient volume feedback for the bezel/touch-ring control (#1397).
+ *
+ * A right-edge brass arc that echoes the [CircularScrubber] ring: a warm-dark
+ * track with a brass fill that grows bottom→top with the STREAM_MUSIC level, so
+ * the level reads at a glance without the system volume panel. Purely visual —
+ * the exact value is surfaced to screen readers via a polite live region rather
+ * than drawn as text (the arc is too small to render a legible number on the
+ * wrist). The caller fades this in/out via a wrapping alpha; here we just paint
+ * one frame at the given [level].
+ */
+@Composable
+private fun VolumeIndicator(level: Int, max: Int, modifier: Modifier = Modifier) {
+    val fraction = volumeFraction(level, max)
+    val cd = stringResource(R.string.wear_cd_volume_level, level, max)
+    Box(
+        modifier = modifier.semantics {
+            liveRegion = LiveRegionMode.Polite
+            contentDescription = cd
+        },
+    ) {
+        // Full-size Canvas so the arc radius tracks the watch face; a ~110° span
+        // centred on 3-o'clock hugs the right bezel, clear of the top TimeText.
+        Canvas(modifier = Modifier.fillMaxSize()) {
+            val stroke = 6.dp.toPx()
+            val inset = stroke / 2f + 2.dp.toPx()
+            val topLeft = Offset(inset, inset)
+            val arcSize = Size(size.width - inset * 2f, size.height - inset * 2f)
+            val sweep = 110f
+            val top = -sweep / 2f // upper end of the right-side arc (from 3 o'clock)
+            drawArc(
+                color = BrassRingTrack,
+                startAngle = top,
+                sweepAngle = sweep,
+                useCenter = false,
+                topLeft = topLeft,
+                size = arcSize,
+                style = Stroke(width = stroke, cap = StrokeCap.Round),
+            )
+            if (fraction > 0f) {
+                // Fill grows from the bottom end upward (counter-clockwise sweep).
+                drawArc(
+                    color = BrassPrimary,
+                    startAngle = top + sweep,
+                    sweepAngle = -sweep * fraction,
+                    useCenter = false,
+                    topLeft = topLeft,
+                    size = arcSize,
+                    style = Stroke(width = stroke, cap = StrokeCap.Round),
+                )
+            }
+        }
+        Icon(
+            imageVector = Icons.Outlined.VolumeUp,
+            contentDescription = null, // level announced via the live region above
+            tint = BrassTint,
+            modifier = Modifier
+                .align(Alignment.CenterEnd)
+                .padding(end = 16.dp)
+                .size(18.dp),
+        )
+    }
+}
+
+/**
+ * STREAM_MUSIC [level] as a 0f..1f fraction of [max], guarding the divide (the
+ * caller coerces [max] ≥ 1) and clamping. Pure logic, so it's unit-tested rather
+ * than verified through a Compose render.
+ */
+internal fun volumeFraction(level: Int, max: Int): Float =
+    if (max <= 0) 0f else (level.toFloat() / max.toFloat()).coerceIn(0f, 1f)
 
 // region --- Previews ---
 

--- a/wear/src/main/res/values/strings.xml
+++ b/wear/src/main/res/values/strings.xml
@@ -43,6 +43,9 @@
     <string name="wear_cd_chapter_progress">Chapter progress</string>
     <string name="wear_cd_open_teleprompter">Open teleprompter remote</string>
 
+    <!-- Volume indicator (#1401) — bezel/touch-ring level feedback -->
+    <string name="wear_cd_volume_level">Volume %1$d of %2$d</string>
+
     <!-- Now Playing tile -->
     <string name="wear_tile_label">Now Playing</string>
     <string name="wear_tile_description">Resume your audiobook — play/pause and progress at a glance.</string>

--- a/wear/src/main/res/values/strings.xml
+++ b/wear/src/main/res/values/strings.xml
@@ -42,6 +42,7 @@
     <string name="wear_state_buffering">Buffering</string>
     <string name="wear_cd_chapter_progress">Chapter progress</string>
     <string name="wear_cd_open_teleprompter">Open teleprompter remote</string>
+    <string name="wear_cd_open_sleep_timer">Open sleep timer</string>
 
     <!-- Volume indicator (#1401) — bezel/touch-ring level feedback -->
     <string name="wear_cd_volume_level">Volume %1$d of %2$d</string>

--- a/wear/src/test/kotlin/in/jphe/storyvox/wear/screens/NowPlayingVolumeTest.kt
+++ b/wear/src/test/kotlin/in/jphe/storyvox/wear/screens/NowPlayingVolumeTest.kt
@@ -1,0 +1,36 @@
+package `in`.jphe.storyvox.wear.screens
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Issue #1401 — unit tests for [volumeFraction], the STREAM_MUSIC level→arc-fill
+ * mapping behind the transient volume indicator on the Wear now-playing surface.
+ * Pure logic, so it's verified here rather than through a Compose render.
+ */
+class NowPlayingVolumeTest {
+
+    @Test fun `zero volume is an empty arc`() {
+        assertEquals(0f, volumeFraction(0, 15), 0f)
+    }
+
+    @Test fun `full volume fills the arc`() {
+        assertEquals(1f, volumeFraction(15, 15), 0f)
+    }
+
+    @Test fun `mid volume is a proportional fraction`() {
+        assertEquals(0.5f, volumeFraction(5, 10), 1e-6f)
+    }
+
+    @Test fun `level above max clamps to full`() {
+        assertEquals(1f, volumeFraction(20, 15), 0f)
+    }
+
+    @Test fun `negative level clamps to empty`() {
+        assertEquals(0f, volumeFraction(-3, 15), 0f)
+    }
+
+    @Test fun `non-positive max is treated as empty rather than dividing by zero`() {
+        assertEquals(0f, volumeFraction(5, 0), 0f)
+    }
+}


### PR DESCRIPTION
## Wear OS now-playing polish — two follow-ups to the #1397 bezel volume control

Salvaged and completed from an OOM-interrupted worktree. Two logical commits, one per issue.

### 1. `feat(wear)` — transient volume indicator (#1401)
Turning the rotating bezel / touch-ring changed `STREAM_MUSIC` volume (wired in #1397) with **no on-screen feedback**. Added a transient brass arc on the right bezel that appears on rotary turn, tracks current/max volume, and fades ~1.5 s after the last step.

- **`VolumeIndicator`** — a full-size `Canvas` painting a ~110° arc centred on 3 o'clock: a warm-dark `BrassRingTrack` track with a `BrassPrimary` fill that grows bottom→top with the level, echoing the `CircularScrubber` ring. A `VolumeUp` glyph anchors `CenterEnd`.
- Each rotary step re-reads `getStreamVolume` (so the arc reflects the level the system actually settled on after clamping at 0/max) and re-arms a show-then-fade timer via a nudge counter + `LaunchedEffect`. Asymmetric fade (120 ms in / 480 ms out).
- **a11y** — the exact level is announced through a **polite live region** (`contentDescription` "Volume N of M"), not drawn as text; the arc is too small to render a legible number on the wrist.
- **`volumeFraction()`** extracted as pure `internal` logic and **unit-tested** (zero / full / mid / over-max / negative / non-positive-max) — the level→fill mapping is verified without a Compose render.

### 2. `fix(wear)` — ≥48dp touch targets for Teleprompter/Sleep (#1402)
The Teleprompter and Sleep entries were bare `Text`+`clickable` at the bottom edge — the tappable area was only the glyphs (sub-48dp), easy to fat-finger against the transport row.

- Wrapped both in a shared **`SecondaryAction`** composable: a **≥48dp** touch target on a subtle rounded brass surface. Modifier order is deliberate — `defaultMinSize` + `padding` sit *inside* the `clickable` so ripple/background fill the whole target.
- Both announce to TalkBack as buttons via `onClickLabel` (Sleep gets one too now).
- **Kept the fixed-`Box` layout** rather than a `ScalingLazyColumn`: since #1397 gave the bezel volume control, a scrollable secondary column would need rotary scroll-vs-volume disambiguation — out of scope for an ergonomics fix.

### Notes
- Base rebased cleanly onto the #1475 wear applicationId rebrand (no source overlap).
- APIs verified present in the module's Compose/wear-compose + `material-icons-extended` — no hallucinated symbols.
- No local gradle; CI is the compile gate.

Closes #1401, closes #1402.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
