### PR TITLE
feat(briefing): Morning Briefing — cross-fiction stitcher + build-and-play (slice A, #1467)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -59,6 +59,7 @@ import `in`.jphe.storyvox.feature.settings.CloudVoicesSettingsScreen
 import `in`.jphe.storyvox.feature.settings.MemoryPalaceSettingsScreen
 import `in`.jphe.storyvox.feature.settings.PerformanceSettingsScreen
 import `in`.jphe.storyvox.feature.settings.ReadingSettingsScreen
+import `in`.jphe.storyvox.feature.briefing.MorningBriefingScreen
 import `in`.jphe.storyvox.feature.settings.SettingsHubScreen
 import `in`.jphe.storyvox.feature.stats.ListeningStatsScreen
 import `in`.jphe.storyvox.feature.settings.SettingsScreen
@@ -113,6 +114,9 @@ object StoryvoxRoutes {
 
     /** Issue #1235 — Listening stats dashboard, reached from the Settings hub. */
     const val STATS = "stats"
+
+    /** Issue #1467 — morning-briefing / personal-podcast queue, reached from the Settings hub. */
+    const val MORNING_BRIEFING = "morning_briefing"
 
     /** Issue #1369 — teleprompter script manager (save/edit/organize). The
      *  list is reached from the Settings hub and (once wired) the teleprompter
@@ -1124,6 +1128,7 @@ private fun StoryvoxNavHostContent(
                     onOpenAbout = { navController.navigate(StoryvoxRoutes.SETTINGS_ABOUT) },
                     onOpenAdvanced = { navController.navigate(StoryvoxRoutes.SETTINGS_ADVANCED) },
                     onOpenStats = { navController.navigate(StoryvoxRoutes.STATS) },
+                    onOpenBriefing = { navController.navigate(StoryvoxRoutes.MORNING_BRIEFING) },
                     onOpenScripts = { navController.navigate(StoryvoxRoutes.SCRIPT_LIST) },
                 )
             }
@@ -1139,6 +1144,18 @@ private fun StoryvoxNavHostContent(
                 popExitTransition = popExit,
             ) {
                 ListeningStatsScreen(onBack = { navController.popBackStack() })
+            }
+
+            // Issue #1467 — morning-briefing / personal-podcast queue. Push
+            // enter/exit: a drill-down from the Settings hub like Stats.
+            composable(
+                StoryvoxRoutes.MORNING_BRIEFING,
+                enterTransition = pushEnter,
+                exitTransition = pushExit,
+                popEnterTransition = popEnter,
+                popExitTransition = popExit,
+            ) {
+                MorningBriefingScreen(onBack = { navController.popBackStack() })
             }
 
             // Issue #1369 — teleprompter script manager. List + editor are

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/briefing/BriefingBuilder.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/briefing/BriefingBuilder.kt
@@ -1,0 +1,77 @@
+package `in`.jphe.storyvox.data.briefing
+
+import `in`.jphe.storyvox.data.repository.FictionRepository
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeoutOrNull
+import javax.inject.Inject
+
+/**
+ * Assembles a [BriefingItem] queue from a [BriefingConfig] (#1467).
+ *
+ * Per source: fetch the latest listing, take the top `count`, and resolve each
+ * summary to a concrete playable chapter. Sources are fetched **concurrently**
+ * and **failure-tolerantly** — a source that errors (network, auth-gated, off)
+ * contributes nothing rather than aborting the whole briefing. The output
+ * preserves config order (source A's items, then source B's, …) so the episode
+ * reads in a predictable sequence.
+ */
+interface BriefingBuilder {
+    /** Build the ordered, playable queue. Empty when nothing resolved. */
+    suspend fun build(config: BriefingConfig): List<BriefingItem>
+}
+
+class DefaultBriefingBuilder @Inject constructor(
+    private val repo: FictionRepository,
+) : BriefingBuilder {
+
+    override suspend fun build(config: BriefingConfig): List<BriefingItem> = coroutineScope {
+        // Fetch every source concurrently; keep config order on the way out.
+        config.sources
+            .map { quota -> async { runCatching { itemsForSource(quota) }.getOrDefault(emptyList()) } }
+            .awaitAll()
+            .flatten()
+    }
+
+    private suspend fun itemsForSource(quota: SourceQuota): List<BriefingItem> {
+        if (quota.count <= 0) return emptyList()
+        val listing = repo.browseLatest(page = 1, sourceId = quota.sourceId)
+        val summaries = (listing as? FictionResult.Success)?.value?.items.orEmpty().take(quota.count)
+        // Resolve each summary to its first playable chapter. `browseLatest`
+        // already cached the row (so `refreshDetail` routes to the right
+        // source); `refreshDetail(force)` hydrates the chapter list, which the
+        // Room-backed `observeFiction` then emits. Each resolve is guarded so
+        // one dud item doesn't drop the rest of the source.
+        return summaries.mapNotNull { summary ->
+            runCatching { resolveFirstChapter(summary.id, summary.title, quota.sourceId) }.getOrNull()
+        }
+    }
+
+    private suspend fun resolveFirstChapter(
+        fictionId: String,
+        title: String,
+        sourceId: String,
+    ): BriefingItem? {
+        repo.refreshDetail(fictionId, force = true)
+        // Wait (bounded) for a hydrated detail carrying at least one chapter.
+        // Bounded so a source that never hydrates can't hang the whole build.
+        val detail = withTimeoutOrNull(DETAIL_TIMEOUT_MS) {
+            repo.observeFiction(fictionId).first { it != null && it.chapters.isNotEmpty() }
+        }
+        val chapter = detail?.chapters?.firstOrNull() ?: return null
+        return BriefingItem(
+            fictionId = fictionId,
+            chapterId = chapter.id,
+            sourceId = sourceId,
+            title = title,
+        )
+    }
+
+    private companion object {
+        /** Upper bound on waiting for one item's chapter list to hydrate. */
+        const val DETAIL_TIMEOUT_MS = 15_000L
+    }
+}

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/briefing/BriefingModels.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/briefing/BriefingModels.kt
@@ -1,0 +1,63 @@
+package `in`.jphe.storyvox.data.briefing
+
+import `in`.jphe.storyvox.data.source.SourceIds
+
+/**
+ * Morning-briefing domain models (#1467).
+ *
+ * A "briefing" is one continuous narrated queue stitched from the *latest*
+ * items of several sources — HN top, arXiv, RSS feeds, GitHub activity — so the
+ * user can listen to it hands-free as a single "episode". Everything here is
+ * plain data with no Android / coroutine dependency, so it's trivially
+ * unit-testable and safe to share across `:core-data` and `:core-playback`.
+ */
+
+/**
+ * One source's contribution to a briefing: pull the [count] most-recent items
+ * from [sourceId]. `sourceId` matches the stable [SourceIds] constants the
+ * source-plugin registry keys on.
+ */
+data class SourceQuota(
+    val sourceId: String,
+    val count: Int,
+)
+
+/**
+ * Which sources feed the briefing and how many items each. In slice 1 this is
+ * hardcoded to [DEFAULT]; the slice-2 config picker (#1467 follow-up) persists
+ * a user-chosen value and swaps it in **without touching the builder** — the
+ * builder consumes a `BriefingConfig`, not a hardcoded list.
+ */
+data class BriefingConfig(
+    val sources: List<SourceQuota>,
+) {
+    companion object {
+        /**
+         * The out-of-the-box briefing: the four "news-shaped" sources called
+         * out in #1467, three items each. Sources the user hasn't enabled (or
+         * that fail to fetch) are skipped at build time, so listing one here is
+         * safe even if it's off.
+         */
+        val DEFAULT = BriefingConfig(
+            sources = listOf(
+                SourceQuota(SourceIds.HACKERNEWS, count = 3),
+                SourceQuota(SourceIds.ARXIV, count = 3),
+                SourceQuota(SourceIds.RSS, count = 3),
+                SourceQuota(SourceIds.GITHUB, count = 3),
+            ),
+        )
+    }
+}
+
+/**
+ * A resolved, immediately-playable briefing entry — a concrete
+ * `(fictionId, chapterId)` the [PlaybackController][in.jphe.storyvox] can load,
+ * plus the display metadata the queue UI shows. Built by
+ * [BriefingBuilder.build] from each source's latest items.
+ */
+data class BriefingItem(
+    val fictionId: String,
+    val chapterId: String,
+    val sourceId: String,
+    val title: String,
+)

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/di/DataModule.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/di/DataModule.kt
@@ -32,6 +32,8 @@ import `in`.jphe.storyvox.data.db.dao.LlmSessionDao
 import `in`.jphe.storyvox.data.db.dao.PlaybackDao
 import `in`.jphe.storyvox.data.db.dao.TeleprompterScriptDao
 import `in`.jphe.storyvox.data.db.migration.ALL_MIGRATIONS
+import `in`.jphe.storyvox.data.briefing.BriefingBuilder
+import `in`.jphe.storyvox.data.briefing.DefaultBriefingBuilder
 import `in`.jphe.storyvox.data.repository.AuthRepository
 import `in`.jphe.storyvox.data.repository.AnnotationRepository
 import `in`.jphe.storyvox.data.repository.AnnotationRepositoryImpl
@@ -316,6 +318,11 @@ abstract class RepositoryBindings {
     abstract fun bindListeningStatsRepository(
         impl: ListeningStatsRepositoryImpl,
     ): ListeningStatsRepository
+
+    // Issue #1467 — morning-briefing queue builder. Resolves each configured
+    // source's latest items to playable chapters (via FictionRepository).
+    @Binds @Singleton
+    abstract fun bindBriefingBuilder(impl: DefaultBriefingBuilder): BriefingBuilder
 
     @Binds @Singleton
     abstract fun bindInboxRepository(impl: InboxRepositoryImpl): InboxRepository

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/briefing/BriefingBuilderTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/briefing/BriefingBuilderTest.kt
@@ -92,6 +92,7 @@ class BriefingBuilderTest {
                     FictionSummary(id = "$source:$n", sourceId = source, title = "$source #$n", author = "a")
                 },
                 page = 1,
+                hasNext = false,
             ),
         )
 
@@ -128,7 +129,7 @@ class BriefingBuilderTest {
             page: Int,
             sourceId: String,
         ): FictionResult<ListPage<FictionSummary>> =
-            latest[sourceId] ?: FictionResult.Success(ListPage(emptyList(), page))
+            latest[sourceId] ?: FictionResult.Success(ListPage(emptyList(), page, hasNext = false))
 
         override suspend fun refreshDetail(id: String, force: Boolean): FictionResult<Unit> =
             FictionResult.Success(Unit)

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/briefing/BriefingBuilderTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/briefing/BriefingBuilderTest.kt
@@ -1,0 +1,160 @@
+package `in`.jphe.storyvox.data.briefing
+
+import `in`.jphe.storyvox.data.repository.FictionRepository
+import `in`.jphe.storyvox.data.source.model.ChapterInfo
+import `in`.jphe.storyvox.data.source.model.FictionDetail
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import `in`.jphe.storyvox.data.source.model.FictionSummary
+import `in`.jphe.storyvox.data.source.model.ListPage
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #1467 — [DefaultBriefingBuilder] resolves each configured source's latest
+ * items to playable chapters, preserving config order, honoring per-source
+ * counts, and tolerating a source that fails or yields nothing.
+ */
+class BriefingBuilderTest {
+
+    @Test fun `builds items across sources in config order, capped per quota`() = runTest {
+        val repo = FakeRepo().apply {
+            latest["hackernews"] = summaries("hackernews", 1, 2, 3) // 3 available…
+            latest["arxiv"] = summaries("arxiv", 1, 2)
+            everySummaryHasOneChapter()
+        }
+        val builder = DefaultBriefingBuilder(repo)
+
+        val items = builder.build(
+            BriefingConfig(listOf(SourceQuota("hackernews", 2), SourceQuota("arxiv", 5))),
+        )
+
+        // hackernews capped to 2; arxiv has only 2; config order preserved.
+        assertEquals(
+            listOf("hackernews:1", "hackernews:2", "arxiv:1", "arxiv:2"),
+            items.map { it.fictionId },
+        )
+        assertEquals("chap-hackernews:1", items.first().chapterId)
+    }
+
+    @Test fun `a failing source contributes nothing but does not abort the briefing`() = runTest {
+        val repo = FakeRepo().apply {
+            latest["hackernews"] = FictionResult.NetworkError(message = "down")
+            latest["arxiv"] = summaries("arxiv", 1)
+            everySummaryHasOneChapter()
+        }
+        val builder = DefaultBriefingBuilder(repo)
+
+        val items = builder.build(
+            BriefingConfig(listOf(SourceQuota("hackernews", 3), SourceQuota("arxiv", 3))),
+        )
+
+        assertEquals(listOf("arxiv:1"), items.map { it.fictionId })
+    }
+
+    @Test fun `summaries whose detail has no chapters are skipped`() = runTest {
+        val repo = FakeRepo().apply {
+            latest["arxiv"] = summaries("arxiv", 1, 2)
+            details["arxiv:1"] = detail("arxiv:1", chapters = emptyList()) // no playable chapter
+            details["arxiv:2"] = detail(
+                "arxiv:2",
+                chapters = listOf(ChapterInfo(id = "chap-arxiv:2", sourceChapterId = "s2", index = 0, title = "T")),
+            )
+        }
+        val builder = DefaultBriefingBuilder(repo)
+
+        val items = builder.build(BriefingConfig(listOf(SourceQuota("arxiv", 5))))
+
+        assertEquals(listOf("arxiv:2"), items.map { it.fictionId })
+    }
+
+    @Test fun `a zero-count quota fetches nothing`() = runTest {
+        val repo = FakeRepo().apply {
+            latest["arxiv"] = summaries("arxiv", 1)
+            everySummaryHasOneChapter()
+        }
+        val builder = DefaultBriefingBuilder(repo)
+
+        val items = builder.build(BriefingConfig(listOf(SourceQuota("arxiv", 0))))
+
+        assertTrue(items.isEmpty())
+    }
+
+    // ─── helpers ──────────────────────────────────────────────────────────────
+
+    private fun summaries(source: String, vararg ns: Int): FictionResult<ListPage<FictionSummary>> =
+        FictionResult.Success(
+            ListPage(
+                items = ns.map { n ->
+                    FictionSummary(id = "$source:$n", sourceId = source, title = "$source #$n", author = "a")
+                },
+                page = 1,
+            ),
+        )
+
+    private fun detail(id: String, chapters: List<ChapterInfo>): FictionDetail =
+        FictionDetail(
+            summary = FictionSummary(id = id, sourceId = id.substringBefore(':'), title = id, author = "a"),
+            chapters = chapters,
+        )
+
+    /**
+     * Hand-rolled [FictionRepository] fake — only the three methods the builder
+     * calls (`browseLatest`, `refreshDetail`, `observeFiction`) are real; the
+     * rest are unreachable for these tests.
+     */
+    private class FakeRepo : FictionRepository {
+        val latest = mutableMapOf<String, FictionResult<ListPage<FictionSummary>>>()
+        val details = mutableMapOf<String, FictionDetail?>()
+
+        /** Convenience: give every summary in every `latest` listing a single chapter. */
+        fun everySummaryHasOneChapter() {
+            latest.values.forEach { res ->
+                (res as? FictionResult.Success)?.value?.items?.forEach { s ->
+                    details[s.id] = FictionDetail(
+                        summary = s,
+                        chapters = listOf(
+                            ChapterInfo(id = "chap-${s.id}", sourceChapterId = s.id, index = 0, title = s.title),
+                        ),
+                    )
+                }
+            }
+        }
+
+        override suspend fun browseLatest(
+            page: Int,
+            sourceId: String,
+        ): FictionResult<ListPage<FictionSummary>> =
+            latest[sourceId] ?: FictionResult.Success(ListPage(emptyList(), page))
+
+        override suspend fun refreshDetail(id: String, force: Boolean): FictionResult<Unit> =
+            FictionResult.Success(Unit)
+
+        override fun observeFiction(id: String): Flow<FictionDetail?> = flowOf(details[id])
+
+        // ── unused by the builder ──
+        override fun observeLibrary(): Flow<List<FictionSummary>> = TODO()
+        override fun observeFollowsRemote(): Flow<List<FictionSummary>> = TODO()
+        override fun observeIsInLibrary(id: String): Flow<Boolean> = TODO()
+        override suspend fun browsePopular(page: Int, sourceId: String): FictionResult<ListPage<FictionSummary>> = TODO()
+        override suspend fun browseByGenre(genre: String, page: Int, sourceId: String): FictionResult<ListPage<FictionSummary>> = TODO()
+        override suspend fun search(query: `in`.jphe.storyvox.data.source.model.SearchQuery, sourceId: String): FictionResult<ListPage<FictionSummary>> = TODO()
+        override suspend fun cacheBrowseListing(result: FictionResult<ListPage<FictionSummary>>): FictionResult<ListPage<FictionSummary>> = TODO()
+        override suspend fun genres(sourceId: String): FictionResult<List<String>> = TODO()
+        override suspend fun refreshRemoteFollows(): FictionResult<Unit> = TODO()
+        override suspend fun addToLibrary(id: String, mode: `in`.jphe.storyvox.data.db.entity.DownloadMode?) = TODO()
+        override suspend fun removeFromLibrary(id: String) = TODO()
+        override suspend fun setDownloadMode(id: String, mode: `in`.jphe.storyvox.data.db.entity.DownloadMode?) = TODO()
+        override suspend fun setPinnedVoice(id: String, voiceId: String?, locale: String?) = TODO()
+        override suspend fun pinnedVoiceId(id: String): String? = TODO()
+        override suspend fun setPlaybackSpeed(id: String, speed: Float?) = TODO()
+        override fun observePlaybackSpeed(id: String): Flow<Float?> = TODO()
+        override suspend fun setFollowedRemote(id: String, followed: Boolean): FictionResult<Unit> = TODO()
+        override suspend fun markAllCaughtUp(): Int = TODO()
+        override suspend fun addByUrl(url: String, preferredSourceId: String?): `in`.jphe.storyvox.data.repository.AddByUrlResult = TODO()
+        override fun previewUrl(url: String): List<`in`.jphe.storyvox.data.source.RouteMatch> = TODO()
+    }
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/briefing/BriefingQueueController.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/briefing/BriefingQueueController.kt
@@ -1,0 +1,137 @@
+package `in`.jphe.storyvox.playback.briefing
+
+import `in`.jphe.storyvox.data.briefing.BriefingBuilder
+import `in`.jphe.storyvox.data.briefing.BriefingConfig
+import `in`.jphe.storyvox.data.briefing.BriefingItem
+import `in`.jphe.storyvox.playback.PlaybackController
+import `in`.jphe.storyvox.playback.PlaybackUiEvent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * The morning-briefing "stitcher" (#1467) — the piece that was missing.
+ *
+ * `PlaybackController` auto-advances **within** a fiction and then emits
+ * [PlaybackUiEvent.BookFinished] at the end; it has no concept of a queue that
+ * spans *different* fictions/sources. This controller adds exactly that layer,
+ * and nothing more: it holds an ordered [BriefingItem] queue, plays the current
+ * item through the real load path ([PlaybackController.play] — never bare
+ * navigation, cf. the #1455 class of "opened without loading" bugs), listens
+ * for `BookFinished`, and advances to the next item. It never reaches into
+ * `EnginePlayer`.
+ *
+ * Scoped as a **`@Singleton`** alongside `PlaybackController`, not to any
+ * ViewModel/composable: a hands-free briefing must keep advancing when the user
+ * navigates away from whatever screen started it. (Process-death recovery of
+ * the cursor is a deliberate follow-up; surviving screen changes is slice 1.)
+ */
+@Singleton
+class BriefingQueueController(
+    private val controller: PlaybackController,
+    private val builder: BriefingBuilder,
+    private val scope: CoroutineScope,
+) {
+    /**
+     * Hilt entry point. The real app gets a long-lived Default-dispatcher scope
+     * that outlives every screen; tests use the primary constructor to inject a
+     * controllable scope.
+     */
+    @Inject
+    constructor(
+        controller: PlaybackController,
+        builder: BriefingBuilder,
+    ) : this(controller, builder, CoroutineScope(SupervisorJob() + Dispatchers.Default))
+
+    private val _session = MutableStateFlow<BriefingSession?>(null)
+
+    /** The live briefing, or null when none is playing. UI observes this. */
+    val session: StateFlow<BriefingSession?> = _session.asStateFlow()
+
+    /** The `BookFinished` listener for the active briefing; cancelled on stop/finish. */
+    private var listenerJob: Job? = null
+
+    /**
+     * Build the queue for [config] and start playing it as one episode.
+     * Returns false (and starts nothing) when the build resolved zero items —
+     * e.g. every configured source was off or failed.
+     */
+    suspend fun start(config: BriefingConfig): Boolean {
+        stop()
+        val items = builder.build(config)
+        if (items.isEmpty()) return false
+        _session.value = BriefingSession(items = items, index = 0)
+        listenerJob = scope.launch {
+            controller.events.collect { ev ->
+                if (ev is PlaybackUiEvent.BookFinished) onCurrentItemFinished()
+            }
+        }
+        playCurrent()
+        return true
+    }
+
+    /** Stop the briefing and detach the advance listener. Does not stop the player. */
+    fun stop() {
+        listenerJob?.cancel()
+        listenerJob = null
+        _session.value = null
+    }
+
+    /** End-of-item hook: advance the cursor and either play the next item or finish. */
+    private suspend fun onCurrentItemFinished() {
+        val current = _session.value ?: return
+        val next = advance(current)
+        _session.value = next
+        if (next.finished) {
+            listenerJob?.cancel()
+            listenerJob = null
+        } else {
+            playCurrent()
+        }
+    }
+
+    private suspend fun playCurrent() {
+        val item = _session.value?.current ?: return
+        controller.play(item.fictionId, item.chapterId)
+    }
+
+    internal companion object {
+        /**
+         * Pure cursor transition: given a session, produce the session after the
+         * current item finishes. Advancing off the end marks it [finished]
+         * (index parked at `items.size`) rather than wrapping. Extracted as pure
+         * logic so the queue's core behavior is unit-tested without a player.
+         */
+        fun advance(session: BriefingSession): BriefingSession {
+            val next = session.index + 1
+            return if (next >= session.items.size) {
+                session.copy(index = session.items.size, finished = true)
+            } else {
+                session.copy(index = next)
+            }
+        }
+    }
+}
+
+/**
+ * Immutable snapshot of an in-flight briefing: the resolved queue plus the
+ * cursor. [finished] latches true once the last item has played out.
+ */
+data class BriefingSession(
+    val items: List<BriefingItem>,
+    val index: Int,
+    val finished: Boolean = false,
+) {
+    /** The item currently playing, or null once finished / out of range. */
+    val current: BriefingItem? get() = items.getOrNull(index)
+
+    /** 1-based position for UI ("3 of 12"); 0 when finished/empty. */
+    val position: Int get() = if (finished) items.size else (index + 1).coerceAtMost(items.size)
+}

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/briefing/BriefingQueueControllerTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/briefing/BriefingQueueControllerTest.kt
@@ -1,0 +1,160 @@
+package `in`.jphe.storyvox.playback.briefing
+
+import `in`.jphe.storyvox.data.briefing.BriefingBuilder
+import `in`.jphe.storyvox.data.briefing.BriefingConfig
+import `in`.jphe.storyvox.data.briefing.BriefingItem
+import `in`.jphe.storyvox.playback.BufferTelemetry
+import `in`.jphe.storyvox.playback.EngineState
+import `in`.jphe.storyvox.playback.PlaybackController
+import `in`.jphe.storyvox.playback.PlaybackState
+import `in`.jphe.storyvox.playback.PlaybackUiEvent
+import `in`.jphe.storyvox.playback.SleepTimerMode
+import `in`.jphe.storyvox.playback.WaitReason
+import `in`.jphe.storyvox.playback.tts.RecapPlaybackState
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #1467 — behavior of the cross-fiction briefing stitcher.
+ *
+ * Two layers are tested: the pure [BriefingQueueController.advance] cursor
+ * transition (no player needed), and the end-to-end play-through where a
+ * `BookFinished` event walks the queue via the real [PlaybackController.play]
+ * path.
+ */
+class BriefingQueueControllerTest {
+
+    private fun item(n: Int) = BriefingItem("f$n", "c$n", "src", "Item $n")
+
+    private fun session(count: Int, index: Int = 0) =
+        BriefingSession(items = (1..count).map(::item), index = index)
+
+    // ─── pure cursor logic ──────────────────────────────────────────────────
+
+    @Test fun `advance moves to the next item`() {
+        val next = BriefingQueueController.advance(session(count = 3, index = 0))
+        assertEquals(1, next.index)
+        assertFalse(next.finished)
+        assertEquals("f2", next.current?.fictionId)
+    }
+
+    @Test fun `advancing off the last item finishes the briefing`() {
+        val next = BriefingQueueController.advance(session(count = 3, index = 2))
+        assertTrue(next.finished)
+        assertNull(next.current)
+        assertEquals(3, next.position) // parks at size for "3 of 3"
+    }
+
+    @Test fun `a single-item briefing finishes after one advance`() {
+        val next = BriefingQueueController.advance(session(count = 1, index = 0))
+        assertTrue(next.finished)
+        assertNull(next.current)
+    }
+
+    @Test fun `position is 1-based while playing`() {
+        assertEquals(1, session(count = 3, index = 0).position)
+        assertEquals(3, session(count = 3, index = 2).position)
+    }
+
+    // ─── end-to-end play-through ──────────────────────────────────────────────
+
+    @Test fun `start plays the first item and BookFinished walks the queue`() = runTest {
+        val controller = RecordingController()
+        val builder = FakeBuilder((1..3).map(::item))
+        val queue = BriefingQueueController(controller, builder, backgroundScope)
+
+        assertTrue(queue.start(BriefingConfig(emptyList())))
+        runCurrent()
+        assertEquals(listOf("f1" to "c1"), controller.plays)
+        assertEquals(0, queue.session.value?.index)
+
+        controller.emittableEvents.emit(PlaybackUiEvent.BookFinished)
+        runCurrent()
+        assertEquals(listOf("f1" to "c1", "f2" to "c2"), controller.plays)
+
+        controller.emittableEvents.emit(PlaybackUiEvent.BookFinished)
+        runCurrent()
+        assertEquals(listOf("f1" to "c1", "f2" to "c2", "f3" to "c3"), controller.plays)
+
+        // Past the last item: finishes, plays nothing more.
+        controller.emittableEvents.emit(PlaybackUiEvent.BookFinished)
+        runCurrent()
+        assertEquals(3, controller.plays.size)
+        assertTrue(queue.session.value?.finished == true)
+    }
+
+    @Test fun `start returns false and plays nothing when the build is empty`() = runTest {
+        val controller = RecordingController()
+        val queue = BriefingQueueController(controller, FakeBuilder(emptyList()), backgroundScope)
+
+        assertFalse(queue.start(BriefingConfig(emptyList())))
+        runCurrent()
+        assertTrue(controller.plays.isEmpty())
+        assertNull(queue.session.value)
+    }
+
+    // ─── test doubles ─────────────────────────────────────────────────────────
+
+    private class FakeBuilder(private val items: List<BriefingItem>) : BriefingBuilder {
+        override suspend fun build(config: BriefingConfig): List<BriefingItem> = items
+    }
+
+    /** Minimal PlaybackController that records play() calls and lets the test drive events. */
+    private class RecordingController : PlaybackController {
+        val plays = mutableListOf<Pair<String, String>>()
+        val emittableEvents = MutableSharedFlow<PlaybackUiEvent>(extraBufferCapacity = 8)
+
+        override suspend fun play(fictionId: String, chapterId: String, charOffset: Int) {
+            plays += fictionId to chapterId
+        }
+
+        override val state: StateFlow<PlaybackState> = MutableStateFlow(PlaybackState()).asStateFlow()
+        override val events: SharedFlow<PlaybackUiEvent> = emittableEvents.asSharedFlow()
+        override val engineState: StateFlow<EngineState> = MutableStateFlow<EngineState>(EngineState.Idle).asStateFlow()
+        override val playbackPositionMs: StateFlow<Long> = MutableStateFlow(0L).asStateFlow()
+        override val chapterDurationMs: StateFlow<Long> = MutableStateFlow(0L).asStateFlow()
+        override val recapPlayback: StateFlow<RecapPlaybackState> =
+            MutableStateFlow(RecapPlaybackState.Idle).asStateFlow()
+        override val waitReason: StateFlow<WaitReason?> = MutableStateFlow<WaitReason?>(null).asStateFlow()
+
+        override fun pause() = Unit
+        override fun resume() = Unit
+        override fun togglePlayPause() = Unit
+        override fun seekTo(charOffset: Int) = Unit
+        override fun seekToPositionMs(positionMs: Long) = Unit
+        override fun skipForward30s() = Unit
+        override fun skipBack30s() = Unit
+        override fun prewarmEngine() = Unit
+        override fun nextSentence() = Unit
+        override fun previousSentence() = Unit
+        override fun nextParagraph() = Unit
+        override fun previousParagraph() = Unit
+        override suspend fun nextChapter() = Unit
+        override suspend fun previousChapter() = Unit
+        override suspend fun jumpToChapter(chapterId: String) = Unit
+        override fun setSpeed(speed: Float) = Unit
+        override fun setPitch(pitch: Float) = Unit
+        override fun setPunctuationPauseMultiplier(multiplier: Float) = Unit
+        override fun startSleepTimer(mode: SleepTimerMode) = Unit
+        override fun cancelSleepTimer() = Unit
+        override fun toggleSleepTimer() = Unit
+        override fun setShakeToExtendEnabled(enabled: Boolean) = Unit
+        override suspend fun speakText(text: String) = Unit
+        override fun stopSpeaking() = Unit
+        override fun bufferTelemetry() = BufferTelemetry()
+        override suspend fun bookmarkHere() = Unit
+        override suspend fun clearBookmark() = Unit
+        override suspend fun jumpToBookmark() = false
+    }
+}

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/briefing/BriefingQueueControllerTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/briefing/BriefingQueueControllerTest.kt
@@ -9,7 +9,7 @@ import `in`.jphe.storyvox.playback.PlaybackController
 import `in`.jphe.storyvox.playback.PlaybackState
 import `in`.jphe.storyvox.playback.PlaybackUiEvent
 import `in`.jphe.storyvox.playback.SleepTimerMode
-import `in`.jphe.storyvox.playback.WaitReason
+import `in`.jphe.storyvox.playback.diagnostics.WaitReason
 import `in`.jphe.storyvox.playback.tts.RecapPlaybackState
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/briefing/BriefingViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/briefing/BriefingViewModel.kt
@@ -1,0 +1,54 @@
+package `in`.jphe.storyvox.feature.briefing
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import `in`.jphe.storyvox.data.briefing.BriefingConfig
+import `in`.jphe.storyvox.playback.briefing.BriefingQueueController
+import `in`.jphe.storyvox.playback.briefing.BriefingSession
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * #1467 — drives the Morning Briefing entry point.
+ *
+ * Thin: the durable queue state lives in the [BriefingQueueController]
+ * singleton (so the episode survives this screen leaving composition), and the
+ * ViewModel just exposes it and triggers an on-demand build with the default
+ * config. Slice 2 will swap [BriefingConfig.DEFAULT] for a persisted user
+ * config without changing this call site.
+ */
+@HiltViewModel
+class BriefingViewModel @Inject constructor(
+    private val queue: BriefingQueueController,
+) : ViewModel() {
+
+    /** The live briefing session (null when none is playing). */
+    val session: StateFlow<BriefingSession?> = queue.session
+
+    private val _building = MutableStateFlow(false)
+    /** True while the queue is being assembled (network fetches in flight). */
+    val building: StateFlow<Boolean> = _building.asStateFlow()
+
+    private val _emptyResult = MutableStateFlow(false)
+    /** True when the last build resolved zero playable items. */
+    val emptyResult: StateFlow<Boolean> = _emptyResult.asStateFlow()
+
+    /** Assemble today's briefing and start playing it as one continuous episode. */
+    fun buildAndPlay() {
+        if (_building.value) return
+        viewModelScope.launch {
+            _building.value = true
+            _emptyResult.value = false
+            val started = runCatching { queue.start(BriefingConfig.DEFAULT) }.getOrDefault(false)
+            _building.value = false
+            _emptyResult.value = !started
+        }
+    }
+
+    /** Stop the briefing and clear the session. */
+    fun stop() = queue.stop()
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/briefing/MorningBriefingScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/briefing/MorningBriefingScreen.kt
@@ -1,0 +1,176 @@
+package `in`.jphe.storyvox.feature.briefing
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import `in`.jphe.storyvox.ui.theme.LocalSpacing
+
+/**
+ * #1467 — Morning Briefing entry point (slice 1).
+ *
+ * Reached from the Settings hub. One button assembles today's briefing from the
+ * default sources and starts playing it as a single continuous episode; the
+ * assembled queue is shown with the current item highlighted. Because the queue
+ * lives in the [BriefingQueueController][in.jphe.storyvox.playback.briefing]
+ * singleton, playback keeps going (and advancing) when you leave this screen.
+ *
+ * Copy is inline for slice 1; source picker + string extraction + brass polish
+ * are #1467 follow-ups.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MorningBriefingScreen(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: BriefingViewModel = hiltViewModel(),
+) {
+    val session by viewModel.session.collectAsStateWithLifecycle()
+    val building by viewModel.building.collectAsStateWithLifecycle()
+    val emptyResult by viewModel.emptyResult.collectAsStateWithLifecycle()
+    val spacing = LocalSpacing.current
+
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text("Morning Briefing") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(spacing.md),
+            verticalArrangement = Arrangement.spacedBy(spacing.md),
+        ) {
+            Text(
+                text = "One continuous episode from your sources — Hacker News, arXiv, RSS, and GitHub. " +
+                    "Play it hands-free on your walk.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            Button(
+                onClick = viewModel::buildAndPlay,
+                enabled = !building,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                if (building) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(18.dp),
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.onPrimary,
+                    )
+                    Spacer(Modifier.width(spacing.sm))
+                    Text("Building your briefing…")
+                } else {
+                    Text("Build & play my briefing")
+                }
+            }
+
+            if (emptyResult) {
+                Text(
+                    text = "No items yet — make sure Hacker News, arXiv, RSS, or GitHub are " +
+                        "enabled and have recent posts, then try again.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+
+            val current = session
+            if (current != null) {
+                Text(
+                    text = if (current.finished) {
+                        "Briefing complete · ${current.items.size} items"
+                    } else {
+                        "Playing ${current.position} of ${current.items.size}"
+                    },
+                    style = MaterialTheme.typography.titleMedium,
+                )
+                LazyColumn(verticalArrangement = Arrangement.spacedBy(spacing.xs)) {
+                    itemsIndexed(current.items) { index, item ->
+                        BriefingItemRow(
+                            title = item.title,
+                            source = item.sourceId,
+                            isCurrent = index == current.index && !current.finished,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun BriefingItemRow(
+    title: String,
+    source: String,
+    isCurrent: Boolean,
+) {
+    val spacing = LocalSpacing.current
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = if (isCurrent) {
+                MaterialTheme.colorScheme.primaryContainer
+            } else {
+                MaterialTheme.colorScheme.surfaceVariant
+            },
+        ),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = spacing.md, vertical = spacing.sm),
+            horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+        ) {
+            Column(modifier = Modifier.fillMaxWidth()) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = if (isCurrent) FontWeight.SemiBold else FontWeight.Normal,
+                    maxLines = 2,
+                )
+                Text(
+                    text = source,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsHubScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsHubScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material.icons.outlined.Extension
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.Description
 import androidx.compose.material.icons.outlined.Insights
+import androidx.compose.material.icons.outlined.Podcasts
 import androidx.compose.material.icons.outlined.RecordVoiceOver
 import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material.icons.outlined.Speed
@@ -159,6 +160,12 @@ fun SettingsHubScreen(
      */
     onOpenStats: () -> Unit = {},
     /**
+     * Issue #1467 — morning-briefing / personal-podcast queue. Default no-op so
+     * existing callers / smoke tests compile without wiring it; production
+     * wiring lives in [`in.jphe.storyvox.navigation.StoryvoxNavHost`].
+     */
+    onOpenBriefing: () -> Unit = {},
+    /**
      * Issue #1369 — teleprompter script manager. Default no-op so existing
      * callers / smoke tests compile without wiring it; production wiring lives
      * in [`in.jphe.storyvox.navigation.StoryvoxNavHost`].
@@ -253,6 +260,16 @@ fun SettingsHubScreen(
                     title = stringResource(R.string.settings_hub_stats_title),
                     subtitle = stringResource(R.string.settings_hub_stats_subtitle),
                     onClick = onOpenStats,
+                )
+                // Issue #1467 — morning briefing / personal-podcast queue.
+                // Reading-adjacent: a curated listen-through of your sources'
+                // latest, stitched into one hands-free episode. (Copy inline
+                // for slice 1; string extraction is a follow-up.)
+                SettingsHubRow(
+                    icon = Icons.Outlined.Podcasts,
+                    title = "Morning Briefing",
+                    subtitle = "One episode from your sources — HN, arXiv, RSS, GitHub",
+                    onClick = onOpenBriefing,
                 )
                 // Issue #1369 — teleprompter script manager. Reading-adjacent:
                 // save/edit/organize scripts the teleprompter can load.


### PR DESCRIPTION
## Morning Briefing / personal-podcast playlist — slice A (#1467)

Auto-assembles one continuous narrated queue from several sources' latest items and plays it hands-free as a single "episode." This is **slice A**: the domain core + cross-fiction stitcher + an on-demand build-and-play entry point. HN/arXiv/RSS/GitHub were already wired as separate browse tabs; the missing piece was the stitcher — that's what this adds.

### Design (checkpointed with the team lead before building)
The key finding: **there is no cross-fiction play queue today.** `PlaybackController.play(fictionId, chapterId)` plays one chapter of one fiction; auto-advance only moves *within* a fiction and then emits `PlaybackUiEvent.BookFinished` on the public `controller.events` flow. So the stitcher is a thin layer **above** `PlaybackController` — it never touches `EnginePlayer` (~6300 lines).

### What's here
**Domain core (commit 1, `core-data` + `core-playback`, fully unit-tested):**
- `BriefingConfig`/`SourceQuota`/`BriefingItem` — plain data; defaults behind `BriefingConfig.DEFAULT` ({HN, arXiv, RSS, GitHub} × 3) so the future picker swaps a value, not the builder.
- `DefaultBriefingBuilder` — per source: `browseLatest` → take N → `refreshDetail(force)` → `observeFiction` → first playable chapter. **Concurrent** and **failure-tolerant**: a source that errors or yields nothing is skipped, never aborts the episode; config order preserved.
- `BriefingQueueController` (**`@Singleton`** in the playback scope, so a hands-free episode survives screen changes) — plays each item via `controller.play` (the real load path, never bare navigation — cf. the #1455 class of bug), listens for `BookFinished`, and walks to the next item. The missing cross-fiction auto-advance.
- Tests: pure `advance()` cursor transitions + an end-to-end `BookFinished` play-through walk; builder order/quota/failure-tolerance/empty-chapter-skip. All `runTest`, no Robolectric.

**Entry point (commit 2, `feature` + nav):**
- `BriefingViewModel` + `MorningBriefingScreen` — one "Build & play my briefing" button, building spinner, empty-result hint, and the assembled queue with the current item highlighted.
- Reached from the Settings hub (new Podcasts row next to Stats) via a `MORNING_BRIEFING` route, mirroring the Stats drill-down.

### Deferred (tracked under #1467)
Source-config **picker UI**, **WorkManager 6am prebuild/prefetch** (the `NewChapterPollWorker` `@HiltWorker` pattern is ready), inter-item **TTS intros**, and **string extraction/brass polish** (copy is inline for slice 1).

Part of #1467.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
