### PR TITLE
feat(browse): wire chipLabel/searchHint from @SourcePlugin descriptors (#1400 step 4)

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -1102,9 +1102,10 @@ private fun ReadabilityHintState() {
 @Composable
 private fun SearchHint(sourceId: String, visibleSources: List<SourcePluginDescriptor>) {
     val spacing = LocalSpacing.current
-    val displayName = remember(sourceId, visibleSources) {
-        visibleSources.firstOrNull { it.id == sourceId }?.displayName ?: sourceId
+    val descriptor = remember(sourceId, visibleSources) {
+        visibleSources.firstOrNull { it.id == sourceId }
     }
+    val displayName = descriptor?.displayName ?: sourceId
     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
@@ -1121,11 +1122,12 @@ private fun SearchHint(sourceId: String, visibleSources: List<SourcePluginDescri
                 style = MaterialTheme.typography.titleMedium,
                 color = MaterialTheme.colorScheme.onSurface,
             )
-            // Issue #271 — per-source empty-state subtitle. Phase 3
-            // (#384) — the per-source phrase lookup goes through the
-            // `BrowseSourceUi` side-table keyed by stable plugin id.
+            // Issue #271 — per-source empty-state subtitle. #1482 — the
+            // phrase now rides the `@SourcePlugin` descriptor
+            // (`searchHint`); `BrowseSourceUi` just falls back to
+            // "Search <displayName>" when a plugin didn't declare one.
             Text(
-                BrowseSourceUi.searchHint(sourceId, displayName),
+                BrowseSourceUi.searchHint(descriptor?.searchHint.orEmpty(), displayName),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseSourceCarousel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseSourceCarousel.kt
@@ -298,7 +298,7 @@ private fun BrowseSourceCard(
         label = "browse-source-card-label",
     )
 
-    val label = BrowseSourceUi.chipLabel(descriptor.id, descriptor.displayName)
+    val label = BrowseSourceUi.chipLabel(descriptor.chipLabel, descriptor.displayName)
     val tagline = sourceTagline(descriptor.id)
     val glyph = sourceGlyph(descriptor.id)
     // Soft brass-tinted gradient on the selected card. Pulls the active
@@ -473,7 +473,7 @@ private fun SourceContextSheet(
     val scope = rememberCoroutineScope()
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
-    val label = BrowseSourceUi.chipLabel(descriptor.id, descriptor.displayName)
+    val label = BrowseSourceUi.chipLabel(descriptor.chipLabel, descriptor.displayName)
     val tagline = sourceTagline(descriptor.id)
     val glyph = sourceGlyph(descriptor.id)
 

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseSourceUi.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseSourceUi.kt
@@ -3,67 +3,47 @@ package `in`.jphe.storyvox.feature.browse
 import `in`.jphe.storyvox.data.source.SourceIds
 
 /**
- * Plugin-seam Phase 3 (#384) — side-table of per-source UI hints
- * keyed by sourceId. Lives in `:feature/browse` because the data here
- * is purely UI-shaped: chip strip labels, supported-tabs lists, filter
- * sheet variants, search-hint copy.
+ * Plugin-seam Phase 3 (#384) — side-table of per-source UI hints that
+ * are genuinely Compose-shaped. Lives in `:feature/browse` because
+ * these bits can't live on the `SourcePluginDescriptor` (which sits in
+ * `:core-data` and shouldn't know about `BrowseTab` or filter shapes).
  *
  * The Phase 1/2 `BrowseSourceKey` enum carried this data inline on
- * each enum entry. Phase 3 deletes the enum in favour of iterating
- * `SourcePluginRegistry.descriptors`, but the per-source UI bits don't
- * belong on the `SourcePluginDescriptor` (which lives in `:core-data`
- * and shouldn't know about Compose tabs or filter shapes).
+ * each enum entry. Phase 3 deleted the enum in favour of iterating
+ * `SourcePluginRegistry.descriptors`.
  *
- * The table is keyed by the `SourceIds` string constants. A future
- * out-of-tree backend that adds a new `SourceIds.X` constant must also
- * add its row here (or rely on the defaults — short label = registry
- * display name, supported tabs = Popular + Search).
- *
- * Adding a row is a single-file diff next to the source's
- * `@SourcePlugin` annotation backfill — far less invasive than the
- * Phase 1/2 17-touchpoint shape.
+ * #1482 — chip labels and search-empty-state hints, which *are*
+ * plain-string UI copy, moved onto the `@SourcePlugin` descriptor
+ * ([chipLabel] / [searchHint] now just prefer the descriptor field and
+ * fall back to `displayName`). What remains keyed by `SourceIds` here
+ * is [supportedTabs] — the one hint whose shape (`List<BrowseTab>`,
+ * auth gating) can't be expressed on a `:core-data` descriptor. A
+ * future out-of-tree backend gets its chip label / search hint from
+ * its own annotation for free, and only needs a [supportedTabs] row if
+ * it wants more than the default Popular + Search.
  */
 internal object BrowseSourceUi {
 
     /**
-     * Short label for the browse chip strip. The registry's
+     * Short label for the browse chip strip. Prefers the source's
+     * `@SourcePlugin(chipLabel = …)` — carried on the descriptor and
+     * passed in as [descriptorChipLabel] — because the registry's
      * `displayName` is the formal "Archive of Our Own" / "Local EPUB
-     * files" form, which doesn't fit on a chip on a narrow phone.
-     * Falls through to the descriptor's `displayName` when no override
-     * is present.
+     * files" form, which doesn't fit on a chip on a narrow phone. Falls
+     * back to [displayName] when the plugin didn't declare a chip label.
+     *
+     * #1482 — replaces the per-source `when`-branch (deferred step 4 of
+     * #1400). The concise labels now live on each source's
+     * `@SourcePlugin` annotation and ride the descriptor, so an
+     * out-of-tree backend can declare its own chip label without a
+     * `:feature` edit. Notable in-tree overrides that used to live in
+     * the branch: "Memory Palace" → "Palace" (#148, avoids a two-line
+     * chip), "Local EPUB files" → "Local" / "Local PDF files" → "PDFs"
+     * (#996, keeps the two local-file backends separable), and
+     * "GitHub fiction" → "GitHub".
      */
-    fun chipLabel(id: String, displayName: String): String = when (id) {
-        SourceIds.ROYAL_ROAD -> "Royal Road"
-        SourceIds.GITHUB -> "GitHub"
-        // "Palace" instead of "Memory Palace" so the segmented source
-        // picker doesn't break the chip label across two lines on
-        // narrow phones (#148).
-        SourceIds.MEMPALACE -> "Palace"
-        SourceIds.RSS -> "RSS"
-        SourceIds.EPUB -> "Local"
-        // #996 — PDF sits next to EPUB ("Local"); a distinct "PDFs" chip
-        // keeps the two local-file backends visually separable.
-        SourceIds.PDF -> "PDFs"
-        SourceIds.OUTLINE -> "Wiki"
-        SourceIds.GUTENBERG -> "Gutenberg"
-        SourceIds.AO3 -> "AO3"
-        SourceIds.STANDARD_EBOOKS -> "Standard Ebooks"
-        SourceIds.WIKIPEDIA -> "Wikipedia"
-        SourceIds.WIKISOURCE -> "Wikisource"
-        // Issue #417 — :source-kvmr → :source-radio. The new canonical
-        // chip says "Radio"; the legacy KVMR id is kept as an alias so
-        // any code path still resolving through it stays consistent.
-        SourceIds.RADIO -> "Radio"
-        SourceIds.KVMR -> "Radio"
-        SourceIds.NOTION_TECHEMPOWER -> "TechEmpower"
-        SourceIds.NOTION_PAT -> "Notion"
-        SourceIds.HACKERNEWS -> "Hacker News"
-        SourceIds.GOOGLE_NEWS -> "Google News"
-        SourceIds.ARXIV -> "arXiv"
-        SourceIds.PLOS -> "PLOS"
-        SourceIds.DISCORD -> "Discord"
-        else -> displayName
-    }
+    fun chipLabel(descriptorChipLabel: String, displayName: String): String =
+        descriptorChipLabel.ifBlank { displayName }
 
     /**
      * Tabs meaningful for [id]. [githubSignedIn] gates the auth-only
@@ -172,31 +152,17 @@ internal object BrowseSourceUi {
         else -> listOf(BrowseTab.Popular, BrowseTab.Search)
     }
 
-    /** Issue #271 — per-source subtitle for the Search empty state. */
-    fun searchHint(id: String, displayName: String): String = when (id) {
-        SourceIds.ROYAL_ROAD -> "Find fictions across Royal Road"
-        SourceIds.GITHUB -> "Search indexed GitHub repositories"
-        SourceIds.MEMPALACE -> "Search your MemPalace knowledge base"
-        SourceIds.RSS -> "Search your subscribed feeds"
-        SourceIds.EPUB -> "Search your local EPUB library"
-        SourceIds.PDF -> "Search your local PDF library"
-        SourceIds.OUTLINE -> "Search your Outline notes"
-        SourceIds.GUTENBERG -> "Search Project Gutenberg's 70,000+ public-domain books"
-        SourceIds.AO3 -> "Search AO3 by tag, fandom, or character"
-        SourceIds.STANDARD_EBOOKS -> "Search Standard Ebooks' hand-curated public-domain classics"
-        SourceIds.WIKIPEDIA -> "Search Wikipedia — narrate any article"
-        SourceIds.WIKISOURCE -> "Search Wikisource — transcribed public-domain texts"
-        // Issue #417 — Radio search drives the Radio Browser API.
-        SourceIds.RADIO -> "Search Radio Browser — community, public, and college stations worldwide"
-        SourceIds.KVMR -> "Tune in to KVMR — live community radio from Nevada City"
-        SourceIds.NOTION_TECHEMPOWER -> "Search TechEmpower guides & resources"
-        SourceIds.NOTION_PAT -> "Search your configured Notion database"
-        SourceIds.HACKERNEWS -> "Search Hacker News stories (Algolia-backed full-text)"
-        SourceIds.GOOGLE_NEWS -> "Search Google News — top stories, topics & more"
-        SourceIds.ARXIV -> "Search arXiv — open-access academic papers"
-        SourceIds.PLOS -> "Search PLOS — open-access peer-reviewed science"
-        SourceIds.DISCORD -> "Search messages in your selected Discord server"
-        else -> "Search $displayName"
-    }
+    /**
+     * Issue #271 — per-source subtitle for the Search empty state.
+     *
+     * #1482 — sourced from the source's `@SourcePlugin(searchHint = …)`
+     * (carried on `SourcePluginDescriptor.searchHint`) instead of a
+     * per-source `when`-branch (deferred step 4 of #1400). Falls back to
+     * "Search &lt;displayName&gt;" when the plugin didn't declare a
+     * hint — matching the old `else` branch, which is exactly what
+     * `supportsSearch = false` sources (Slack, Telegram) surfaced.
+     */
+    fun searchHint(descriptorSearchHint: String, displayName: String): String =
+        descriptorSearchHint.ifBlank { "Search $displayName" }
 }
 

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/catalog/SourceCatalogCard.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/catalog/SourceCatalogCard.kt
@@ -131,7 +131,7 @@ internal fun SourceCatalogCard(
     val accent = catalogAccent(group)
     val brass = MaterialTheme.colorScheme.primary
 
-    val label = BrowseSourceUi.chipLabel(descriptor.id, descriptor.displayName)
+    val label = BrowseSourceUi.chipLabel(descriptor.chipLabel, descriptor.displayName)
     // Disabled cards hold back the title/icon emphasis so the shelf reads
     // enabled-vs-not at a glance without hiding the source entirely.
     val contentAlpha = if (row.enabled) 1f else 0.55f

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/browse/BrowseSourceUiTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/browse/BrowseSourceUiTest.kt
@@ -8,57 +8,35 @@ import org.junit.Test
 
 /**
  * Plugin-seam Phase 3 (#384) — unit tests for the [BrowseSourceUi]
- * side-table. Verifies the lookup tables return the expected per-
- * source UI hints for all 17 in-tree backends, with sensible defaults
- * for ids the table doesn't know about (out-of-tree plugin posture).
+ * side-table.
+ *
+ * [BrowseSourceUi.supportedTabs] is still keyed by `SourceIds`, so it's
+ * verified per in-tree backend. [BrowseSourceUi.chipLabel] and
+ * [BrowseSourceUi.searchHint] moved their per-source strings onto the
+ * `@SourcePlugin` descriptor in #1482; here they're only the
+ * prefer-descriptor-else-displayName fallback, so those tests pin the
+ * contract rather than enumerate every source.
  */
 class BrowseSourceUiTest {
 
-    @Test fun `chipLabel returns concise label for every in-tree source`() {
-        val expected = mapOf(
-            SourceIds.ROYAL_ROAD to "Royal Road",
-            SourceIds.GITHUB to "GitHub",
-            SourceIds.MEMPALACE to "Palace",
-            SourceIds.RSS to "RSS",
-            SourceIds.EPUB to "Local",
-            SourceIds.OUTLINE to "Wiki",
-            SourceIds.GUTENBERG to "Gutenberg",
-            SourceIds.AO3 to "AO3",
-            SourceIds.STANDARD_EBOOKS to "Standard Ebooks",
-            SourceIds.WIKIPEDIA to "Wikipedia",
-            SourceIds.WIKISOURCE to "Wikisource",
-            // Issue #417 — :source-kvmr → :source-radio. Both ids
-            // resolve to the "Radio" chip during the one-cycle
-            // migration overlap.
-            SourceIds.RADIO to "Radio",
-            SourceIds.KVMR to "Radio",
-            // Issue #770 — split NOTION into TECHEMPOWER + PAT.
-            SourceIds.NOTION_TECHEMPOWER to "TechEmpower",
-            SourceIds.NOTION_PAT to "Notion",
-            SourceIds.HACKERNEWS to "Hacker News",
-            SourceIds.GOOGLE_NEWS to "Google News",
-            SourceIds.ARXIV to "arXiv",
-            SourceIds.PLOS to "PLOS",
-            SourceIds.DISCORD to "Discord",
-        )
+    // #1482 — chip labels moved onto the `@SourcePlugin` descriptor
+    // (`chipLabel`). `BrowseSourceUi.chipLabel` is now the tiny
+    // "prefer the descriptor value, else the formal displayName"
+    // fallback; the per-source strings are asserted by each source's
+    // annotation. These tests pin the fallback contract.
 
-        // 20 = 11 catalog backends + Radio/Kvmr alias +
-        // Notion TechEmpower + Notion PAT + HN + Google News + arXiv +
-        // PLOS + Discord. Slack and Telegram intentionally fall through to
-        // the registry's displayName (chip strip uses the same string as
-        // the Settings → Plugins label).
-        assertEquals(20, expected.size)
-        for ((id, label) in expected) {
-            assertEquals(
-                "Unexpected chip label for $id",
-                label,
-                BrowseSourceUi.chipLabel(id, "fallback"),
-            )
-        }
+    @Test fun `chipLabel prefers the descriptor value over displayName`() {
+        // e.g. AO3's formal displayName is "Archive of Our Own"; the
+        // concise chip label rides @SourcePlugin(chipLabel = "AO3").
+        assertEquals("AO3", BrowseSourceUi.chipLabel("AO3", "Archive of Our Own"))
     }
 
-    @Test fun `chipLabel falls through to displayName for unknown ids`() {
-        assertEquals("Custom Backend", BrowseSourceUi.chipLabel("custom-id", "Custom Backend"))
+    @Test fun `chipLabel falls back to displayName when the descriptor label is blank`() {
+        // Out-of-tree backend that didn't declare a chip label, or an
+        // in-tree source whose chip == its formal name (e.g. "Radio").
+        assertEquals("Custom Backend", BrowseSourceUi.chipLabel("", "Custom Backend"))
+        // Whitespace-only is treated as "unset" too.
+        assertEquals("Custom Backend", BrowseSourceUi.chipLabel("   ", "Custom Backend"))
     }
 
     @Test fun `supportedTabs gives a non-empty list for every in-tree source`() {
@@ -130,30 +108,23 @@ class BrowseSourceUiTest {
         assertEquals(withDefault, withExplicitTrue)
     }
 
-    @Test fun `searchHint returns sensible copy for every in-tree source`() {
-        // Issue #695 — sources that declare `supportsSearch = false`
-        // (Slack, Telegram) never reach the Search tab's empty state,
-        // so a dedicated `searchHint` entry is unreachable copy. The
-        // generic "Search <displayName>" fallback is fine for them.
-        // Every other in-tree source must override.
-        val noSearchSources = setOf(SourceIds.SLACK, SourceIds.TELEGRAM)
-        for (id in IN_TREE_IDS - noSearchSources) {
-            val hint = BrowseSourceUi.searchHint(id, displayName = "FallbackName")
-            assertTrue(
-                "Expected non-empty searchHint for $id (got: '$hint')",
-                hint.isNotBlank(),
-            )
-            // Default `else` branch uses the displayName; in-tree
-            // sources should NOT fall through to that branch.
-            assertFalse(
-                "$id fell through to the default searchHint",
-                hint == "Search FallbackName",
-            )
-        }
+    // #1482 — per-source search-empty-state copy moved onto the
+    // `@SourcePlugin` descriptor (`searchHint`). `BrowseSourceUi.searchHint`
+    // is now the "prefer the descriptor value, else Search <displayName>"
+    // fallback. These tests pin that contract.
+
+    @Test fun `searchHint prefers the descriptor value over the generic fallback`() {
+        assertEquals(
+            "Search AO3 by tag, fandom, or character",
+            BrowseSourceUi.searchHint("Search AO3 by tag, fandom, or character", "Archive of Our Own"),
+        )
     }
 
-    @Test fun `searchHint falls through to displayName for unknown ids`() {
-        assertEquals("Search My Backend", BrowseSourceUi.searchHint("custom-id", "My Backend"))
+    @Test fun `searchHint falls back to Search displayName when the descriptor hint is blank`() {
+        // Matches the old `else` branch — exactly what supportsSearch=false
+        // sources (Slack, Telegram) surface, since they declare no hint.
+        assertEquals("Search My Backend", BrowseSourceUi.searchHint("", "My Backend"))
+        assertEquals("Search My Backend", BrowseSourceUi.searchHint("   ", "My Backend"))
     }
 
     private companion object {

--- a/source-ao3/src/main/kotlin/in/jphe/storyvox/source/ao3/Ao3Source.kt
+++ b/source-ao3/src/main/kotlin/in/jphe/storyvox/source/ao3/Ao3Source.kt
@@ -97,6 +97,9 @@ import javax.inject.Singleton
     supportsSearch = true,
     description = "14M+ fanfiction works via per-tag Atom feeds + official EPUB downloads",
     sourceUrl = "https://archiveofourown.org",
+    // #1482 — "AO3" chip vs. the formal "Archive of Our Own" displayName.
+    chipLabel = "AO3",
+    searchHint = "Search AO3 by tag, fandom, or character",
 )
 @Singleton
 internal class Ao3Source @Inject constructor(

--- a/source-arxiv/src/main/kotlin/in/jphe/storyvox/source/arxiv/ArxivSource.kt
+++ b/source-arxiv/src/main/kotlin/in/jphe/storyvox/source/arxiv/ArxivSource.kt
@@ -74,6 +74,8 @@ import javax.inject.Singleton
     supportsSearch = true,
     description = "Open-access academic papers · abstract + author byline as single-chapter fictions · default cs.AI",
     sourceUrl = "https://arxiv.org",
+    // #1482 — chipLabel omitted: "arXiv" chip == displayName.
+    searchHint = "Search arXiv — open-access academic papers",
 )
 @Singleton
 internal class ArxivSource @Inject constructor(

--- a/source-discord/src/main/kotlin/in/jphe/storyvox/source/discord/DiscordSource.kt
+++ b/source-discord/src/main/kotlin/in/jphe/storyvox/source/discord/DiscordSource.kt
@@ -67,6 +67,8 @@ import javax.inject.Singleton
     supportsSearch = true,
     description = "Bot-token-authed channel reader · server = filter, channel = fiction, message = chapter (with same-author coalescing)",
     sourceUrl = "https://discord.com",
+    // #1482 — chipLabel omitted: "Discord" chip == displayName.
+    searchHint = "Search messages in your selected Discord server",
 )
 @Singleton
 internal class DiscordSource @Inject constructor(

--- a/source-epub/src/main/kotlin/in/jphe/storyvox/source/epub/EpubSource.kt
+++ b/source-epub/src/main/kotlin/in/jphe/storyvox/source/epub/EpubSource.kt
@@ -50,6 +50,10 @@ import javax.inject.Singleton
     supportsSearch = false,
     description = "Read .epub files from a folder you pick · zero-network",
     sourceUrl = "",
+    // #1482 — "Local" chip vs. the formal "Local EPUB files" displayName
+    // (#996 keeps it separable from the PDF "PDFs" chip).
+    chipLabel = "Local",
+    searchHint = "Search your local EPUB library",
 )
 @Singleton
 internal class EpubSource @Inject constructor(

--- a/source-github/src/main/kotlin/in/jphe/storyvox/source/github/GitHubSource.kt
+++ b/source-github/src/main/kotlin/in/jphe/storyvox/source/github/GitHubSource.kt
@@ -75,6 +75,10 @@ import kotlin.time.toDuration
     supportsSearch = true,
     description = "Repo READMEs as fictions · OAuth Device Flow unlocks 5000/hr + private repos",
     sourceUrl = "https://github.com",
+    // #1482 — Browse UI copy carried on the descriptor; "GitHub" chip
+    // vs. the formal "GitHub fiction" displayName.
+    chipLabel = "GitHub",
+    searchHint = "Search indexed GitHub repositories",
 )
 @Singleton
 internal class GitHubSource @Inject constructor(

--- a/source-google-news/src/main/kotlin/in/jphe/storyvox/source/googlenews/GoogleNewsSource.kt
+++ b/source-google-news/src/main/kotlin/in/jphe/storyvox/source/googlenews/GoogleNewsSource.kt
@@ -58,6 +58,8 @@ import javax.inject.Singleton
     supportsSearch = true,
     description = "Top stories, topic sections & search · headlines and related coverage as listenable briefings",
     sourceUrl = "https://news.google.com",
+    // #1482 — chipLabel omitted: "Google News" chip == displayName.
+    searchHint = "Search Google News — top stories, topics & more",
 )
 @Singleton
 internal class GoogleNewsSource @Inject constructor(

--- a/source-gutenberg/src/main/kotlin/in/jphe/storyvox/source/gutenberg/GutenbergSource.kt
+++ b/source-gutenberg/src/main/kotlin/in/jphe/storyvox/source/gutenberg/GutenbergSource.kt
@@ -66,6 +66,10 @@ import javax.inject.Singleton
     supportsSearch = true,
     description = "70,000+ public-domain books via Gutendex · tap-to-add downloads EPUB once",
     sourceUrl = "https://www.gutenberg.org",
+    // #1482 — "Gutenberg" chip vs. the formal "Project Gutenberg"
+    // displayName.
+    chipLabel = "Gutenberg",
+    searchHint = "Search Project Gutenberg's 70,000+ public-domain books",
 )
 @Singleton
 internal class GutenbergSource @Inject constructor(

--- a/source-hackernews/src/main/kotlin/in/jphe/storyvox/source/hackernews/HackerNewsSource.kt
+++ b/source-hackernews/src/main/kotlin/in/jphe/storyvox/source/hackernews/HackerNewsSource.kt
@@ -75,6 +75,8 @@ import javax.inject.Singleton
     supportsSearch = true,
     description = "Top stories, Ask HN, Show HN · stories + top comments as single-chapter fictions · Algolia search",
     sourceUrl = "https://news.ycombinator.com",
+    // #1482 — chipLabel omitted: "Hacker News" chip == displayName.
+    searchHint = "Search Hacker News stories (Algolia-backed full-text)",
 )
 @Singleton
 internal class HackerNewsSource @Inject constructor(

--- a/source-mempalace/src/main/kotlin/in/jphe/storyvox/source/mempalace/MemPalaceSource.kt
+++ b/source-mempalace/src/main/kotlin/in/jphe/storyvox/source/mempalace/MemPalaceSource.kt
@@ -60,6 +60,10 @@ import javax.inject.Singleton
     supportsSearch = true,
     description = "Your local mempalace daemon · LAN-only · wings + rooms become fictions",
     sourceUrl = "http://mempalace.realm.watch",
+    // #1482 — "Palace" chip (#148, avoids a two-line chip) vs. the
+    // formal "Memory Palace" displayName.
+    chipLabel = "Palace",
+    searchHint = "Search your MemPalace knowledge base",
 )
 @Singleton
 internal class MemPalaceSource @Inject constructor(

--- a/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/NotionPATSource.kt
+++ b/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/NotionPATSource.kt
@@ -39,6 +39,8 @@ import javax.inject.Singleton
     supportsSearch = true,
     description = "Private Notion databases via Integration Token",
     sourceUrl = "https://www.notion.so",
+    // #1482 — chipLabel omitted: "Notion" chip == displayName.
+    searchHint = "Search your configured Notion database",
 )
 @Singleton
 internal class NotionPATSource @Inject constructor(

--- a/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/NotionTechEmpowerSource.kt
+++ b/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/NotionTechEmpowerSource.kt
@@ -36,6 +36,8 @@ import javax.inject.Singleton
     supportsSearch = true,
     description = "TechEmpower guides, resources & about pages",
     sourceUrl = "https://www.notion.so",
+    // #1482 — chipLabel omitted: "TechEmpower" chip == displayName.
+    searchHint = "Search TechEmpower guides & resources",
 )
 @Singleton
 internal class NotionTechEmpowerSource @Inject constructor(

--- a/source-outline/src/main/kotlin/in/jphe/storyvox/source/outline/OutlineSource.kt
+++ b/source-outline/src/main/kotlin/in/jphe/storyvox/source/outline/OutlineSource.kt
@@ -46,6 +46,9 @@ import javax.inject.Singleton
     supportsSearch = false,
     description = "Self-hosted Outline wiki · collections = fictions, documents = chapters",
     sourceUrl = "https://www.getoutline.com",
+    // #1482 — "Wiki" chip vs. the formal "Outline wiki" displayName.
+    chipLabel = "Wiki",
+    searchHint = "Search your Outline notes",
 )
 @Singleton
 internal class OutlineSource @Inject constructor(

--- a/source-pdf/src/main/kotlin/in/jphe/storyvox/source/pdf/PdfSource.kt
+++ b/source-pdf/src/main/kotlin/in/jphe/storyvox/source/pdf/PdfSource.kt
@@ -58,6 +58,10 @@ import javax.inject.Singleton
     supportsSearch = false,
     description = "Read .pdf files from a folder you pick · zero-network",
     sourceUrl = "",
+    // #1482 — "PDFs" chip (#996) vs. the formal "Local PDF files"
+    // displayName; distinct from the EPUB "Local" chip.
+    chipLabel = "PDFs",
+    searchHint = "Search your local PDF library",
 )
 @Singleton
 internal class PdfSource @Inject constructor(

--- a/source-plos/src/main/kotlin/in/jphe/storyvox/source/plos/PlosSource.kt
+++ b/source-plos/src/main/kotlin/in/jphe/storyvox/source/plos/PlosSource.kt
@@ -75,6 +75,8 @@ import javax.inject.Singleton
     supportsSearch = true,
     description = "Open-access peer-reviewed science · abstract + first sections as single-chapter fictions · Solr search",
     sourceUrl = "https://plos.org",
+    // #1482 — chipLabel omitted: "PLOS" chip == displayName.
+    searchHint = "Search PLOS — open-access peer-reviewed science",
 )
 @Singleton
 internal class PlosSource @Inject constructor(

--- a/source-radio/src/main/kotlin/in/jphe/storyvox/source/radio/RadioSource.kt
+++ b/source-radio/src/main/kotlin/in/jphe/storyvox/source/radio/RadioSource.kt
@@ -70,6 +70,10 @@ import javax.inject.Singleton
     supportsSearch = true,
     description = "Live community / public / college / specialty radio · Media3 stream (bypasses TTS) · CC0 Radio Browser search",
     sourceUrl = "https://www.radio-browser.info",
+    // #1482 — chipLabel omitted: "Radio" chip == displayName. The legacy
+    // "kvmr" alias is routing-only (no descriptor) so it never renders a
+    // chip/hint; its old when-branch copy was dead.
+    searchHint = "Search Radio Browser — community, public, and college stations worldwide",
 )
 @Singleton
 internal class RadioSource @Inject constructor(

--- a/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/RoyalRoadSource.kt
+++ b/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/RoyalRoadSource.kt
@@ -59,6 +59,8 @@ import okhttp3.HttpUrl.Companion.toHttpUrl
     supportsSearch = true,
     description = "Web fiction · cookie sign-in for Follows + premium chapters",
     sourceUrl = "https://www.royalroad.com",
+    // #1482 — chipLabel omitted: "Royal Road" chip == displayName.
+    searchHint = "Find fictions across Royal Road",
 )
 @Singleton
 class RoyalRoadSource @Inject internal constructor(

--- a/source-rss/src/main/kotlin/in/jphe/storyvox/source/rss/RssSource.kt
+++ b/source-rss/src/main/kotlin/in/jphe/storyvox/source/rss/RssSource.kt
@@ -55,6 +55,9 @@ import javax.inject.Singleton
     supportsSearch = false,
     description = "Any RSS/Atom feed · one feed = one fiction · items become chapters",
     sourceUrl = "",
+    // #1482 — "RSS" chip vs. the formal "RSS / Atom feeds" displayName.
+    chipLabel = "RSS",
+    searchHint = "Search your subscribed feeds",
 )
 @Singleton
 internal class RssSource @Inject constructor(

--- a/source-standard-ebooks/src/main/kotlin/in/jphe/storyvox/source/standardebooks/StandardEbooksSource.kt
+++ b/source-standard-ebooks/src/main/kotlin/in/jphe/storyvox/source/standardebooks/StandardEbooksSource.kt
@@ -65,6 +65,8 @@ import javax.inject.Singleton
     supportsSearch = true,
     description = "Hand-curated, typographically polished public-domain classics · tap-to-add downloads EPUB",
     sourceUrl = "https://standardebooks.org",
+    // #1482 — chipLabel omitted: "Standard Ebooks" chip == displayName.
+    searchHint = "Search Standard Ebooks' hand-curated public-domain classics",
 )
 @Singleton
 internal class StandardEbooksSource @Inject constructor(

--- a/source-wikipedia/src/main/kotlin/in/jphe/storyvox/source/wikipedia/WikipediaSource.kt
+++ b/source-wikipedia/src/main/kotlin/in/jphe/storyvox/source/wikipedia/WikipediaSource.kt
@@ -69,6 +69,8 @@ import javax.inject.Singleton
     supportsSearch = true,
     description = "Any Wikipedia article narrated · article = fiction, sections = chapters · per-language",
     sourceUrl = "https://en.wikipedia.org",
+    // #1482 — chipLabel omitted: "Wikipedia" chip == displayName.
+    searchHint = "Search Wikipedia — narrate any article",
 )
 @Singleton
 internal class WikipediaSource @Inject constructor(

--- a/source-wikisource/src/main/kotlin/in/jphe/storyvox/source/wikisource/WikisourceSource.kt
+++ b/source-wikisource/src/main/kotlin/in/jphe/storyvox/source/wikisource/WikisourceSource.kt
@@ -72,6 +72,8 @@ import javax.inject.Singleton
     supportsSearch = true,
     description = "Transcribed public-domain texts · multi-part works become per-chapter playlists",
     sourceUrl = "https://en.wikisource.org",
+    // #1482 — chipLabel omitted: "Wikisource" chip == displayName.
+    searchHint = "Search Wikisource — transcribed public-domain texts",
 )
 @Singleton
 internal class WikisourceSource @Inject constructor(


### PR DESCRIPTION
## Summary

Completes the deliberately-deferred **step 4 of #1400**: `BrowseSourceUi.chipLabel` /
`searchHint` now read their per-source strings from the `@SourcePlugin` **descriptor**
instead of hand-maintained `when`-blocks keyed by `SourceIds`.

**No annotation or KSP change was needed** — #1481 already plumbed `chipLabel` / `searchHint`
/ `iconName` through the annotation (`:core-data`), the KSP processor (`:core-plugin-ksp`),
and `SourcePluginDescriptor`, all with empty defaults. This PR is purely the *consumption*
flip #1481's body left as follow-up, plus the per-source value backfill.

**Closes #1482.**

## What changed

**Consumer (`:feature/browse`)**
- `BrowseSourceUi.chipLabel(descriptorChipLabel, displayName)` → `descriptorChipLabel.ifBlank { displayName }`
- `BrowseSourceUi.searchHint(descriptorSearchHint, displayName)` → `descriptorSearchHint.ifBlank { "Search $displayName" }`
- The two `when`-blocks are deleted. `supportedTabs()` is **untouched** — its
  `List<BrowseTab>` + auth-gating shape genuinely can't live on a `:core-data` descriptor,
  so it stays keyed by `SourceIds` in this file.
- Callers pass descriptor fields: `BrowseSourceCarousel` (×2) and `catalog/SourceCatalogCard`
  use `descriptor.chipLabel`; `BrowseScreen`'s `SearchHint` resolves the descriptor and passes
  `descriptor?.searchHint.orEmpty()`.

**Backfill (20 source modules)** — additive named args on `@SourcePlugin`:
- `searchHint` on all 20 in-tree sources that had a `when`-branch (copied verbatim).
- `chipLabel` on the **8** whose concise chip differs from the formal `displayName`
  (GitHub, Palace, RSS, Local, PDFs, Wiki, Gutenberg, AO3). The other 12 render `displayName`
  and are omitted (the `ifBlank` fallback reproduces the old `else -> displayName`).

**Tests** — `BrowseSourceUiTest`'s chipLabel/searchHint cases repurposed from per-source
enumeration to fallback-contract tests (the per-source strings now live on the annotations).
`supportedTabs` tests and `IN_TREE_IDS` are unchanged.

## User-visible text changes

**None.** Every backfilled `chipLabel` / `searchHint` matches the original `when`-block string
verbatim (em-dashes and apostrophes included), and every omitted `chipLabel` falls back to the
same `displayName` the old `else` branch produced.

One `when`-branch is dropped without a backfill: the **`kvmr` alias**'s chip ("Radio") and hint
("Tune in to KVMR…"). `kvmr` is a routing-only `@Binds @IntoMap @StringKey(SourceIds.KVMR)`
alias in `RadioModule` with **no `@SourcePlugin`** → no `SourcePluginDescriptor` → it never
renders a Browse chip or search empty-state. Those branches were dead code; the canonical
`radio` source keeps its "Radio" chip and Radio-Browser hint.

## Out of scope

`iconName` is the third descriptor-backed Browse field and still falls back to the
`sourceGlyph` `when`-branch in `BrowseSourceCarousel`. Wiring it is the same mechanical shape
and a clean follow-up; this PR stays scoped to chipLabel + searchHint per the issue.

## CI gates
- **Build APK** — Hilt resolves the whole descriptor `Set` / `Map<String, FictionSource>` at
  `:app`, where any KSP/DI regression surfaces.
- **Test Compile + unit tests** — `:feature` `BrowseSourceUiTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
