### PR TITLE
fix(notion): child-page-aware chaptering — sub-pages become chapters (#1508)

### DIFF
--- a/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/NotionHelpers.kt
+++ b/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/NotionHelpers.kt
@@ -107,6 +107,75 @@ internal fun splitOnHeading1(blocks: List<NotionBlock>): List<NotionSection> {
 }
 
 /**
+ * A planned chapter derived from a page's top-level blocks (#1508). Pure —
+ * no I/O — so [planChapters] is unit-testable; the source resolves each
+ * plan to real block content (a [Child] triggers a per-child block fetch).
+ */
+internal sealed interface NotionChapterPlan {
+    val title: String
+
+    /** The non-child top-level blocks rendered as one chapter, or a
+     *  `heading_1`-delimited section. [sectionIndex] indexes into the
+     *  section list the source re-derives when opening the chapter. */
+    data class Section(override val title: String, val sectionIndex: Int) : NotionChapterPlan
+
+    /** A sub-page: its whole block tree is this chapter. [childPageId] is
+     *  compact (dash-stripped) and fetchable via [NotionApi.pageBlocks]. */
+    data class Child(override val title: String, val childPageId: String) : NotionChapterPlan
+}
+
+/**
+ * Turn a page's top-level blocks into a chapter plan (#1508).
+ *
+ * - **Child-page pages** (JP's shorts DB: a lead of notes + N `child_page`
+ *   sub-pages) → an "Introduction" [Section] for the non-child lead (only
+ *   when that lead has blocks) followed by one [Child] per sub-page, in
+ *   document order. This is the case `splitOnHeading1` alone got wrong —
+ *   with no `heading_1` present it collapsed everything into one chapter.
+ * - **Flat pages** (no `child_page` blocks) → the existing
+ *   `heading_1`-split behaviour, one [Section] per split.
+ */
+internal fun planChapters(blocks: List<NotionBlock>): List<NotionChapterPlan> {
+    val childPages = blocks.filter { it.type == "child_page" }
+    if (childPages.isEmpty()) {
+        return splitOnHeading1(blocks)
+            .mapIndexed { i, s -> NotionChapterPlan.Section(s.title, i) }
+    }
+    val plans = mutableListOf<NotionChapterPlan>()
+    // The lead is section 0 — everything that isn't a sub-page. Include it
+    // only when it carries blocks, so a page that is purely sub-pages
+    // doesn't get an empty "Introduction" chapter.
+    if (blocks.any { it.type != "child_page" }) {
+        plans.add(NotionChapterPlan.Section("Introduction", 0))
+    }
+    for (cp in childPages) {
+        plans.add(
+            NotionChapterPlan.Child(
+                title = childPageTitle(cp) ?: "Untitled",
+                childPageId = cp.id.replace("-", ""),
+            ),
+        )
+    }
+    return plans
+}
+
+/** The non-child top-level blocks — the "lead" section 0 in child-page
+ *  mode (the source renders these for a `section-0` chapter request). */
+internal fun leadBlocks(blocks: List<NotionBlock>): List<NotionBlock> =
+    blocks.filter { it.type != "child_page" }
+
+/** Extract a `child_page` block's title (`{"title":"..."}`). */
+internal fun childPageTitle(block: NotionBlock): String? {
+    val obj = block.childPage as? JsonObject ?: return null
+    return obj["title"]?.jsonPrimitive?.contentOrNull?.ifBlank { null }
+}
+
+/** Chapter id for a child-page chapter — carries a `child-` marker so the
+ *  source routes it to a per-child block fetch (vs `section-N`). */
+internal fun childChapterIdFor(fictionId: String, childPageId: String): String =
+    "${fictionId}::child-${childPageId.replace("-", "")}"
+
+/**
  * Project a NotionPage into a [FictionSummary]. Returns null if no
  * usable title can be extracted (a property of type "title" must
  * exist and contain at least one rich-text segment).

--- a/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/NotionPATSource.kt
+++ b/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/NotionPATSource.kt
@@ -140,15 +140,29 @@ internal class NotionPATSource @Inject constructor(
             is FictionResult.Success -> blocksResult.value
             is FictionResult.Failure -> return blocksResult
         }
-        val sections = splitOnHeading1(blocks)
-        val chapters = sections.mapIndexed { idx, section ->
-            ChapterInfo(
-                id = chapterIdFor(fictionId, idx),
-                sourceChapterId = "section-$idx",
-                index = idx,
-                title = section.title,
-                publishedAt = null,
-            )
+        // #1508 — child-page-aware chaptering. A page whose sub-pages are
+        // the real chapters (JP's shorts DB) has no heading_1, so the old
+        // splitOnHeading1 collapsed all 20 shorts into one "Intro" chapter.
+        // planChapters emits a lead Section (the notes) + one Child per
+        // sub-page; child titles come from the block inline, so listing
+        // costs no extra fetches — only opening a child fetches its body.
+        val chapters = planChapters(blocks).mapIndexed { idx, plan ->
+            when (plan) {
+                is NotionChapterPlan.Section -> ChapterInfo(
+                    id = chapterIdFor(fictionId, plan.sectionIndex),
+                    sourceChapterId = "section-${plan.sectionIndex}",
+                    index = idx,
+                    title = plan.title,
+                    publishedAt = null,
+                )
+                is NotionChapterPlan.Child -> ChapterInfo(
+                    id = childChapterIdFor(fictionId, plan.childPageId),
+                    sourceChapterId = "child-${plan.childPageId}",
+                    index = idx,
+                    title = plan.title,
+                    publishedAt = null,
+                )
+            }
         }
         val summary = page.toSummary(SourceIds.NOTION_PAT)?.copy(chapterCount = chapters.size)
             ?: FictionSummary(
@@ -169,12 +183,44 @@ internal class NotionPATSource @Inject constructor(
     ): FictionResult<ChapterContent> {
         val pageId = fictionId.toPageId()
             ?: return FictionResult.NotFound("Notion fiction id not recognized: $fictionId")
+
+        // #1508 — a child-page chapter (`::child-<id>`) is its own sub-page:
+        // fetch only THAT page's blocks and render the whole thing as one
+        // chapter. Its title comes from the parent's block list.
+        val childPageId = chapterId.substringAfterLast("::child-", "")
+        if (childPageId.isNotBlank()) {
+            return when (val r = api.pageBlocks(childPageId)) {
+                is FictionResult.Success -> {
+                    val title = childTitleFromParent(pageId, childPageId)
+                    FictionResult.Success(
+                        ChapterContent(
+                            info = ChapterInfo(
+                                id = chapterId,
+                                sourceChapterId = "child-$childPageId",
+                                index = 0,
+                                title = title,
+                            ),
+                            htmlBody = r.value.joinToString("\n") { it.toHtml() },
+                            plainBody = r.value.joinToString("\n\n") { it.toPlainText() }.trim(),
+                        ),
+                    )
+                }
+                is FictionResult.Failure -> r
+            }
+        }
+
         val sectionIndex = chapterId.substringAfterLast("::section-", "")
             .toIntOrNull()
             ?: return FictionResult.NotFound("Notion chapter id not recognized: $chapterId")
         return when (val r = api.pageBlocks(pageId)) {
             is FictionResult.Success -> {
-                val sections = splitOnHeading1(r.value)
+                // In child-page mode section 0 is the non-child lead; in flat
+                // mode fall back to heading_1 splitting.
+                val sections = if (r.value.any { it.type == "child_page" }) {
+                    listOf(NotionSection("Introduction", leadBlocks(r.value)))
+                } else {
+                    splitOnHeading1(r.value)
+                }
                 val section = sections.getOrNull(sectionIndex)
                     ?: return FictionResult.NotFound(
                         "Section $sectionIndex not found in Notion page $pageId",
@@ -198,6 +244,20 @@ internal class NotionPATSource @Inject constructor(
             }
             is FictionResult.Failure -> r
         }
+    }
+
+    /** Recover a child page's title from the parent's block list (the
+     *  `child_page` block carries it inline). Falls back to "Untitled" if
+     *  the parent fetch fails or the child isn't found — the body still
+     *  renders. */
+    private suspend fun childTitleFromParent(parentPageId: String, childPageId: String): String {
+        val parent = api.pageBlocks(parentPageId)
+        if (parent is FictionResult.Success) {
+            parent.value.firstOrNull {
+                it.type == "child_page" && it.id.replace("-", "") == childPageId
+            }?.let { return childPageTitle(it) ?: "Untitled" }
+        }
+        return "Untitled"
     }
 
     // ─── auth-gated ─────────────────────────────────────────────────────

--- a/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/net/NotionModels.kt
+++ b/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/net/NotionModels.kt
@@ -117,6 +117,11 @@ internal data class NotionBlock(
     val divider: JsonElement? = null,
     val toggle: JsonElement? = null,
     @SerialName("to_do") val toDo: JsonElement? = null,
+    /** A sub-page nested under this page. Its payload is
+     *  `{"title": "..."}` and the block [id] IS the child page's id, so
+     *  [NotionApi.pageBlocks] can fetch its content directly. Used by the
+     *  child-page chaptering path (#1508). */
+    @SerialName("child_page") val childPage: JsonElement? = null,
     /** Issue #1036 — nesting level in the flattened document order.
      *  Top-level blocks are depth 0; children spliced in by
      *  [flattenNested] carry their parent's depth + 1. Not part of the

--- a/source-notion/src/test/kotlin/in/jphe/storyvox/source/notion/NotionChildPageChapterTest.kt
+++ b/source-notion/src/test/kotlin/in/jphe/storyvox/source/notion/NotionChildPageChapterTest.kt
@@ -1,0 +1,107 @@
+package `in`.jphe.storyvox.source.notion
+
+import `in`.jphe.storyvox.source.notion.net.NotionBlock
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #1508 — child-page chaptering. A Notion page whose sub-pages are the
+ * real chapters (JP's shorts DB: a lead of notes + N `child_page` blocks)
+ * has no `heading_1`, so the old `splitOnHeading1` collapsed everything
+ * into one "Intro" chapter. [planChapters] must instead emit a lead
+ * Section (when there are non-child blocks) + one Child per sub-page.
+ */
+class NotionChildPageChapterTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    // Test titles/text below are quote-free, so direct interpolation into
+    // the JSON string literal is safe (no escaping needed).
+    private fun childPage(id: String, title: String): NotionBlock =
+        NotionBlock(
+            id = id,
+            type = "child_page",
+            childPage = json.parseToJsonElement("""{"title":"$title"}"""),
+        )
+
+    private fun para(text: String): NotionBlock =
+        NotionBlock(
+            id = "p",
+            type = "paragraph",
+            paragraph = json.parseToJsonElement(
+                """{"rich_text":[{"type":"text","plain_text":"$text"}]}""",
+            ),
+        )
+
+    private fun heading1(text: String): NotionBlock =
+        NotionBlock(
+            id = "h",
+            type = "heading_1",
+            heading1 = json.parseToJsonElement(
+                """{"rich_text":[{"type":"text","plain_text":"$text"}]}""",
+            ),
+        )
+
+    @Test fun `lead notes plus child pages become intro plus one chapter each`() {
+        val blocks = listOf(
+            para("Recording notes"),
+            childPage("aaaa1111-2222-3333-4444-555566667777", "Short 01 — Myth-busting"),
+            childPage("bbbb1111-2222-3333-4444-555566667777", "Short 02 — Getting connected"),
+            childPage("cccc1111-2222-3333-4444-555566667777", "Short 03 — Food"),
+        )
+        val plans = planChapters(blocks)
+        assertEquals("intro + 3 shorts", 4, plans.size)
+        assertTrue("first is the lead section", plans[0] is NotionChapterPlan.Section)
+        assertEquals("Introduction", plans[0].title)
+        assertTrue("rest are child pages", plans.drop(1).all { it is NotionChapterPlan.Child })
+        assertEquals("Short 02 — Getting connected", plans[2].title)
+        assertEquals(
+            "child id is compact",
+            "bbbb1111222233334444555566667777",
+            (plans[2] as NotionChapterPlan.Child).childPageId,
+        )
+    }
+
+    @Test fun `page of only child pages gets no empty intro`() {
+        val blocks = listOf(
+            childPage("aaaa1111-2222-3333-4444-555566667777", "Short 01"),
+            childPage("bbbb1111-2222-3333-4444-555566667777", "Short 02"),
+        )
+        val plans = planChapters(blocks)
+        assertEquals(2, plans.size)
+        assertTrue(plans.all { it is NotionChapterPlan.Child })
+    }
+
+    @Test fun `flat page with no child pages still splits on heading_1`() {
+        val blocks = listOf(
+            para("lead"),
+            heading1("Chapter One"),
+            para("body one"),
+            heading1("Chapter Two"),
+            para("body two"),
+        )
+        val plans = planChapters(blocks)
+        assertTrue("all sections", plans.all { it is NotionChapterPlan.Section })
+        assertEquals(listOf("Introduction", "Chapter One", "Chapter Two"), plans.map { it.title })
+    }
+
+    @Test fun `childChapterId round-trips the compact id with a child marker`() {
+        val id = childChapterIdFor("notion:abc", "bbbb1111-2222-3333-4444-555566667777")
+        assertEquals("notion:abc::child-bbbb1111222233334444555566667777", id)
+        assertEquals(
+            "bbbb1111222233334444555566667777",
+            id.substringAfterLast("::child-", ""),
+        )
+    }
+
+    @Test fun `leadBlocks drops child pages, keeps the rest`() {
+        val blocks = listOf(
+            para("keep me"),
+            childPage("aaaa1111-2222-3333-4444-555566667777", "drop me"),
+        )
+        assertEquals(1, leadBlocks(blocks).size)
+        assertEquals("paragraph", leadBlocks(blocks).first().type)
+    }
+}


### PR DESCRIPTION
## Problem
Opening a Notion page whose entries are `child_page` sub-pages (JP's TechEmpower shorts DB "Show planning": a lead of recording notes + 20 sub-page shorts) yielded ONE chapter "Intro" instead of Intro + 20. Root cause: `splitOnHeading1` only breaks on `heading_1`; the page has none, so everything folded into the lead and the sub-pages were never descended into. Confirmed against the live page (20 × `child_page`, 0 × `heading_1`).

## Fix
- `NotionBlock` gains a `child_page` field (title lives at `child_page.title`; the block `id` IS the child page id).
- New pure `planChapters(blocks)` (unit-tested): child-page pages → a lead `Section` (only when non-child blocks exist) + one `Child` per sub-page, in document order; flat pages → unchanged `heading_1` split.
- `fictionDetail` builds the chapter list from the plan — child titles are inline, so **listing costs zero extra fetches**; only opening a child fetches its body.
- `chapter()` routes `::child-<compactId>` to a single `pageBlocks(childId)` fetch, and `section-0` to the non-child lead in child-page mode (heading split otherwise).

## Tests
`NotionChildPageChapterTest` (plain JVM, no network): intro+N planning, all-child page (no empty intro), flat heading_1 fallback, child-chapter-id round-trip, leadBlocks filtering.

## Scope
`source-notion` only. Does NOT touch the OAuth PR (#1509) surface beyond the shared `NotionPATSource` — that PR rebases onto this.

Closes #1508.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notion pages now support chaptering that includes sub-pages as separate chapters.
  * Pages with both main content and sub-pages show a dedicated introduction section before sub-page chapters.
  * Sub-page titles are now carried through when available, improving chapter labels.

* **Bug Fixes**
  * Pages without sub-pages continue to split into sections as before.
  * Empty introduction sections are no longer created for pages made up only of sub-pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->