### PR TITLE
feat(bookshare): DataStore-backed BookshareConfig + Settings key field (#1471)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/data/BookshareConfigImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/BookshareConfigImpl.kt
@@ -1,0 +1,63 @@
+package `in`.jphe.storyvox.data
+
+import android.content.SharedPreferences
+import `in`.jphe.storyvox.source.bookshare.BookshareConfig
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/** EncryptedSharedPreferences key for the Bookshare partner API key.
+ *  Lives in the `storyvox.secrets` bag alongside the other source
+ *  credentials (Discord/Notion tokens, `palace.api_key`), so it rides
+ *  the same AES-GCM-at-rest + backup-exclusion posture as every other
+ *  stored secret. */
+internal const val BOOKSHARE_API_KEY_PREF = "pref_source_bookshare_api_key"
+
+/**
+ * Issue #1471 — production [BookshareConfig]. Supplies the partner
+ * `api_key` from the encrypted `storyvox.secrets` bag, replacing the
+ * no-op `InMemoryBookshareConfig` the source module used to bind.
+ *
+ * The moment a non-blank key is stored, `BookshareApi`'s discovery
+ * surface (search / browse / categories) goes live — `BookshareSource`
+ * stops short-circuiting those calls to `FictionResult.AuthRequired`.
+ * When the key is blank/absent, behaviour is identical to today: every
+ * Bookshare call is gated.
+ *
+ * [accessToken] stays `null`: the per-user OAuth2 flow is Stage 2b
+ * (#1462), out of scope here, so member-scoped endpoints remain gated.
+ * Content download (`fictionDetail` / `chapter` — Protected-DAISY) is
+ * gated on the partner agreement (Stage 3) regardless of the api_key.
+ *
+ * Mirrors [DiscordConfigImpl] / [NotionConfigImpl]'s secrets-backed
+ * token leg, minus the DataStore leg — Bookshare has no non-secret
+ * config fields, so the api key is the whole surface.
+ */
+@Singleton
+class BookshareConfigImpl @Inject constructor(
+    private val secrets: SharedPreferences,
+) : BookshareConfig {
+
+    override suspend fun apiKey(): String? =
+        secrets.getString(BOOKSHARE_API_KEY_PREF, null)?.ifBlank { null }
+
+    override suspend fun accessToken(): String? = null
+
+    /**
+     * Settings-UI write hook. Kept off the [BookshareConfig] interface
+     * so the source module reads but cannot write its own credentials
+     * (same posture as [DiscordConfigImpl.setApiToken]). Null/blank
+     * clears the entry, re-gating the source.
+     */
+    fun setApiKey(key: String?) {
+        if (key.isNullOrBlank()) {
+            secrets.edit().remove(BOOKSHARE_API_KEY_PREF).apply()
+        } else {
+            secrets.edit().putString(BOOKSHARE_API_KEY_PREF, key.trim()).apply()
+        }
+    }
+
+    /** True when a non-blank partner key is stored. Drives the UI's
+     *  `bookshareKeyConfigured` projection. */
+    fun isKeyConfigured(): Boolean =
+        !secrets.getString(BOOKSHARE_API_KEY_PREF, null).isNullOrBlank()
+}

--- a/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
@@ -1095,6 +1095,11 @@ class SettingsRepositoryUiImpl(
      *  quota, combined into the [settings] flow so the Settings UI's
      *  "Currently used: 1.4 GB / 2 GB" row stays live. */
     private val cacheStats: CacheStatsRepository,
+    /** Issue #1471 — Bookshare partner-key store. Nullable + null-default
+     *  so the pre-existing primary-ctor test harnesses (named args ending
+     *  at [cacheStats]) need no update; production's @Inject constructor
+     *  below always supplies the real impl. */
+    private val bookshareConfig: BookshareConfigImpl? = null,
     /** Issue #977 — push-on-write seam. The action [scheduleSettingsPush]
      *  fires after the debounce so every synced preference change reaches
      *  InstantDB without a cold-start/manual sync (and can't be clobbered
@@ -1167,6 +1172,7 @@ class SettingsRepositoryUiImpl(
         pcmCache: PcmCache,
         pcmCacheConfig: PcmCacheConfig,
         cacheStats: CacheStatsRepository,
+        bookshareConfig: BookshareConfigImpl,
         // Issue #977 — ⚠️ [dagger.Lazy] is load-bearing: the DI graph has
         // a cycle — SyncCoordinator → Set<Syncer> → SettingsSyncer →
         // SettingsSnapshotSource (this class) → SyncCoordinator. Lazy
@@ -1184,6 +1190,7 @@ class SettingsRepositoryUiImpl(
         azureCreds, azureClient, azureRoster,
         googleTokenSource,
         pcmCache, pcmCacheConfig, cacheStats,
+        bookshareConfig = bookshareConfig,
         pushSettings = { coordinator.get().requestPush(SETTINGS_PUSH_DOMAIN) },
     )
 
@@ -1352,6 +1359,10 @@ class SettingsRepositoryUiImpl(
             // that lands, this default is ON for all builds.
             wikipediaLanguageCode = wikipedia.languageCode,
             discordTokenConfigured = discord.apiToken.isNotBlank(),
+            // Issue #1471 — read the secrets-backed Bookshare key directly
+            // (BookshareConfig has no state Flow); azureTick re-emits this
+            // block when setBookshareApiKey bumps it.
+            bookshareKeyConfigured = bookshareConfig?.isKeyConfigured() ?: false,
             discordServerId = discord.serverId,
             discordServerName = discord.serverName,
             discordCoalesceMinutes = discord.coalesceMinutes,
@@ -2038,6 +2049,14 @@ class SettingsRepositoryUiImpl(
 
     override suspend fun clearPalaceConfig() {
         palaceConfig.clear()
+    }
+
+    /** Issue #1471 — persist/clear the Bookshare partner API key. Bumps
+     *  [azureTick] (the shared non-Flow-secrets tick) so the settings
+     *  Flow re-emits `bookshareKeyConfigured` without a manual refetch. */
+    override suspend fun setBookshareApiKey(key: String?) {
+        bookshareConfig?.setApiKey(key)
+        azureTick.value = azureTick.value + 1
     }
 
     override suspend fun testPalaceConnection(): PalaceProbeResult {

--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -397,6 +397,15 @@ object AppBindings {
     fun provideGoogleNewsConfig(impl: SettingsRepositoryUiImpl):
         `in`.jphe.storyvox.data.repository.GoogleNewsConfig = impl
 
+    /** Issue #1471 — Bookshare partner API key. Supplies the
+     *  secrets-backed [BookshareConfigImpl] over `:source-bookshare`'s
+     *  default (which no longer binds one), so `BookshareSource` /
+     *  `BookshareApi` read the entered `api_key`. Blank key ⇒ the source
+     *  stays gated to AuthRequired, exactly as before. */
+    @Provides @Singleton
+    fun provideBookshareConfig(impl: `in`.jphe.storyvox.data.BookshareConfigImpl):
+        `in`.jphe.storyvox.source.bookshare.BookshareConfig = impl
+
     /** Issue #597 — user-tunable HTTP timeout preset. Same singleton;
      *  consumed by source-* modules' OkHttp factories via an
      *  Interceptor / timeout override. v1 wires this into the most-

--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -55,6 +55,7 @@ import `in`.jphe.storyvox.feature.settings.AccountSettingsScreen
 import `in`.jphe.storyvox.feature.settings.AdvancedSettingsScreen
 import `in`.jphe.storyvox.feature.settings.AppearanceSettingsScreen
 import `in`.jphe.storyvox.feature.settings.AiSettingsScreen
+import `in`.jphe.storyvox.feature.settings.BookshareSettingsScreen
 import `in`.jphe.storyvox.feature.settings.CloudVoicesSettingsScreen
 import `in`.jphe.storyvox.feature.settings.MemoryPalaceSettingsScreen
 import `in`.jphe.storyvox.feature.settings.PerformanceSettingsScreen
@@ -179,6 +180,8 @@ object StoryvoxRoutes {
     const val SETTINGS_ACCOUNT = "settings/account"
     /** Settings → Memory Palace. Daemon host, API key, test probe. */
     const val SETTINGS_MEMORY_PALACE = "settings/memory-palace"
+    /** Settings → Bookshare. Partner API key entry (#1471). */
+    const val SETTINGS_BOOKSHARE = "settings/bookshare"
     /** Settings → About. Version + sigil name + build hash + the
      *  v0.5.00 milestone pill. */
     const val SETTINGS_ABOUT = "settings/about"
@@ -1121,6 +1124,7 @@ private fun StoryvoxNavHostContent(
                     onOpenAppearance = { navController.navigate(StoryvoxRoutes.SETTINGS_APPEARANCE) },
                     onOpenAccount = { navController.navigate(StoryvoxRoutes.SETTINGS_ACCOUNT) },
                     onOpenMemoryPalace = { navController.navigate(StoryvoxRoutes.SETTINGS_MEMORY_PALACE) },
+                    onOpenBookshare = { navController.navigate(StoryvoxRoutes.SETTINGS_BOOKSHARE) },
                     onOpenAbout = { navController.navigate(StoryvoxRoutes.SETTINGS_ABOUT) },
                     onOpenAdvanced = { navController.navigate(StoryvoxRoutes.SETTINGS_ADVANCED) },
                     onOpenStats = { navController.navigate(StoryvoxRoutes.STATS) },
@@ -1419,6 +1423,17 @@ private fun StoryvoxNavHostContent(
                 popExitTransition = popExit,
             ) {
                 MemoryPalaceSettingsScreen(
+                    onBack = { navController.popBackStack() },
+                )
+            }
+            composable(
+                StoryvoxRoutes.SETTINGS_BOOKSHARE,
+                enterTransition = pushEnter,
+                exitTransition = pushExit,
+                popEnterTransition = popEnter,
+                popExitTransition = popExit,
+            ) {
+                BookshareSettingsScreen(
                     onBack = { navController.popBackStack() },
                 )
             }

--- a/app/src/test/kotlin/in/jphe/storyvox/data/BookshareConfigImplTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/BookshareConfigImplTest.kt
@@ -1,0 +1,66 @@
+package `in`.jphe.storyvox.data
+
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1471 — [BookshareConfigImpl] behaviour. The crux is the gating
+ * contract: a blank/absent key must read back as `null` so
+ * `BookshareSource` behaves exactly as before the key wiring landed
+ * (short-circuit to AuthRequired). Backed by the shared in-memory
+ * [FakeSecrets] so no encrypted-prefs / Android runtime is needed.
+ */
+class BookshareConfigImplTest {
+
+    private fun config() = BookshareConfigImpl(FakeSecrets())
+
+    @Test
+    fun `apiKey is null when unset`() = runTest {
+        val c = config()
+        assertNull(c.apiKey())
+        assertFalse(c.isKeyConfigured())
+    }
+
+    @Test
+    fun `apiKey round-trips after set`() = runTest {
+        val c = config()
+        c.setApiKey("partner-key-123")
+        assertEquals("partner-key-123", c.apiKey())
+        assertTrue(c.isKeyConfigured())
+    }
+
+    @Test
+    fun `blank key reads back as null (source stays gated)`() = runTest {
+        val c = config()
+        c.setApiKey("   ")
+        assertNull(c.apiKey())
+        assertFalse(c.isKeyConfigured())
+    }
+
+    @Test
+    fun `key is trimmed on store`() = runTest {
+        val c = config()
+        c.setApiKey("  key  ")
+        assertEquals("key", c.apiKey())
+    }
+
+    @Test
+    fun `null clears a previously stored key`() = runTest {
+        val c = config()
+        c.setApiKey("k")
+        c.setApiKey(null)
+        assertNull(c.apiKey())
+        assertFalse(c.isKeyConfigured())
+    }
+
+    @Test
+    fun `accessToken is always null until stage 2b OAuth`() = runTest {
+        val c = config()
+        c.setApiKey("k")
+        assertNull(c.accessToken())
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -1064,6 +1064,12 @@ data class UiSettings(
      *  page storyvox walks for fictions. Defaults to TechEmpower's
      *  root; users can override to any public Notion page. */
     val notionRootPageId: String = "",
+    /** Issue #1471 — true when a Bookshare partner `api_key` has been
+     *  stored. The key itself is never surfaced to the UI — only this
+     *  boolean. Blank/absent ⇒ the source stays gated to AuthRequired.
+     *  Discovery (search/browse/categories) lights up when set; content
+     *  download stays gated on the partner agreement regardless. */
+    val bookshareKeyConfigured: Boolean = false,
     /** Issue #150 — when ON, a shake during the sleep timer's fade
      *  tail re-arms the timer. Default ON; users with bumpy commutes
      *  can disable to avoid accidental extensions. */
@@ -2207,6 +2213,13 @@ interface SettingsRepositoryUi {
      *  Pass null or empty to clear. Stored encrypted alongside the
      *  Outline / palace tokens in `storyvox.secrets`. */
     suspend fun setNotionApiToken(token: String?)
+
+    /** Issue #1471 — persist or clear the Bookshare partner API key.
+     *  Pass null or empty to clear. Stored encrypted under
+     *  `pref_source_bookshare_api_key` in `storyvox.secrets`. Default
+     *  `= Unit` so test/fake [SettingsRepositoryUi] implementations
+     *  don't need to override it. */
+    suspend fun setBookshareApiKey(key: String?) = Unit
 
     /** Issue #403 — persist or clear the Discord bot token. Pass
      *  null or empty to clear. Stored encrypted under

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/BookshareSettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/BookshareSettingsScreen.kt
@@ -1,0 +1,136 @@
+package `in`.jphe.storyvox.feature.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import `in`.jphe.storyvox.feature.R
+import `in`.jphe.storyvox.feature.settings.components.StatusPill
+import `in`.jphe.storyvox.feature.settings.components.StatusTone
+import `in`.jphe.storyvox.ui.component.BrassButton
+import `in`.jphe.storyvox.ui.component.BrassButtonVariant
+import `in`.jphe.storyvox.ui.theme.LocalSpacing
+
+/**
+ * Settings → Bookshare subscreen (#1471).
+ *
+ * A single masked field to enter / clear the Bookshare partner
+ * `api_key`. The key is write-only from the UI's perspective — it's
+ * persisted encrypted (`storyvox.secrets`) and never read back into the
+ * field; the status pill reflects only whether one is configured
+ * (mirrors the AI BYOK-key posture, so the secret never round-trips
+ * through UI state).
+ *
+ * With a key stored, Bookshare's discovery surface (search / browse /
+ * categories) goes live. Content download stays gated on the Bookshare
+ * partner agreement (a later stage), independent of this key.
+ */
+@Composable
+fun BookshareSettingsScreen(
+    onBack: () -> Unit,
+    viewModel: SettingsViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val spacing = LocalSpacing.current
+
+    SettingsSubscreenScaffold(
+        title = stringResource(R.string.settings_bookshare_title),
+        onBack = onBack,
+    ) { padding ->
+        val s = state.settings ?: run {
+            SettingsSkeleton(modifier = Modifier.fillMaxSize().padding(padding).padding(spacing.md))
+            return@SettingsSubscreenScaffold
+        }
+        SettingsSubscreenBody(padding) {
+            SettingsGroupCard {
+                BookshareApiKeySection(
+                    keyConfigured = s.bookshareKeyConfigured,
+                    onSaveKey = viewModel::setBookshareApiKey,
+                    onClearKey = { viewModel.setBookshareApiKey(null) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun BookshareApiKeySection(
+    keyConfigured: Boolean,
+    onSaveKey: (String) -> Unit,
+    onClearKey: () -> Unit,
+) {
+    val spacing = LocalSpacing.current
+
+    val (statusText, statusTone) = if (keyConfigured) {
+        stringResource(R.string.settings_bookshare_status_configured) to StatusTone.Connected
+    } else {
+        stringResource(R.string.settings_bookshare_status_unconfigured) to StatusTone.Neutral
+    }
+    StatusPill(text = statusText, tone = statusTone)
+
+    Column(
+        modifier = Modifier.padding(horizontal = spacing.md, vertical = spacing.sm),
+        verticalArrangement = Arrangement.spacedBy(spacing.sm),
+    ) {
+        // Write-only field: the stored key is a partner secret and is
+        // never surfaced back into the UI. Typing a new value + Save
+        // replaces it; the status pill above reports configured state.
+        var keyInput by remember { mutableStateOf("") }
+        var keyVisible by remember { mutableStateOf(false) }
+        OutlinedTextField(
+            value = keyInput,
+            onValueChange = { keyInput = it },
+            label = { Text(stringResource(R.string.settings_bookshare_key_label)) },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+            visualTransformation = if (keyVisible) {
+                VisualTransformation.None
+            } else {
+                PasswordVisualTransformation()
+            },
+            modifier = Modifier.fillMaxWidth(),
+        )
+
+        Text(stringResource(R.string.settings_bookshare_help))
+
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+        ) {
+            BrassButton(
+                label = stringResource(R.string.settings_bookshare_save),
+                onClick = {
+                    onSaveKey(keyInput.trim())
+                    keyInput = ""
+                },
+                variant = BrassButtonVariant.Primary,
+                enabled = keyInput.isNotBlank(),
+            )
+            if (keyConfigured) {
+                BrassButton(
+                    label = stringResource(R.string.settings_bookshare_clear),
+                    onClick = onClearKey,
+                    variant = BrassButtonVariant.Secondary,
+                )
+            }
+        }
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsHubScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsHubScreen.kt
@@ -144,6 +144,7 @@ fun SettingsHubScreen(
     onOpenAppearance: () -> Unit,
     onOpenAccount: () -> Unit,
     onOpenMemoryPalace: () -> Unit,
+    onOpenBookshare: () -> Unit,
     onOpenAbout: () -> Unit,
     /**
      * v1 settings-bundle-7 — Advanced subscreen. Default no-op so
@@ -324,6 +325,15 @@ fun SettingsHubScreen(
                     title = stringResource(R.string.settings_hub_memory_palace_title),
                     subtitle = stringResource(R.string.settings_hub_memory_palace_subtitle),
                     onClick = onOpenMemoryPalace,
+                )
+                // Issue #1471 — Bookshare partner-key entry. Source-
+                // credential subscreen, adjacent to Memory Palace (both
+                // configure a source's access).
+                SettingsHubRow(
+                    icon = Icons.AutoMirrored.Outlined.LibraryBooks,
+                    title = stringResource(R.string.settings_hub_bookshare_title),
+                    subtitle = stringResource(R.string.settings_hub_bookshare_subtitle),
+                    onClick = onOpenBookshare,
                 )
                 // v1 settings-bundle-7 — Advanced subscreen. Power-
                 // user knobs (Android Auto bucket size, future

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
@@ -344,6 +344,12 @@ class SettingsViewModel @Inject constructor(
         palaceProbe.value = null
     }
 
+    /** Issue #1471 — persist (or clear, with null) the Bookshare
+     *  partner API key. Stored encrypted; drives `bookshareKeyConfigured`. */
+    fun setBookshareApiKey(key: String?) = viewModelScope.launch {
+        repo.setBookshareApiKey(key)
+    }
+
     fun clearPalaceConfig() = viewModelScope.launch {
         repo.clearPalaceConfig()
         palaceProbe.value = null

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -668,6 +668,8 @@
     <string name="settings_hub_account_subtitle">Royal Road, GitHub.</string>
     <string name="settings_hub_memory_palace_title">Memory Palace</string>
     <string name="settings_hub_memory_palace_subtitle">Daemon host, probe, integration.</string>
+    <string name="settings_hub_bookshare_title">Bookshare</string>
+    <string name="settings_hub_bookshare_subtitle">Accessible DAISY library · partner API key.</string>
     <string name="settings_hub_advanced_title">Advanced</string>
     <string name="settings_hub_advanced_subtitle">Android Auto, integration tunables.</string>
     <string name="settings_hub_developer_title">Developer</string>
@@ -762,6 +764,13 @@
 
     <!-- Settings · Memory Palace subscreen -->
     <string name="settings_memory_palace_title">Memory Palace</string>
+    <string name="settings_bookshare_title">Bookshare</string>
+    <string name="settings_bookshare_key_label">Partner API key</string>
+    <string name="settings_bookshare_help">Bookshare requires a partner API key issued by Benetech. With a key stored, you can search and browse the accessible-book catalog. Downloading protected titles needs a separate partner agreement.</string>
+    <string name="settings_bookshare_save">Save key</string>
+    <string name="settings_bookshare_clear">Clear</string>
+    <string name="settings_bookshare_status_configured">Partner key stored · discovery enabled</string>
+    <string name="settings_bookshare_status_unconfigured">No partner key · Bookshare stays locked</string>
 
     <!-- Settings · Advanced subscreen -->
     <string name="settings_advanced_title">Advanced</string>

--- a/source-bookshare/src/main/kotlin/in/jphe/storyvox/source/bookshare/BookshareConfig.kt
+++ b/source-bookshare/src/main/kotlin/in/jphe/storyvox/source/bookshare/BookshareConfig.kt
@@ -1,18 +1,19 @@
 package `in`.jphe.storyvox.source.bookshare
 
-import javax.inject.Inject
-
 /**
  * Issue #1002 — runtime credentials for the Bookshare API.
  *
  * Bookshare API v2 requires a partner `api_key` on every endpoint (issued by
  * partner-support@bookshare.org) and, for member-scoped endpoints, a per-user
  * OAuth bearer token. Neither is hardcodable — they're partnership / user data
- * — so [BookshareSource] reads them through this seam. The in-memory default
- * ([InMemoryBookshareConfig]) returns null for both, so until a DataStore-backed
- * implementation in :app supplies them, every Bookshare network call
- * short-circuits to `FictionResult.AuthRequired`. Mirrors the
- * `PalaceLibraryConfig` / `GoogleNewsConfig` config seams.
+ * — so [BookshareSource] reads them through this seam.
+ *
+ * The production implementation is `:app`'s `BookshareConfigImpl` (#1471),
+ * `@Provides`-bound over this interface and backed by the encrypted
+ * `storyvox.secrets` bag. Until the partner key is entered in Settings,
+ * [apiKey] returns null and every Bookshare network call short-circuits to
+ * `FictionResult.AuthRequired`. Mirrors the `DiscordConfig` / `NotionConfig`
+ * source-credential seams.
  */
 interface BookshareConfig {
 
@@ -21,14 +22,4 @@ interface BookshareConfig {
 
     /** Per-user OAuth bearer token for member-scoped endpoints, or null. */
     suspend fun accessToken(): String?
-}
-
-/**
- * Default no-credentials binding. Replaced by a DataStore-backed implementation
- * in :app once the Bookshare partnership + settings UI land (tracked on #1002);
- * until then the source stays gated.
- */
-internal class InMemoryBookshareConfig @Inject constructor() : BookshareConfig {
-    override suspend fun apiKey(): String? = null
-    override suspend fun accessToken(): String? = null
 }

--- a/source-bookshare/src/main/kotlin/in/jphe/storyvox/source/bookshare/di/BookshareModule.kt
+++ b/source-bookshare/src/main/kotlin/in/jphe/storyvox/source/bookshare/di/BookshareModule.kt
@@ -1,14 +1,10 @@
 package `in`.jphe.storyvox.source.bookshare.di
 
-import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import `in`.jphe.storyvox.data.network.UserAgentHeader
-import `in`.jphe.storyvox.source.bookshare.BookshareConfig
-import `in`.jphe.storyvox.source.bookshare.BookshareSource
-import `in`.jphe.storyvox.source.bookshare.InMemoryBookshareConfig
 import `in`.jphe.storyvox.source.bookshare.net.BookshareApi
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
@@ -47,18 +43,4 @@ internal object BookshareHttpModule {
     fun provideBookshareApi(
         @BookshareHttp client: OkHttpClient,
     ): BookshareApi = BookshareApi(client)
-}
-
-/**
- * Default credentials binding — the in-memory config returns no api_key, so the
- * source stays gated until a DataStore-backed implementation in :app supplies
- * one (mirrors `:source-palace`'s `PalaceConfigBindings` / #501 pattern).
- */
-@Module
-@InstallIn(SingletonComponent::class)
-internal abstract class BookshareConfigBindings {
-
-    @Binds
-    @Singleton
-    abstract fun bindConfig(impl: InMemoryBookshareConfig): BookshareConfig
 }


### PR DESCRIPTION
## Summary

Stage 2 of the Bookshare partnership (#1462): replace the no-op `InMemoryBookshareConfig` with a **DataStore/secrets-backed `BookshareConfig` in `:app`**, fed from a Settings key field. **Closes #1471 · part of #1462.**

The instant a partner `api_key` is stored, `BookshareApi`'s discovery surface (search / browse / categories) goes live — `BookshareSource` stops short-circuiting those calls to `AuthRequired`. **When the key is blank/absent, behaviour is byte-identical to today** (fully gated). Content download stays gated on the partner agreement (Stage 3) regardless of the key.

This is wiring that lies **dormant until Benetech issues a key** (Stage 1, tracked on #1462).

## What changed

**Backend (commit 1)**
- New `BookshareConfigImpl` (`:app`) — reads the partner `api_key` from the encrypted `storyvox.secrets` bag (`pref_source_bookshare_api_key`), so it rides the same AES-GCM-at-rest + backup-exclusion as every other secret. `apiKey()` returns null when blank; `accessToken()` stays null (per-user OAuth2 is Stage 2b, out of scope).
- **Removed `:source-bookshare`'s default `InMemoryBookshareConfig` `@IntoMap` binding** (deleted the class + `BookshareConfigBindings`). `:app` is now the sole `BookshareConfig` provider — same shape as Discord / Notion / mempalace, which bind no source-side default. Two bindings would be a **Hilt duplicate at `:app`**.
- `AppBindings.provideBookshareConfig` binds impl → interface.
- `SettingsRepositoryUi.setBookshareApiKey(key)` — declared with a **`= Unit` default** so the ~8 fake/test implementors need no update (the interface-method fake trap). `SettingsRepositoryUiImpl` delegates to `BookshareConfigImpl` and bumps the shared secrets tick so `bookshareKeyConfigured` re-emits.
- `UiSettings.bookshareKeyConfigured` — boolean projection; the key itself is never surfaced.
- `BookshareConfigImplTest` locks the blank→null gating contract.

**UI (commit 2)**
- `BookshareSettingsScreen` + self-contained masked-key `Section` (Save / Clear / `StatusPill`), reached from a Settings-hub row next to Memory Palace. Key is **write-only** from the UI (mirrors the AI BYOK posture — never read back into the field).

## Design notes / deviations (flagged for review)

- **Impl named `BookshareConfigImpl`** (not the brief's `DataStoreBookshareConfig`) to match the established `*ConfigImpl` convention (`PalaceConfigImpl`, `NotionConfigImpl`, …). It's secrets-backed, not DataStore-backed, since Bookshare has no non-secret config fields.
- **Closest analog is Discord/Notion, not Palace/GoogleNews**: `PalaceLibraryConfig` is still in-memory (not a real DataStore seam), and GoogleNewsConfig is a plain opt-in, not a secret. Discord/Notion (source token in encrypted prefs, `:app` impl, provided over the interface, no source default) is the exact structural twin — that's what this mirrors.
- **`bookshareConfig` is a nullable-default param on `SettingsRepositoryUiImpl`'s primary ctor** so the 16 existing (named-arg) test harnesses need no edit; production's `@Inject` ctor always supplies the real impl.
- **Hub-row placement**: put next to Memory Palace as a source-credential subscreen. Happy to relocate (e.g. under Plugin Manager) if preferred.

## Verification (CI is the gate — no local gradle)

- `BookshareConfigImplTest`: blank/trimmed/null/round-trip gating.
- **`:app` Hilt graph** is the real check — exactly one `BookshareConfig` binding now (`:app`), source default removed. Test Compile covers the new interface default + `UiSettings` field.

## Not in scope (per #1471)

OAuth2 per-user flow (Stage 2b) · Protected-DAISY download unlock (Stage 3) · any UI beyond the key field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
