### PR TITLE
refactor(intents): consolidate storyvox.open_reader.* extras into ReaderIntentContract (#1478)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -32,6 +32,7 @@ import `in`.jphe.storyvox.R
 import `in`.jphe.storyvox.auth.AuthWebViewScreen
 import `in`.jphe.storyvox.auth.anthropic.AnthropicTeamsSignInScreen
 import `in`.jphe.storyvox.auth.github.GitHubSignInScreen
+import `in`.jphe.storyvox.data.intent.ReaderIntentContract
 import `in`.jphe.storyvox.data.share.FictionShareLink
 import `in`.jphe.storyvox.data.source.SourceIds
 import `in`.jphe.storyvox.source.github.auth.GitHubAuthConfig
@@ -1632,22 +1633,14 @@ private fun StoryvoxNavHostContent(
 object DeepLinkResolver {
     private val FICTION_PATH = Regex("^/fiction/(\\d+)(/.*)?$")
 
-    /** Extras the playback notification's tap intent carries — see
-     *  [in.jphe.storyvox.playback.StoryvoxPlaybackService] session activity. */
-    const val EXTRA_OPEN_READER_FICTION_ID = "storyvox.open_reader.fiction_id"
-    const val EXTRA_OPEN_READER_CHAPTER_ID = "storyvox.open_reader.chapter_id"
-
-    /**
-     * Issue #1455 — set only by the new-chapter notification
-     * ([in.jphe.storyvox.data.work.NewChapterNotifier]), which deep-links a
-     * brand-new chapter the PlaybackController has never loaded. Signals
-     * MainActivity to `startListening` that chapter before navigating; the
-     * playback notification and now-playing widget carry the ids above but
-     * point at the already-playing chapter, so they omit this flag and stay
-     * navigate-only. Kept in sync by string with the mirror in
-     * NewChapterNotifier.
-     */
-    const val EXTRA_OPEN_READER_PRELOAD = "storyvox.open_reader.preload"
+    // Issue #1478 — the open_reader.* extra keys now live in the shared
+    // [ReaderIntentContract] (:core-data), so the emit sides (new-chapter
+    // notification, playback service, now-playing widget) and this read side
+    // reference one declaration and can no longer drift. EXTRA_PRELOAD is set
+    // only by NewChapterNotifier (#1455): it deep-links a brand-new chapter the
+    // PlaybackController has never loaded, so MainActivity must startListening
+    // it before navigating. The playback notification and now-playing widget
+    // point at the already-playing chapter and omit the flag (navigate-only).
 
     /** Issue #472 — query-string carried on the Library route when a
      *  shared URL needs to land in the Magic-add sheet. The Library
@@ -1699,10 +1692,10 @@ object DeepLinkResolver {
         // these extras: the playback notification and now-playing widget
         // (the currently-playing chapter) and the new-chapter notification
         // (#1455, a brand-new chapter — which additionally sets
-        // EXTRA_OPEN_READER_PRELOAD so MainActivity loads it first; see
+        // ReaderIntentContract.EXTRA_PRELOAD so MainActivity loads it first; see
         // [readerPreload]).
-        val rf = intent.getStringExtra(EXTRA_OPEN_READER_FICTION_ID)
-        val rc = intent.getStringExtra(EXTRA_OPEN_READER_CHAPTER_ID)
+        val rf = intent.getStringExtra(ReaderIntentContract.EXTRA_FICTION_ID)
+        val rc = intent.getStringExtra(ReaderIntentContract.EXTRA_CHAPTER_ID)
         if (!rf.isNullOrBlank() && !rc.isNullOrBlank()) {
             return StoryvoxRoutes.reader(rf, rc)
         }
@@ -1777,9 +1770,9 @@ object DeepLinkResolver {
      *  extraction isn't unit-testable without Robolectric, so MainActivity
      *  calls this glue and the pure decision above carries the logic. */
     fun readerPreload(intent: Intent): ReaderPreload? = shouldPreloadReader(
-        fictionId = intent.getStringExtra(EXTRA_OPEN_READER_FICTION_ID),
-        chapterId = intent.getStringExtra(EXTRA_OPEN_READER_CHAPTER_ID),
-        preloadRequested = intent.getBooleanExtra(EXTRA_OPEN_READER_PRELOAD, false),
+        fictionId = intent.getStringExtra(ReaderIntentContract.EXTRA_FICTION_ID),
+        chapterId = intent.getStringExtra(ReaderIntentContract.EXTRA_CHAPTER_ID),
+        preloadRequested = intent.getBooleanExtra(ReaderIntentContract.EXTRA_PRELOAD, false),
     )
 
     /** Lightweight URL sniffer — accepts http(s) URLs only. Apps that

--- a/app/src/main/kotlin/in/jphe/storyvox/widget/NowPlayingWidgetProvider.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/widget/NowPlayingWidgetProvider.kt
@@ -40,7 +40,7 @@ import kotlinx.coroutines.launch
  *     [WidgetEntryPoint] lookup and invokes the same methods that the
  *     in-app transport row uses — no service-side duplication.
  *  3. Tapping the cover routes through a [PendingIntent.getActivity]
- *     into MainActivity with the same `EXTRA_OPEN_READER_*` extras the
+ *     into MainActivity with the same `ReaderIntentContract` extras the
  *     notification carries (see DeepLinkResolver in navigation/), so
  *     the user lands on the audiobook screen for the playing chapter.
  *

--- a/app/src/main/kotlin/in/jphe/storyvox/widget/NowPlayingWidgetRenderer.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/widget/NowPlayingWidgetRenderer.kt
@@ -12,6 +12,7 @@ import android.view.View
 import android.widget.RemoteViews
 import androidx.annotation.LayoutRes
 import `in`.jphe.storyvox.R
+import `in`.jphe.storyvox.data.intent.ReaderIntentContract
 
 /**
  * Issue #159 — pure-functional RemoteViews builder. Given the current
@@ -215,8 +216,8 @@ internal object NowPlayingWidgetRenderer {
             flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
         }
         if (!snapshot.isIdle) {
-            intent.putExtra(EXTRA_OPEN_READER_FICTION_ID, snapshot.fictionId)
-            intent.putExtra(EXTRA_OPEN_READER_CHAPTER_ID, snapshot.chapterId)
+            intent.putExtra(ReaderIntentContract.EXTRA_FICTION_ID, snapshot.fictionId)
+            intent.putExtra(ReaderIntentContract.EXTRA_CHAPTER_ID, snapshot.chapterId)
         }
         return intent
     }
@@ -262,12 +263,6 @@ internal object NowPlayingWidgetRenderer {
     }
 
     private const val MAIN_ACTIVITY_FQN = "in.jphe.storyvox.MainActivity"
-
-    // Keep these in lockstep with DeepLinkResolver.EXTRA_OPEN_READER_*.
-    // We literal-string them here so :app's widget module doesn't take
-    // a hard dep on the navigation package, but the values must match.
-    private const val EXTRA_OPEN_READER_FICTION_ID = "storyvox.open_reader.fiction_id"
-    private const val EXTRA_OPEN_READER_CHAPTER_ID = "storyvox.open_reader.chapter_id"
 
     // Distinct request codes per PendingIntent so the system caches
     // them separately. Without unique codes, PendingIntent.getBroadcast

--- a/app/src/test/kotlin/in/jphe/storyvox/navigation/ReaderPreloadResolverTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/navigation/ReaderPreloadResolverTest.kt
@@ -8,10 +8,10 @@ import org.junit.Test
  * Issue #1455 — the deep-link handler must LOAD a brand-new chapter into the
  * PlaybackController before opening the reader (the reader is a passive view
  * of the controller; navigating alone hangs it on "loading chapter"). Three
- * emitters share the `storyvox.open_reader.*` extras — the playback
+ * emitters share the `ReaderIntentContract` extras — the playback
  * notification and now-playing widget (already-playing chapter → navigate
  * only) and the new-chapter notification (brand-new chapter → preload). The
- * discriminator is [DeepLinkResolver.EXTRA_OPEN_READER_PRELOAD]; the pure
+ * discriminator is `ReaderIntentContract.EXTRA_PRELOAD`; the pure
  * decision below is what MainActivity keys on.
  *
  * Pure (no Android types), so it runs as a plain JUnit test — no Robolectric,

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/intent/ReaderIntentContract.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/intent/ReaderIntentContract.kt
@@ -1,0 +1,44 @@
+package `in`.jphe.storyvox.data.intent
+
+/**
+ * Issue #1478 — the single source of truth for the `storyvox.open_reader.*`
+ * intent-extra keys that deep-link the reader.
+ *
+ * Four sites build or read these extras and used to hand-mirror the literals,
+ * each guarded only by a "kept in sync by string" comment:
+ *  - `NewChapterNotifier` (`:core-data`) — new-chapter notification tap; the
+ *    only emitter that sets [EXTRA_PRELOAD] (#1455).
+ *  - `StoryvoxPlaybackService` (`:core-playback`) — playback-notification /
+ *    lock-screen tap.
+ *  - `NowPlayingWidgetRenderer` (`:app`) — now-playing home-screen widget tap.
+ *  - `DeepLinkResolver` (`:app`) — the read side that decodes the extras into a
+ *    reader route.
+ *
+ * These strings are baked into `PendingIntent`s already sitting in users'
+ * notification shades and home-screen widgets, so the VALUES are a
+ * backward-compatibility contract: **never change a literal below.** A drifted
+ * key is a silently-broken deep link — exactly the class of bug #1455 fixed.
+ * Consolidating the declarations here lets the compiler enforce the sync the
+ * comments used to ask humans for; `ReaderIntentContractTest` additionally
+ * locks each value byte-for-byte against a future rename.
+ *
+ * Lives in `:core-data` — the lowest module all four sites already depend on —
+ * and holds only `String` constants (no `android.content.Intent` coupling), so
+ * it unit-tests without Robolectric, mirroring [`in`.jphe.storyvox.data.share.FictionShareLink].
+ */
+object ReaderIntentContract {
+    /** String fiction id the tap should open. Value frozen — see class doc. */
+    const val EXTRA_FICTION_ID: String = "storyvox.open_reader.fiction_id"
+
+    /** String chapter id the tap should open. Value frozen — see class doc. */
+    const val EXTRA_CHAPTER_ID: String = "storyvox.open_reader.chapter_id"
+
+    /**
+     * Boolean flag (#1455) set only by the new-chapter notification: the target
+     * chapter has never been loaded, so `MainActivity` must `startListening` it
+     * before navigating (the reader is a passive view of the PlaybackController).
+     * The playback notification and now-playing widget point at the
+     * already-playing chapter and omit this flag. Value frozen — see class doc.
+     */
+    const val EXTRA_PRELOAD: String = "storyvox.open_reader.preload"
+}

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/work/NewChapterNotifier.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/work/NewChapterNotifier.kt
@@ -11,6 +11,7 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import dagger.hilt.android.qualifiers.ApplicationContext
 import `in`.jphe.storyvox.data.R
+import `in`.jphe.storyvox.data.intent.ReaderIntentContract
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -20,8 +21,8 @@ import javax.inject.Singleton
  *
  * Lives in `:core-data` next to the worker that calls it. To deep-link the
  * tap into the reader without depending on `:app`, the content intent targets
- * [MAIN_ACTIVITY] by fully-qualified name and carries the same
- * `storyvox.open_reader.*` extras that
+ * [MAIN_ACTIVITY] by fully-qualified name and carries the shared
+ * [ReaderIntentContract] extras that
  * [`in`.jphe.storyvox.navigation.DeepLinkResolver] already decodes for the
  * playback notification — so the existing nav plumbing routes the tap to the
  * first new chapter.
@@ -31,7 +32,7 @@ import javax.inject.Singleton
  * deep-links a brand-new chapter the controller has never loaded. The reader
  * is a passive view of the controller, so navigating alone would leave it
  * stuck on "loading chapter" (until the 30s timeout). We therefore also set
- * [EXTRA_OPEN_READER_PRELOAD]; MainActivity keys on it to `startListening`
+ * [ReaderIntentContract.EXTRA_PRELOAD]; MainActivity keys on it to `startListening`
  * the chapter before navigating, mirroring the inbox (#1343) and history
  * (#1350) navigate-without-load fixes. The playback notification / widget
  * omit the flag, so their tap stays navigate-only (a preload there would
@@ -109,14 +110,14 @@ class NewChapterNotifier @Inject constructor(
         val launchIntent = Intent().apply {
             component = ComponentName(context.packageName, MAIN_ACTIVITY)
             flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
-            putExtra(EXTRA_OPEN_READER_FICTION_ID, fictionId)
-            putExtra(EXTRA_OPEN_READER_CHAPTER_ID, chapterId)
+            putExtra(ReaderIntentContract.EXTRA_FICTION_ID, fictionId)
+            putExtra(ReaderIntentContract.EXTRA_CHAPTER_ID, chapterId)
             // Issue #1455 — load this (brand-new, never-played) chapter into
             // the PlaybackController before navigating; without it the passive
             // reader hangs on "loading chapter". The playback notification and
             // now-playing widget omit this flag (their chapter is already the
             // one playing).
-            putExtra(EXTRA_OPEN_READER_PRELOAD, true)
+            putExtra(ReaderIntentContract.EXTRA_PRELOAD, true)
         }
         // FLAG_UPDATE_CURRENT so the per-fiction extras overwrite a prior
         // intent for the same request code (PendingIntent equality ignores
@@ -130,9 +131,5 @@ class NewChapterNotifier @Inject constructor(
         const val CHANNEL_NEW_CHAPTERS = "new_chapters"
         private const val GROUP_NEW_CHAPTERS = "in.jphe.storyvox.NEW_CHAPTERS"
         private const val MAIN_ACTIVITY = "in.jphe.storyvox.MainActivity"
-        // Mirror DeepLinkResolver.EXTRA_OPEN_READER_* — kept in sync by string.
-        private const val EXTRA_OPEN_READER_FICTION_ID = "storyvox.open_reader.fiction_id"
-        private const val EXTRA_OPEN_READER_CHAPTER_ID = "storyvox.open_reader.chapter_id"
-        private const val EXTRA_OPEN_READER_PRELOAD = "storyvox.open_reader.preload"
     }
 }

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/intent/ReaderIntentContractTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/intent/ReaderIntentContractTest.kt
@@ -1,0 +1,43 @@
+package `in`.jphe.storyvox.data.intent
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Issue #1478 — locks the `storyvox.open_reader.*` extra keys byte-for-byte.
+ *
+ * These strings live inside `PendingIntent`s already delivered to users'
+ * notification shades and home-screen widgets. Consolidating the four
+ * hand-mirrored copies into [ReaderIntentContract] made the compiler enforce
+ * that the emit and read sides agree — but the compiler is happy with ANY
+ * shared value, so a well-meaning "cleanup" rename would still break every
+ * live deep link. This test freezes the literals against that: if you must
+ * change a value here, you are breaking backward compatibility on purpose.
+ */
+class ReaderIntentContractTest {
+
+    @Test
+    fun fictionIdKey_isFrozen() {
+        assertEquals("storyvox.open_reader.fiction_id", ReaderIntentContract.EXTRA_FICTION_ID)
+    }
+
+    @Test
+    fun chapterIdKey_isFrozen() {
+        assertEquals("storyvox.open_reader.chapter_id", ReaderIntentContract.EXTRA_CHAPTER_ID)
+    }
+
+    @Test
+    fun preloadKey_isFrozen() {
+        assertEquals("storyvox.open_reader.preload", ReaderIntentContract.EXTRA_PRELOAD)
+    }
+
+    @Test
+    fun keysAreDistinct() {
+        val keys = setOf(
+            ReaderIntentContract.EXTRA_FICTION_ID,
+            ReaderIntentContract.EXTRA_CHAPTER_ID,
+            ReaderIntentContract.EXTRA_PRELOAD,
+        )
+        assertEquals(3, keys.size)
+    }
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/StoryvoxPlaybackService.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/StoryvoxPlaybackService.kt
@@ -27,6 +27,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.IntentFilter
 import dagger.hilt.android.AndroidEntryPoint
+import `in`.jphe.storyvox.data.intent.ReaderIntentContract
 import `in`.jphe.storyvox.data.repository.playback.BedtimeSleepConfig
 import `in`.jphe.storyvox.data.repository.playback.SleepTimerExtendConfig
 import `in`.jphe.storyvox.playback.diagnostics.AudioOutputMonitor
@@ -278,8 +279,8 @@ class StoryvoxPlaybackService : MediaSessionService() {
             component = ComponentName(packageName, MAIN_ACTIVITY)
             flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
             if (!fictionId.isNullOrBlank() && !chapterId.isNullOrBlank()) {
-                putExtra(EXTRA_OPEN_READER_FICTION_ID, fictionId)
-                putExtra(EXTRA_OPEN_READER_CHAPTER_ID, chapterId)
+                putExtra(ReaderIntentContract.EXTRA_FICTION_ID, fictionId)
+                putExtra(ReaderIntentContract.EXTRA_CHAPTER_ID, chapterId)
             }
         }
         // FLAG_UPDATE_CURRENT so the new fictionId/chapterId actually overwrite
@@ -460,9 +461,6 @@ class StoryvoxPlaybackService : MediaSessionService() {
         /** FQN of the launcher Activity. Hardcoded so :core-playback doesn't
          *  need a dependency on :app. Mirrors the manifest entry. */
         private const val MAIN_ACTIVITY = "in.jphe.storyvox.MainActivity"
-        /** Mirrors [in.jphe.storyvox.navigation.DeepLinkResolver.EXTRA_OPEN_READER_FICTION_ID]. */
-        private const val EXTRA_OPEN_READER_FICTION_ID = "storyvox.open_reader.fiction_id"
-        private const val EXTRA_OPEN_READER_CHAPTER_ID = "storyvox.open_reader.chapter_id"
         /** Issue #150 — duration of the sleep timer's fade tail. The
          *  shake-to-extend listener only runs when remainingMs is in
          *  this window, matching SleepTimer.FADE_TAIL_MS. Fixed


### PR DESCRIPTION
## What

Consolidates the hand-mirrored `storyvox.open_reader.*` intent-extra string
literals — previously duplicated across four sites, each guarded only by a
"kept in sync by string" comment — into one compiler-enforced shared contract.

New: **`ReaderIntentContract`** in `:core-data` (`in.jphe.storyvox.data.intent`)
— the lowest module all four sites already depend on (no new inter-module
dependencies added). Follows the existing `FictionShareLink` idiom: a plain
`object` of `String` constants, unit-testable without Robolectric.

## The three keys (values unchanged — byte-identical)

| constant | value |
| --- | --- |
| `EXTRA_FICTION_ID` | `storyvox.open_reader.fiction_id` |
| `EXTRA_CHAPTER_ID` | `storyvox.open_reader.chapter_id` |
| `EXTRA_PRELOAD` | `storyvox.open_reader.preload` |

**These strings live inside `PendingIntent`s already delivered to users'
notification shades and home-screen widgets**, so the VALUES are a
backward-compatibility contract. This PR consolidates *declarations only* — every
literal was diff-checked character-for-character. `ReaderIntentContractTest`
locks each value byte-for-byte so a future "cleanup" rename can't silently break
every live deep link (the class of bug #1455 fixed).

## Sites migrated

- `NewChapterNotifier` (`:core-data`) — emitter (sets `EXTRA_PRELOAD`, #1455)
- `StoryvoxPlaybackService` (`:core-playback`) — emitter
- `NowPlayingWidgetRenderer` (`:app`) — emitter
- `DeepLinkResolver` (`:app`, in `StoryvoxNavHost.kt`) — read side

Deleted all four local `const val` declarations + their "kept in sync by string"
comments. Verified no external code referenced `DeepLinkResolver.EXTRA_OPEN_READER_*`
(only KDoc/prose, which were updated).

## Note on the issue's "five extras" wording

The issue says #1477 "added a fifth extra." In the tree there are **three
distinct `storyvox.open_reader.*` keys** (fiction_id, chapter_id, preload),
hand-mirrored across the four sites (≈10 declaration lines total). The
consolidation covers all three distinct keys and every mirror site.

## Verification

- Final grep: zero `storyvox.open_reader` literals remain outside the contract
  object + its test; zero `EXTRA_OPEN_READER_*` symbols remain anywhere.
- Every added import is used; net −17 lines.
- Not built locally (per project rules) — CI `Build APK` + `Test Compile` are the gate.

Closes #1478.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Standardized reader deep-link handling across notifications, playback, and the now-playing widget.
  * Added a shared set of reader intent extras to keep link routing consistent.

* **Bug Fixes**
  * Improved preload handling so reader screens open with the correct behavior depending on the entry point.
  * Clarified widget and notification tap behavior to avoid unintended audio interruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->