### PR TITLE
fix(reader): surface the silent 30s chapter-start abort as TimedOut + Retry (#1489 follow-up)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -35,6 +35,7 @@ import `in`.jphe.storyvox.data.repository.AddByUrlResult
 import `in`.jphe.storyvox.feature.api.DocumentImporterUi
 import `in`.jphe.storyvox.feature.api.FictionRepositoryUi
 import `in`.jphe.storyvox.feature.api.UiAddByUrlResult
+import `in`.jphe.storyvox.feature.api.ChapterStartFailure
 import `in`.jphe.storyvox.feature.api.PlaybackControllerUi
 import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
 import `in`.jphe.storyvox.feature.api.UiChapter
@@ -56,7 +57,9 @@ import `in`.jphe.storyvox.playback.StoryvoxPlaybackService
 import javax.inject.Named
 import javax.inject.Singleton
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
@@ -1002,6 +1005,13 @@ internal class RealPlaybackControllerUi(
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
 
+    /** #1489 — see [PlaybackControllerUi.chapterStartFailures]. Buffered +
+     *  tryEmit so the abort (inside a scope.launch) never suspends on a slow
+     *  collector; replay = 0 so a freshly-opened reader can't pick up a stale
+     *  failure from a previous chapter. */
+    private val _chapterStartFailures = MutableSharedFlow<ChapterStartFailure>(extraBufferCapacity = 4)
+    override val chapterStartFailures: Flow<ChapterStartFailure> = _chapterStartFailures.asSharedFlow()
+
     /**
      * Issue #98 — Mode A live cache. Read by [toUi] when computing
      * `isWarmingUp` + the wall-time freeze gate. Volatile because writers
@@ -1292,6 +1302,10 @@ internal class RealPlaybackControllerUi(
             }
             if (ready == null) {
                 android.util.Log.e("PlaybackBindings", "startListening: chapter $chapterId body not ready within 30s — aborting")
+                // #1489 — don't abort silently (the on-device root cause: the
+                // reader never learned and "Loading chapter…" spun forever).
+                // Signal the reader so it flips to its TimedOut → Retry surface.
+                _chapterStartFailures.tryEmit(ChapterStartFailure(fictionId, chapterId))
                 return@launch
             }
             controller.play(fictionId, chapterId, charOffset = charOffset)

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -533,6 +533,14 @@ sealed class UiSleepTimerMode {
  *  toggles between the two states. */
 enum class UiRecapPlaybackState { Idle, Speaking }
 
+/**
+ * Issue #1489 — identifies the chapter whose [PlaybackControllerUi.startListening]
+ * gave up. Carries the fiction too so the reader's Retry can re-invoke
+ * startListening even when nothing is loaded into the controller yet (a cold
+ * abort leaves `UiPlaybackState.fictionId` null).
+ */
+data class ChapterStartFailure(val fictionId: String, val chapterId: String)
+
 interface PlaybackControllerUi {
     val state: Flow<UiPlaybackState>
     val chapterText: Flow<String>
@@ -583,6 +591,21 @@ interface PlaybackControllerUi {
      */
     val waitReason: Flow<`in`.jphe.storyvox.playback.diagnostics.WaitReason?>
         get() = kotlinx.coroutines.flow.flowOf(null)
+
+    /**
+     * Issue #1489 — emits when a [startListening] call gives up waiting for the
+     * chapter body to download (the source is rate-limiting / offline / the
+     * body never parses). Before this the abort was log-only (`PlaybackBindings:
+     * body not ready within 30s — aborting`), so the reader sat on "Loading
+     * chapter…" forever. The reader observes this to flip its LoadingPhase to
+     * TimedOut — the existing "Couldn't start this chapter" + Retry surface —
+     * and to remember the ref so Retry can actually re-attempt the load.
+     *
+     * Default emits nothing so the many lightweight [PlaybackControllerUi] test
+     * fakes stay slim (same defaulting pattern as [events] / [engineState]).
+     */
+    val chapterStartFailures: Flow<ChapterStartFailure>
+        get() = kotlinx.coroutines.flow.emptyFlow()
     fun play()
     fun pause()
     fun seekTo(ms: Long)

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/ReaderViewModel.kt
@@ -409,6 +409,13 @@ class ReaderViewModel @Inject constructor(
     private val _loadingPhase = MutableStateFlow(LoadingPhase.Loading)
     private var loadingTimerJob: Job? = null
 
+    /** Issue #1489 — the ref from the most recent
+     *  [PlaybackControllerUi.chapterStartFailures] emission. Retained so
+     *  [retryLoading] can re-invoke `startListening`: a cold abort never handed
+     *  the chapter to the controller, so `playback.play()` alone can't recover
+     *  it (there's nothing loaded to play). */
+    private var lastFailedStart: `in`.jphe.storyvox.feature.api.ChapterStartFailure? = null
+
     /**
      * Calliope (v0.5.00) — one-shot signal for the chapter-complete
      * confetti easter-egg. Conflated capacity 1 so a missed observer
@@ -474,6 +481,22 @@ class ReaderViewModel @Inject constructor(
                     delay(LOADING_SLOW_HINT_MS)
                     _loadingPhase.value = LoadingPhase.Slow
                     delay(LOADING_TIMEOUT_MS - LOADING_SLOW_HINT_MS)
+                    _loadingPhase.value = LoadingPhase.TimedOut
+                }
+            }
+        }
+        // Issue #1489 — a startListening() that gave up waiting for the chapter
+        // body used to abort log-only, leaving the reader spinning on "Loading
+        // chapter…" forever (confirmed on-device: reddit 429 → body never
+        // downloads → 30s abort). Surface the existing TimedOut → "Couldn't
+        // start this chapter" + Retry immediately, and remember the ref so
+        // retryLoading re-attempts the load. Gated on isLoading so a stray
+        // failure can't clobber an already-loaded reader.
+        viewModelScope.launch {
+            playback.chapterStartFailures.collect { failure ->
+                if (isLoading.value) {
+                    lastFailedStart = failure
+                    loadingTimerJob?.cancel()
                     _loadingPhase.value = LoadingPhase.TimedOut
                 }
             }
@@ -865,7 +888,18 @@ class ReaderViewModel @Inject constructor(
      *  play() is a documented no-op. */
     fun retryLoading() {
         _loadingPhase.value = LoadingPhase.Loading
-        playback.play()
+        // #1489 — if the last attempt aborted before the controller ever
+        // received the chapter (body never downloaded — e.g. the source was
+        // rate-limiting), play() can't recover it: nothing is loaded. Re-invoke
+        // startListening for the remembered ref. Otherwise (a mid-buffer stall
+        // on an already-loaded chapter) resume as before.
+        val failed = lastFailedStart
+        if (failed != null) {
+            lastFailedStart = null
+            playback.startListening(fictionId = failed.fictionId, chapterId = failed.chapterId)
+        } else {
+            playback.play()
+        }
     }
 
     /**


### PR DESCRIPTION
Fast-follow to #1490 (which shipped in v1.8.0). Completes the #1489 fix set.

## What v1.8.0 shipped vs. what this adds

#1490 made **feed / list** failures visible (cache, chapter-list error+Retry state machine, `429 → RateLimited` + typed-failure propagation, autodiscovery). But the **reader-side** failure was still silent, so this on-device symptom survives in v1.8.0:

> `E/PlaybackBindings: startListening: chapter rss:…::… body not ready within 30s — aborting`

Tapping a chapter on a rate-limited/failing feed (e.g. a reddit `.rss` that 429s the app's UA) → `startListening` queues the download, waits ≤30s for the body, and on timeout hits `return@launch` with **only a `Log.e`**. The reader is never told → "Loading chapter…" spins forever. Its own 30s `LoadingPhase` wall can't save it: the abort touches no playback state, and `retryLoading()` = `playback.play()` can't recover a load the controller never received.

## Fix (feature/ + app/ only — the abort site is app/-side, freeze-compatible)

- `PlaybackControllerUi` gains `chapterStartFailures: Flow<ChapterStartFailure>` (DEFAULT `emptyFlow()` → the many test fakes stay slim, same pattern as `events` / `engineState`).
- `AppBindings.startListening` **emits** `(fictionId, chapterId)` at the 30s abort instead of only logging (buffered SharedFlow, `tryEmit`, `replay = 0` so a re-opened reader can't inherit a stale failure).
- `ReaderViewModel` collects it (gated on `isLoading`, so a stray failure can't clobber an already-loaded reader) → flips `LoadingPhase` to `TimedOut`, driving the **existing** "Couldn't start this chapter" + Retry surface in `HybridReaderScreen`.
- `retryLoading` re-invokes `startListening` for the remembered ref (`play()` alone can't — nothing is loaded); falls back to `play()` for a normal mid-buffer stall.

With this, every failure mode from #1489 is visible: empty feed → the list state machine (v1.8.0); hung tap → reader `TimedOut` + Retry (here).

## Notes

- Split from #1490 purely by merge timing (#1490 was merged + released before this landed) — not a scope change. Rides the next release.
- Related follow-ups already filed: #1497 (persist RSS item bodies so cold-session taps never re-fetch) and #1498 (decouple RSS subscription identity from fetch-URL). The `retryLoading` path here makes the reddit case *recoverable*; #1497 would make a fresh tap after the throttle window *succeed without a network round-trip*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
