### PR TITLE
feat(epic): Epic Games Store weekly free games source (#1493)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -617,6 +617,7 @@ dependencies {
     implementation(project(":source-arxiv"))
     implementation(project(":source-plos"))
     implementation(project(":source-discord"))
+    implementation(project(":source-epic-free-games"))
     implementation(project(":source-telegram"))
     // Issue #454 — Slack Web API backend. Channels-as-fictions via
     // Bot Token auth (xoxb-…). Mirrors :source-telegram's leaf

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -87,6 +87,10 @@ include(":source-google-news")
 include(":source-arxiv")
 include(":source-plos")
 include(":source-discord")
+// Issue #1493 — Epic Games Store weekly free-game giveaways. One fiction
+// ("Epic Free Games"), each current/upcoming giveaway a chapter. Reads the
+// public no-auth freeGamesPromotions JSON endpoint; no follows, no search.
+include(":source-epic-free-games")
 // Issue #462 — Telegram Bot API backend. Public-channel reader (bot
 // gets invited to channels, messages become chapters). Architectural
 // twin to :source-discord but simpler — no thread coalescing, no

--- a/source-epic-free-games/build.gradle.kts
+++ b/source-epic-free-games/build.gradle.kts
@@ -1,0 +1,46 @@
+plugins {
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.hilt)
+    alias(libs.plugins.kotlin.serialization)
+}
+
+android {
+    namespace = "in.jphe.storyvox.source.epicfreegames"
+    compileSdk = 37
+
+    defaultConfig {
+        minSdk = 26
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+    }
+}
+
+dependencies {
+    implementation(project(":core-data"))
+
+    implementation(libs.kotlinx.coroutines.android)
+    implementation(libs.kotlinx.serialization.json)
+    implementation(libs.okhttp)
+
+    implementation(libs.hilt.android)
+    ksp(libs.hilt.compiler)
+
+    // @SourcePlugin -> KSP emits the SourcePluginDescriptor @IntoSet binding
+    // AND the Map<String, FictionSource> @IntoMap binding (#1371). No hand
+    // di/ module needed.
+    ksp(project(":core-plugin-ksp"))
+
+    testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(project(":core-source-testkit"))
+}

--- a/source-epic-free-games/src/main/kotlin/in/jphe/storyvox/source/epicfreegames/EpicFreeGamesSource.kt
+++ b/source-epic-free-games/src/main/kotlin/in/jphe/storyvox/source/epicfreegames/EpicFreeGamesSource.kt
@@ -2,70 +2,365 @@ package `in`.jphe.storyvox.source.epicfreegames
 
 import `in`.jphe.storyvox.data.source.FictionSource
 import `in`.jphe.storyvox.data.source.model.ChapterContent
+import `in`.jphe.storyvox.data.source.model.ChapterInfo
 import `in`.jphe.storyvox.data.source.model.FictionDetail
 import `in`.jphe.storyvox.data.source.model.FictionResult
+import `in`.jphe.storyvox.data.source.model.FictionStatus
 import `in`.jphe.storyvox.data.source.model.FictionSummary
 import `in`.jphe.storyvox.data.source.model.ListPage
 import `in`.jphe.storyvox.data.source.model.SearchQuery
 import `in`.jphe.storyvox.data.source.plugin.SourceCategory
 import `in`.jphe.storyvox.data.source.plugin.SourcePlugin
 import `in`.jphe.storyvox.source.epicfreegames.net.EpicFreeGamesApi
+import `in`.jphe.storyvox.source.epicfreegames.net.OfferGroup
+import `in`.jphe.storyvox.source.epicfreegames.net.PromotionalOffer
+import `in`.jphe.storyvox.source.epicfreegames.net.PromotionsResponse
+import `in`.jphe.storyvox.source.epicfreegames.net.StoreElement
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * Epic Free Games source (scaffolded by scripts/new-source.sh).
+ * Issue #1493 — Epic Games Store weekly free-game giveaways as a listenable
+ * source.
  *
- * Every member is stubbed with an honest [FictionResult.NotFound] — wire each
- * one to [EpicFreeGamesApi] and map the response into the core-data models. The
- * contract test in src/test fails until popular()/search()/etc. talk to the
- * Api; making it green is your definition of done. See
- * docs/CONTRIBUTING-SOURCES.md.
+ * **Shape.** Exactly one fiction — "Epic Free Games" — whose chapters are the
+ * individual giveaways. Each currently-free game and each announced upcoming
+ * freebie is one chapter reading the title, the free-claim window, the normal
+ * price, the publisher, and the store blurb. Current giveaways sort ahead of
+ * upcoming ones; [latestUpdates] surfaces the same fiction (the "current
+ * rotation" the Morning Briefing (#1467) can narrate).
  *
- * The @SourcePlugin id below is the SINGLE source of truth for this backend's
- * identity — do NOT add a SourceIds constant (that table is frozen).
+ * That single-fiction shape mirrors how the content is actually consumed —
+ * "what's free this week" is one short episode, not a library of separate
+ * books. There is no per-game detail page to drill into; every surface reads
+ * from the one [EpicFreeGamesApi.fetchPromotions] document.
+ *
+ * **No auth, no follows, no search.** The feed is public and anonymous; there
+ * is no account concept to follow against, and searching a single rotating
+ * fiction has no meaning — [search] returns empty and `supportsSearch` is
+ * false so Browse hides the search tab.
+ *
+ * **Fragile vendor JSON.** The upstream endpoint is unofficial; parsing is
+ * lenient (see [EpicFreeGamesApi]) and the giveaway filter ([giveaways])
+ * tolerates the feed bundling plain sales alongside the actual freebies.
  */
 @SourcePlugin(
+    // String literal (the scaffold convention) — the annotation id is the
+    // single source of truth for this backend's identity.
     id = "epic-free-games",
     displayName = "Epic Free Games",
     defaultEnabled = false,
-    category = SourceCategory.Ebook,
-    supportsSearch = true,
-    description = "One-line subtitle — surface + auth posture (fill me in)",
-    sourceUrl = "https://example.com",
+    category = SourceCategory.Text,
+    supportsFollow = false,
+    supportsSearch = false,
+    description = "Epic Games Store weekly free-game giveaways · public feed, no sign-in",
+    sourceUrl = "https://store.epicgames.com/free-games",
+    chipLabel = "Epic",
+    iconName = "Redeem",
 )
 @Singleton
 internal class EpicFreeGamesSource @Inject constructor(
-    @Suppress("unused") private val api: EpicFreeGamesApi,
+    private val api: EpicFreeGamesApi,
 ) : FictionSource {
 
-    override val id: String = "epic-free-games"
+    override val id: String = EPIC_SOURCE_ID
     override val displayName: String = "Epic Free Games"
 
-    override suspend fun popular(page: Int): FictionResult<ListPage<FictionSummary>> =
-        FictionResult.NotFound("not implemented")
+    // ─── browse ────────────────────────────────────────────────────────
 
+    /** The single "Epic Free Games" fiction, its description summarising the
+     *  current rotation. Always issues the network fetch (the count in the
+     *  subtitle is live). */
+    override suspend fun popular(page: Int): FictionResult<ListPage<FictionSummary>> =
+        singleFictionPage()
+
+    /** Same single fiction — "latest" for this source IS the current rotation. */
     override suspend fun latestUpdates(page: Int): FictionResult<ListPage<FictionSummary>> =
-        FictionResult.NotFound("not implemented")
+        singleFictionPage()
 
     override suspend fun byGenre(genre: String, page: Int): FictionResult<ListPage<FictionSummary>> =
-        FictionResult.NotFound("not implemented")
+        FictionResult.Success(ListPage(items = emptyList(), page = 1, hasNext = false))
 
+    /** No meaningful search over a single rotating fiction; the annotation's
+     *  `supportsSearch = false` hides the Browse search tab. Returning an empty
+     *  page keeps the contract kit's blank-query check honest. */
     override suspend fun search(query: SearchQuery): FictionResult<ListPage<FictionSummary>> =
-        FictionResult.NotFound("not implemented")
-
-    override suspend fun fictionDetail(fictionId: String): FictionResult<FictionDetail> =
-        FictionResult.NotFound("not implemented")
-
-    override suspend fun chapter(fictionId: String, chapterId: String): FictionResult<ChapterContent> =
-        FictionResult.NotFound("not implemented")
-
-    override suspend fun followsList(page: Int): FictionResult<ListPage<FictionSummary>> =
-        FictionResult.AuthRequired("not implemented")
-
-    override suspend fun setFollowed(fictionId: String, followed: Boolean): FictionResult<Unit> =
-        FictionResult.AuthRequired("not implemented")
+        FictionResult.Success(ListPage(items = emptyList(), page = 1, hasNext = false))
 
     override suspend fun genres(): FictionResult<List<String>> =
         FictionResult.Success(emptyList())
+
+    private suspend fun singleFictionPage(): FictionResult<ListPage<FictionSummary>> {
+        val resp = when (val r = api.fetchPromotions()) {
+            is FictionResult.Success -> r.value
+            is FictionResult.Failure -> return r
+        }
+        val summary = summaryOf(giveaways(resp))
+        return FictionResult.Success(
+            ListPage(items = listOf(summary), page = 1, hasNext = false),
+        )
+    }
+
+    // ─── detail ────────────────────────────────────────────────────────
+
+    override suspend fun fictionDetail(fictionId: String): FictionResult<FictionDetail> {
+        if (fictionId != EPIC_FICTION_ID) {
+            return FictionResult.NotFound("Not an Epic Free Games fiction: $fictionId")
+        }
+        val resp = when (val r = api.fetchPromotions()) {
+            is FictionResult.Success -> r.value
+            is FictionResult.Failure -> return r
+        }
+        val list = giveaways(resp)
+        val chapters = list.mapIndexed { i, g -> g.toChapterInfo(i) }
+        return FictionResult.Success(
+            FictionDetail(
+                summary = summaryOf(list).copy(chapterCount = list.size),
+                chapters = chapters,
+            ),
+        )
+    }
+
+    override suspend fun chapter(
+        fictionId: String,
+        chapterId: String,
+    ): FictionResult<ChapterContent> {
+        if (fictionId != EPIC_FICTION_ID) {
+            return FictionResult.NotFound("Not an Epic Free Games fiction: $fictionId")
+        }
+        val resp = when (val r = api.fetchPromotions()) {
+            is FictionResult.Success -> r.value
+            is FictionResult.Failure -> return r
+        }
+        val indexed = giveaways(resp).withIndex()
+            .firstOrNull { chapterIdFor(it.value.key) == chapterId }
+            ?: return FictionResult.NotFound("No Epic giveaway for chapter $chapterId")
+        val giveaway = indexed.value
+        val body = narrateGiveaway(giveaway)
+        return FictionResult.Success(
+            ChapterContent(
+                info = giveaway.toChapterInfo(indexed.index),
+                htmlBody = body.toHtmlParagraphs(),
+                plainBody = body,
+            ),
+        )
+    }
+
+    // ─── auth-gated (no-ops — the feed is anonymous) ─────────────────────
+
+    override suspend fun followsList(page: Int): FictionResult<ListPage<FictionSummary>> =
+        FictionResult.Success(ListPage(items = emptyList(), page = 1, hasNext = false))
+
+    override suspend fun setFollowed(
+        fictionId: String,
+        followed: Boolean,
+    ): FictionResult<Unit> = FictionResult.Success(Unit)
+
+    // ─── polling ─────────────────────────────────────────────────────────
+
+    /**
+     * Cheap rotation-change token for the poll worker (Morning Briefing #1467).
+     * Derived from the currently-free giveaways + their end dates, so the token
+     * changes exactly when the weekly rotation flips. Falls back to `null` on a
+     * fetch failure so the worker retries the full path.
+     */
+    override suspend fun latestRevisionToken(fictionId: String): FictionResult<String?> {
+        if (fictionId != EPIC_FICTION_ID) return FictionResult.Success(null)
+        val resp = when (val r = api.fetchPromotions()) {
+            is FictionResult.Success -> r.value
+            is FictionResult.Failure -> return r
+        }
+        val token = giveaways(resp).filter { it.current }
+            .joinToString("|") { "${it.key}@${it.endDate}" }
+            .ifBlank { "none" }
+        return FictionResult.Success(token)
+    }
+
+    // ─── helpers ─────────────────────────────────────────────────────────
+
+    private fun summaryOf(list: List<Giveaway>): FictionSummary {
+        val currentCount = list.count { it.current }
+        val upcomingCount = list.size - currentCount
+        val subtitle = buildString {
+            if (currentCount > 0) append("$currentCount free to claim now")
+            else append("No free games right now")
+            if (upcomingCount > 0) append(" · $upcomingCount coming soon")
+        }
+        return FictionSummary(
+            id = EPIC_FICTION_ID,
+            sourceId = EPIC_SOURCE_ID,
+            title = "Epic Free Games",
+            author = "Epic Games Store",
+            description = subtitle,
+            coverUrl = list.firstOrNull { it.current }?.coverUrl ?: list.firstOrNull()?.coverUrl,
+            status = FictionStatus.ONGOING,
+            chapterCount = list.size,
+        )
+    }
+
+    private fun Giveaway.toChapterInfo(index: Int): ChapterInfo = ChapterInfo(
+        id = chapterIdFor(key),
+        sourceChapterId = key,
+        index = index,
+        title = if (current) title else "$title (coming soon)",
+    )
 }
+
+// ── identity ────────────────────────────────────────────────────────────
+
+/** @SourcePlugin id — the single source of truth for this backend (no SourceIds entry). */
+internal const val EPIC_SOURCE_ID: String = "epic-free-games"
+
+/** The one fiction this source exposes. Distinct from the source id so a routed
+ *  `fictionId` is unambiguous at the repository layer. */
+internal const val EPIC_FICTION_ID: String = "epic-free-games:weekly"
+
+/** Stable chapter id: fiction id + the game's Epic element key. */
+internal fun chapterIdFor(key: String): String = "$EPIC_FICTION_ID::$key"
+
+// ── domain model + pure mappers (unit-tested without a network client) ────
+
+/**
+ * A single free-game promotion projected out of the raw feed. `current` is the
+ * headline "free right now" state; `false` is an announced upcoming freebie.
+ */
+internal data class Giveaway(
+    val key: String,
+    val title: String,
+    val description: String,
+    val seller: String?,
+    val storeUrl: String?,
+    val coverUrl: String?,
+    val current: Boolean,
+    val startDate: String?,
+    val endDate: String?,
+    val originalPriceFmt: String?,
+)
+
+/**
+ * Project the feed into giveaways. An element qualifies only if it carries a
+ * promotional offer with `discountPercentage == 0` (pay 0% → free); the feed's
+ * plain sales (20/50/80% off) are dropped. Current giveaways sort ahead of
+ * upcoming ones; feed order is preserved within each group (stable sort).
+ */
+internal fun giveaways(resp: PromotionsResponse): List<Giveaway> {
+    val out = mutableListOf<Giveaway>()
+    for (el in resp.data.catalog.searchStore.elements) {
+        val title = el.title?.trim().orEmpty()
+        if (title.isBlank()) continue
+        val promos = el.promotions ?: continue
+        val currentOffer = promos.promotionalOffers.firstFreeOffer()
+        val upcomingOffer = promos.upcomingPromotionalOffers.firstFreeOffer()
+        val (isCurrent, offer) = when {
+            currentOffer != null -> true to currentOffer
+            upcomingOffer != null -> false to upcomingOffer
+            else -> continue // plain sale / not a giveaway
+        }
+        out += Giveaway(
+            key = el.id ?: el.namespace ?: title,
+            title = title,
+            description = el.description?.trim().orEmpty(),
+            seller = el.seller?.name?.trim()?.takeIf { it.isNotBlank() },
+            storeUrl = storeUrlFor(el),
+            coverUrl = coverUrlFor(el),
+            current = isCurrent,
+            startDate = offer.startDate,
+            endDate = offer.endDate,
+            originalPriceFmt = el.price?.totalPrice?.fmtPrice?.originalPrice
+                ?.takeIf { it.isNotBlank() && it != "0" },
+        )
+    }
+    return out.sortedBy { if (it.current) 0 else 1 }
+}
+
+/** The first offer in these groups that makes the game free (pay 0%). Upcoming
+ *  groups can bundle several offers (a free week among later % sales) — we pick
+ *  the free one, not the first one. */
+private fun List<OfferGroup>.firstFreeOffer(): PromotionalOffer? =
+    this.asSequence()
+        .flatMap { it.promotionalOffers.asSequence() }
+        .firstOrNull { it.discountSetting?.discountPercentage == 0 }
+
+/**
+ * Build a store URL from whichever slug the element exposes. `productSlug` is
+ * the clean canonical path; the offer/catalog `pageSlug`s are the hashed
+ * current-storefront paths and both redirect. Returns null when the element
+ * carries no usable slug.
+ */
+internal fun storeUrlFor(el: StoreElement): String? {
+    val slug = el.productSlug?.substringBefore('/')?.takeIf { it.isNotBlank() }
+        ?: el.offerMappings.firstOrNull { it.pageType == "productHome" }?.pageSlug
+        ?: el.offerMappings.firstOrNull()?.pageSlug
+        ?: el.catalogNs?.mappings?.firstOrNull { it.pageType == "productHome" }?.pageSlug
+        ?: el.catalogNs?.mappings?.firstOrNull()?.pageSlug
+        ?: return null
+    return "https://store.epicgames.com/p/$slug"
+}
+
+private fun coverUrlFor(el: StoreElement): String? {
+    val imgs = el.keyImages
+    return (
+        imgs.firstOrNull { it.type == "OfferImageWide" }
+            ?: imgs.firstOrNull { it.type == "Thumbnail" }
+            ?: imgs.firstOrNull()
+        )?.url?.takeIf { it.isNotBlank() }
+}
+
+/** Narratable body for one giveaway chapter. Plain text — the playback layer
+ *  normalises prosody on top; the reader view gets [toHtmlParagraphs]. */
+internal fun narrateGiveaway(g: Giveaway): String {
+    val sb = StringBuilder()
+    sb.append(g.title).append("\n\n")
+    val window = formatWindow(g.startDate, g.endDate)
+    sb.append(if (g.current) "Free to claim now on the Epic Games Store" else "Free to claim soon on the Epic Games Store")
+    if (window != null) sb.append(", ").append(window)
+    sb.append(".")
+    g.originalPriceFmt?.let { sb.append(" Normally ").append(it).append(".") }
+    g.seller?.let { sb.append(" Published by ").append(it).append(".") }
+    if (g.description.isNotBlank()) sb.append("\n\n").append(g.description)
+    g.storeUrl?.let { sb.append("\n\nClaim it at ").append(it) }
+    return sb.toString().trim()
+}
+
+/** "from Jul 2, 2026 to Jul 9, 2026" / "through Jul 9, 2026" / null. */
+internal fun formatWindow(startIso: String?, endIso: String?): String? {
+    val start = formatEpicDate(startIso)
+    val end = formatEpicDate(endIso)
+    return when {
+        start != null && end != null -> "from $start to $end"
+        end != null -> "through $end"
+        start != null -> "starting $start"
+        else -> null
+    }
+}
+
+private val EPIC_DATE_FORMAT: DateTimeFormatter =
+    DateTimeFormatter.ofPattern("MMM d, yyyy", Locale.US).withZone(ZoneOffset.UTC)
+
+/** Parse Epic's ISO-8601 instant (`2026-07-02T15:00:00.000Z`) to `Jul 2, 2026`
+ *  (UTC — the window is announced in UTC, and UTC keeps this deterministic).
+ *  Falls back to the raw string if the shape ever changes. */
+internal fun formatEpicDate(iso: String?): String? {
+    if (iso.isNullOrBlank()) return null
+    return try {
+        EPIC_DATE_FORMAT.format(Instant.parse(iso))
+    } catch (_: DateTimeParseException) {
+        iso
+    }
+}
+
+/** Split the plain body on blank lines into `<p>` blocks for the reader view. */
+internal fun String.toHtmlParagraphs(): String =
+    split("\n\n")
+        .filter { it.isNotBlank() }
+        .joinToString("") { "<p>${escapeHtml(it).replace("\n", "<br/>")}</p>" }
+
+internal fun escapeHtml(s: String): String =
+    s.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")

--- a/source-epic-free-games/src/main/kotlin/in/jphe/storyvox/source/epicfreegames/EpicFreeGamesSource.kt
+++ b/source-epic-free-games/src/main/kotlin/in/jphe/storyvox/source/epicfreegames/EpicFreeGamesSource.kt
@@ -1,0 +1,71 @@
+package `in`.jphe.storyvox.source.epicfreegames
+
+import `in`.jphe.storyvox.data.source.FictionSource
+import `in`.jphe.storyvox.data.source.model.ChapterContent
+import `in`.jphe.storyvox.data.source.model.FictionDetail
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import `in`.jphe.storyvox.data.source.model.FictionSummary
+import `in`.jphe.storyvox.data.source.model.ListPage
+import `in`.jphe.storyvox.data.source.model.SearchQuery
+import `in`.jphe.storyvox.data.source.plugin.SourceCategory
+import `in`.jphe.storyvox.data.source.plugin.SourcePlugin
+import `in`.jphe.storyvox.source.epicfreegames.net.EpicFreeGamesApi
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Epic Free Games source (scaffolded by scripts/new-source.sh).
+ *
+ * Every member is stubbed with an honest [FictionResult.NotFound] — wire each
+ * one to [EpicFreeGamesApi] and map the response into the core-data models. The
+ * contract test in src/test fails until popular()/search()/etc. talk to the
+ * Api; making it green is your definition of done. See
+ * docs/CONTRIBUTING-SOURCES.md.
+ *
+ * The @SourcePlugin id below is the SINGLE source of truth for this backend's
+ * identity — do NOT add a SourceIds constant (that table is frozen).
+ */
+@SourcePlugin(
+    id = "epic-free-games",
+    displayName = "Epic Free Games",
+    defaultEnabled = false,
+    category = SourceCategory.Ebook,
+    supportsSearch = true,
+    description = "One-line subtitle — surface + auth posture (fill me in)",
+    sourceUrl = "https://example.com",
+)
+@Singleton
+internal class EpicFreeGamesSource @Inject constructor(
+    @Suppress("unused") private val api: EpicFreeGamesApi,
+) : FictionSource {
+
+    override val id: String = "epic-free-games"
+    override val displayName: String = "Epic Free Games"
+
+    override suspend fun popular(page: Int): FictionResult<ListPage<FictionSummary>> =
+        FictionResult.NotFound("not implemented")
+
+    override suspend fun latestUpdates(page: Int): FictionResult<ListPage<FictionSummary>> =
+        FictionResult.NotFound("not implemented")
+
+    override suspend fun byGenre(genre: String, page: Int): FictionResult<ListPage<FictionSummary>> =
+        FictionResult.NotFound("not implemented")
+
+    override suspend fun search(query: SearchQuery): FictionResult<ListPage<FictionSummary>> =
+        FictionResult.NotFound("not implemented")
+
+    override suspend fun fictionDetail(fictionId: String): FictionResult<FictionDetail> =
+        FictionResult.NotFound("not implemented")
+
+    override suspend fun chapter(fictionId: String, chapterId: String): FictionResult<ChapterContent> =
+        FictionResult.NotFound("not implemented")
+
+    override suspend fun followsList(page: Int): FictionResult<ListPage<FictionSummary>> =
+        FictionResult.AuthRequired("not implemented")
+
+    override suspend fun setFollowed(fictionId: String, followed: Boolean): FictionResult<Unit> =
+        FictionResult.AuthRequired("not implemented")
+
+    override suspend fun genres(): FictionResult<List<String>> =
+        FictionResult.Success(emptyList())
+}

--- a/source-epic-free-games/src/main/kotlin/in/jphe/storyvox/source/epicfreegames/di/EpicFreeGamesModule.kt
+++ b/source-epic-free-games/src/main/kotlin/in/jphe/storyvox/source/epicfreegames/di/EpicFreeGamesModule.kt
@@ -1,0 +1,45 @@
+package `in`.jphe.storyvox.source.epicfreegames.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import `in`.jphe.storyvox.data.network.UserAgentHeader
+import `in`.jphe.storyvox.source.epicfreegames.net.EpicFreeGamesApi
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
+import java.util.concurrent.TimeUnit
+import javax.inject.Qualifier
+import javax.inject.Singleton
+
+/** Dedicated OkHttp client qualifier for the Epic Free Games backend. */
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class EpicFreeGamesHttp
+
+@Module
+@InstallIn(SingletonComponent::class)
+internal object EpicFreeGamesHttpModule {
+
+    @Provides
+    @Singleton
+    @EpicFreeGamesHttp
+    fun provideClient(
+        @UserAgentHeader userAgent: Interceptor,
+    ): OkHttpClient =
+        OkHttpClient.Builder()
+            .connectTimeout(10, TimeUnit.SECONDS)
+            .readTimeout(15, TimeUnit.SECONDS)
+            .writeTimeout(10, TimeUnit.SECONDS)
+            .followRedirects(true)
+            .retryOnConnectionFailure(true)
+            // #1204 — shared descriptive User-Agent on every request.
+            .addInterceptor(userAgent)
+            .build()
+
+    @Provides
+    @Singleton
+    fun provideEpicFreeGamesApi(
+        @EpicFreeGamesHttp client: OkHttpClient,
+    ): EpicFreeGamesApi = EpicFreeGamesApi(client)
+}

--- a/source-epic-free-games/src/main/kotlin/in/jphe/storyvox/source/epicfreegames/net/EpicFreeGamesApi.kt
+++ b/source-epic-free-games/src/main/kotlin/in/jphe/storyvox/source/epicfreegames/net/EpicFreeGamesApi.kt
@@ -3,16 +3,28 @@ package `in`.jphe.storyvox.source.epicfreegames.net
 import `in`.jphe.storyvox.data.source.model.FictionResult
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import java.io.IOException
 import javax.inject.Inject
 
 /**
- * HTTP client for Epic Free Games. The [request] wrapper is pre-written to satisfy
- * the FictionSourceContractTest: it pins the blocking OkHttp call to
- * Dispatchers.IO (#585) and maps status codes to typed failures. Copy its shape
- * for every endpoint you add — do NOT surface raw HTTP codes or exceptions.
+ * HTTP client for the Epic Games Store "free games promotions" feed (#1493).
+ *
+ * There is a single upstream endpoint —
+ * `store-site-backend-static.ak.epicgames.com/freeGamesPromotions` — an
+ * unofficial-but-long-stable, no-auth JSON document that the Epic storefront's
+ * own "Free Games" widget consumes. We treat it as **fragile vendor JSON**:
+ * every wire field is optional with a default, unknown keys are ignored, and a
+ * malformed body surfaces as a typed [FictionResult.NetworkError] rather than a
+ * thrown exception (see [request]).
+ *
+ * The [request] wrapper is the scaffold's pre-written shape and satisfies the
+ * FictionSourceContractTest: it pins the blocking OkHttp call to
+ * Dispatchers.IO (#585) and maps status codes to typed failures.
  */
 internal open class EpicFreeGamesApi @Inject constructor(
     private val client: OkHttpClient,
@@ -20,6 +32,29 @@ internal open class EpicFreeGamesApi @Inject constructor(
     /** Test seam — `open` so unit tests point this at a MockWebServer without
      *  restructuring call sites (mirrors StandardEbooksApi.baseUrl). */
     internal open val baseUrl: String get() = BASE_URL
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+        coerceInputValues = true
+    }
+
+    /**
+     * `GET /freeGamesPromotions` — the whole promotions document in one shot.
+     * The single Browse/detail/chapter surface all read from this; there is no
+     * per-game detail endpoint to fan out to.
+     */
+    suspend fun fetchPromotions(): FictionResult<PromotionsResponse> =
+        request(PROMOTIONS_PATH) { parsePromotions(it) }
+
+    /**
+     * Parse the promotions document. Hoisted out of the network call so the
+     * mapping unit test can exercise it against a captured fixture without an
+     * OkHttp client. A shape mismatch throws [kotlinx.serialization.SerializationException],
+     * which [request] catches and converts to a typed failure.
+     */
+    internal fun parsePromotions(text: String): PromotionsResponse =
+        json.decodeFromString(text)
 
     /**
      * IO-pinned GET. `parse` turns the response body into your typed model.
@@ -92,6 +127,117 @@ internal open class EpicFreeGamesApi @Inject constructor(
             body.contains("cf-mitigated")
 
     companion object {
-        const val BASE_URL = "https://example.com"
+        const val BASE_URL = "https://store-site-backend-static.ak.epicgames.com"
+
+        /**
+         * The free-games feed. `country`/`allowCountries` scope the promotions
+         * to a storefront (giveaways are region-uniform in practice, but the
+         * price strings and availability windows are localized). US/en-US is a
+         * stable default; a future settings knob could localize this.
+         */
+        const val PROMOTIONS_PATH =
+            "/freeGamesPromotions?locale=en-US&country=US&allowCountries=US"
     }
 }
+
+// ── Wire types ────────────────────────────────────────────────────────────
+//
+// Every field is nullable-with-default: the feed is unofficial and Epic
+// reshapes it without notice. Missing/renamed fields degrade to null and are
+// filtered downstream, never crash the parse.
+
+@Serializable
+internal data class PromotionsResponse(
+    val data: CatalogData = CatalogData(),
+)
+
+@Serializable
+internal data class CatalogData(
+    @SerialName("Catalog") val catalog: Catalog = Catalog(),
+)
+
+@Serializable
+internal data class Catalog(
+    val searchStore: SearchStore = SearchStore(),
+)
+
+@Serializable
+internal data class SearchStore(
+    val elements: List<StoreElement> = emptyList(),
+)
+
+/** One catalog entry — a game or add-on that is currently or soon free, OR
+ *  merely on sale (the feed bundles plain discounts too; the source filters
+ *  those out — see [in.jphe.storyvox.source.epicfreegames.giveaways]). */
+@Serializable
+internal data class StoreElement(
+    val title: String? = null,
+    val id: String? = null,
+    val namespace: String? = null,
+    val description: String? = null,
+    val seller: Seller? = null,
+    val productSlug: String? = null,
+    val urlSlug: String? = null,
+    val keyImages: List<KeyImage> = emptyList(),
+    val price: Price? = null,
+    val promotions: Promotions? = null,
+    val offerMappings: List<PageMapping> = emptyList(),
+    val catalogNs: CatalogNs? = null,
+)
+
+@Serializable
+internal data class Seller(val name: String? = null)
+
+@Serializable
+internal data class KeyImage(val type: String? = null, val url: String? = null)
+
+@Serializable
+internal data class Price(val totalPrice: TotalPrice? = null)
+
+@Serializable
+internal data class TotalPrice(
+    val discountPrice: Long? = null,
+    val originalPrice: Long? = null,
+    val currencyCode: String? = null,
+    val fmtPrice: FmtPrice? = null,
+)
+
+@Serializable
+internal data class FmtPrice(
+    val originalPrice: String? = null,
+    val discountPrice: String? = null,
+)
+
+@Serializable
+internal data class Promotions(
+    val promotionalOffers: List<OfferGroup> = emptyList(),
+    val upcomingPromotionalOffers: List<OfferGroup> = emptyList(),
+)
+
+@Serializable
+internal data class OfferGroup(
+    val promotionalOffers: List<PromotionalOffer> = emptyList(),
+)
+
+@Serializable
+internal data class PromotionalOffer(
+    val startDate: String? = null,
+    val endDate: String? = null,
+    val discountSetting: DiscountSetting? = null,
+)
+
+/**
+ * Epic's `discountPercentage` is the percentage of the price the buyer still
+ * PAYS, not the percentage off: `0` means "pay 0%" → the game is free, `50`
+ * means half price. A giveaway is therefore an offer with
+ * `discountPercentage == 0` — that single test separates the free games from
+ * the plain sales the same feed carries.
+ */
+@Serializable
+internal data class DiscountSetting(val discountPercentage: Int? = null)
+
+@Serializable
+internal data class PageMapping(val pageSlug: String? = null, val pageType: String? = null)
+
+@Serializable
+internal data class CatalogNs(val mappings: List<PageMapping> = emptyList())

--- a/source-epic-free-games/src/main/kotlin/in/jphe/storyvox/source/epicfreegames/net/EpicFreeGamesApi.kt
+++ b/source-epic-free-games/src/main/kotlin/in/jphe/storyvox/source/epicfreegames/net/EpicFreeGamesApi.kt
@@ -1,0 +1,97 @@
+package `in`.jphe.storyvox.source.epicfreegames.net
+
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.IOException
+import javax.inject.Inject
+
+/**
+ * HTTP client for Epic Free Games. The [request] wrapper is pre-written to satisfy
+ * the FictionSourceContractTest: it pins the blocking OkHttp call to
+ * Dispatchers.IO (#585) and maps status codes to typed failures. Copy its shape
+ * for every endpoint you add — do NOT surface raw HTTP codes or exceptions.
+ */
+internal open class EpicFreeGamesApi @Inject constructor(
+    private val client: OkHttpClient,
+) {
+    /** Test seam — `open` so unit tests point this at a MockWebServer without
+     *  restructuring call sites (mirrors StandardEbooksApi.baseUrl). */
+    internal open val baseUrl: String get() = BASE_URL
+
+    /**
+     * IO-pinned GET. `parse` turns the response body into your typed model.
+     * Returns a typed [FictionResult] failure for every non-2xx status — never
+     * throws for an HTTP error.
+     */
+    suspend fun <T> request(path: String, parse: (String) -> T): FictionResult<T> =
+        withContext(Dispatchers.IO) {
+            val url = baseUrl + path
+            try {
+                val req = Request.Builder()
+                    .url(url)
+                    .header("Accept", "application/json")
+                    .get()
+                    .build()
+                client.newCall(req).execute().use { resp ->
+                    when {
+                        resp.code == 404 -> FictionResult.NotFound("Epic Free Games: $path not found")
+                        resp.code == 401 -> FictionResult.AuthRequired("HTTP 401 from $url")
+                        resp.code == 403 -> {
+                            // Cloudflare interstitials arrive as HTTP 403 with challenge
+                            // HTML — the CF sniff MUST precede the auth mapping, or a
+                            // CF-gated 403 misreports as "sign in required" (see
+                            // docs/CONTRIBUTING-SOURCES.md decision table).
+                            val body = resp.body?.string().orEmpty()
+                            if (looksLikeCfChallenge(body)) {
+                                FictionResult.NetworkError(
+                                    "Epic Free Games returned a Cloudflare challenge page — try again later",
+                                    IOException("Cloudflare challenge"),
+                                )
+                            } else {
+                                FictionResult.AuthRequired("HTTP 403 from $url")
+                            }
+                        }
+                        resp.code == 429 -> FictionResult.RateLimited(
+                            retryAfter = null,
+                            message = "Epic Free Games rate limited (HTTP 429)",
+                        )
+                        !resp.isSuccessful -> FictionResult.NetworkError(
+                            "HTTP ${resp.code} from $url",
+                            IOException("HTTP ${resp.code}"),
+                        )
+                        else -> {
+                            val text = resp.body?.string()
+                                ?: return@withContext FictionResult.NetworkError(
+                                    "empty body",
+                                    IOException("empty body"),
+                                )
+                            FictionResult.Success(parse(text))
+                        }
+                    }
+                }
+            } catch (e: IOException) {
+                FictionResult.NetworkError(e.message ?: "fetch failed", e)
+            } catch (e: kotlinx.serialization.SerializationException) {
+                // A throwing parse lambda must stay inside the typed-error
+                // contract — never escape as a raw exception.
+                FictionResult.NetworkError("Epic Free Games returned an unexpected response shape", e)
+            }
+        }
+
+    /**
+     * #1443-family heuristic: does a body look like a Cloudflare challenge
+     * interstitial rather than your API's payload? Keep this arm ahead of
+     * the 401/403 auth mapping (see the request() template above).
+     */
+    private fun looksLikeCfChallenge(body: String): Boolean =
+        body.contains("/cdn-cgi/challenge-platform/") ||
+            body.contains("Just a moment...") ||
+            body.contains("cf-mitigated")
+
+    companion object {
+        const val BASE_URL = "https://example.com"
+    }
+}

--- a/source-epic-free-games/src/test/kotlin/in/jphe/storyvox/source/epicfreegames/EpicFreeGamesContractTest.kt
+++ b/source-epic-free-games/src/test/kotlin/in/jphe/storyvox/source/epicfreegames/EpicFreeGamesContractTest.kt
@@ -6,12 +6,11 @@ import `in`.jphe.storyvox.testkit.source.FictionSourceContractTest
 import okhttp3.OkHttpClient
 
 /**
- * Epic Free Games against the shared contract kit. This FAILS until you wire
- * [EpicFreeGamesSource.popular] (and friends) through [EpicFreeGamesApi.request]:
- * the stub never hits the network, so the "network work leaves the caller
- * thread" and auth/rate-limit checks fail honestly. Replace [happyListBody] /
- * [listPathFragment] with your real list endpoint, make the source talk to the
- * Api, and turn this green. See docs/CONTRIBUTING-SOURCES.md.
+ * Epic Free Games against the shared [FictionSourceContractTest]. The single
+ * `freeGamesPromotions` endpoint is pointed at the kit's MockWebServer via the
+ * [EpicFreeGamesApi.baseUrl] seam; `popular()` -> `fetchPromotions()` hits it,
+ * so the IO-pin / auth / rate-limit / Cloudflare checks all exercise the real
+ * request path.
  */
 class EpicFreeGamesContractTest : FictionSourceContractTest() {
     override fun createSource(client: OkHttpClient, baseUrl: String): FictionSource {
@@ -23,9 +22,12 @@ class EpicFreeGamesContractTest : FictionSourceContractTest() {
         )
     }
 
-    /** Replace with a trimmed real response body from your list endpoint. */
-    override fun happyListBody(): String = "{}"
+    /** A trimmed real `freeGamesPromotions` body — one currently-free game and
+     *  one upcoming freebie (see [EPIC_FIXTURE_BODY]). */
+    override fun happyListBody(): String = EPIC_FIXTURE_BODY
 
-    /** Replace with a path fragment your popular()/list endpoint hits. */
-    override fun listPathFragment(): String = "epic-free-games"
+    /** `/freeGamesPromotions?...` — the one endpoint this source reads. NOTE:
+     *  the scaffold defaults this to the source id; Epic's path does not contain
+     *  the id, so it must be the real path fragment. */
+    override fun listPathFragment(): String = "freeGamesPromotions"
 }

--- a/source-epic-free-games/src/test/kotlin/in/jphe/storyvox/source/epicfreegames/EpicFreeGamesContractTest.kt
+++ b/source-epic-free-games/src/test/kotlin/in/jphe/storyvox/source/epicfreegames/EpicFreeGamesContractTest.kt
@@ -1,0 +1,31 @@
+package `in`.jphe.storyvox.source.epicfreegames
+
+import `in`.jphe.storyvox.data.source.FictionSource
+import `in`.jphe.storyvox.source.epicfreegames.net.EpicFreeGamesApi
+import `in`.jphe.storyvox.testkit.source.FictionSourceContractTest
+import okhttp3.OkHttpClient
+
+/**
+ * Epic Free Games against the shared contract kit. This FAILS until you wire
+ * [EpicFreeGamesSource.popular] (and friends) through [EpicFreeGamesApi.request]:
+ * the stub never hits the network, so the "network work leaves the caller
+ * thread" and auth/rate-limit checks fail honestly. Replace [happyListBody] /
+ * [listPathFragment] with your real list endpoint, make the source talk to the
+ * Api, and turn this green. See docs/CONTRIBUTING-SOURCES.md.
+ */
+class EpicFreeGamesContractTest : FictionSourceContractTest() {
+    override fun createSource(client: OkHttpClient, baseUrl: String): FictionSource {
+        val host = baseUrl.trimEnd('/')
+        return EpicFreeGamesSource(
+            object : EpicFreeGamesApi(client) {
+                override val baseUrl: String get() = host
+            },
+        )
+    }
+
+    /** Replace with a trimmed real response body from your list endpoint. */
+    override fun happyListBody(): String = "{}"
+
+    /** Replace with a path fragment your popular()/list endpoint hits. */
+    override fun listPathFragment(): String = "epic-free-games"
+}

--- a/source-epic-free-games/src/test/kotlin/in/jphe/storyvox/source/epicfreegames/EpicFreeGamesMappingTest.kt
+++ b/source-epic-free-games/src/test/kotlin/in/jphe/storyvox/source/epicfreegames/EpicFreeGamesMappingTest.kt
@@ -1,0 +1,221 @@
+package `in`.jphe.storyvox.source.epicfreegames
+
+import `in`.jphe.storyvox.source.epicfreegames.net.EpicFreeGamesApi
+import okhttp3.OkHttpClient
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure parse + mapping coverage for the Epic Free Games feed. Exercises the
+ * [giveaways] projection and the narration helpers directly off a captured
+ * fixture — no network, no MockWebServer (the contract kit owns the HTTP
+ * behaviours).
+ */
+class EpicFreeGamesMappingTest {
+
+    private val api = EpicFreeGamesApi(OkHttpClient())
+    private fun parse() = giveaways(api.parsePromotions(EPIC_FIXTURE_BODY))
+
+    @Test
+    fun `only actual giveaways survive — plain sales are dropped`() {
+        val list = parse()
+        // Fixture has 4 elements: current-free, upcoming-free, a 20%-off sale,
+        // and a null-promotions entry. Only the two giveaways survive.
+        assertEquals(2, list.size)
+        assertTrue(list.none { it.title.contains("Sale Only") })
+        assertTrue(list.none { it.title.contains("No Promo") })
+    }
+
+    @Test
+    fun `current giveaways sort ahead of upcoming`() {
+        val list = parse()
+        assertTrue("first must be current", list.first().current)
+        assertFalse("last must be upcoming", list.last().current)
+        assertEquals("River City Girls 2", list.first().title)
+        assertEquals("Nova Lands", list.last().title)
+    }
+
+    @Test
+    fun `upcoming free week is picked out of a mix of percentage sales`() {
+        // Nova Lands has 50%/0%/50% upcoming offers; the 0% (free) window must
+        // be the one selected, not the first-listed 50% one.
+        val nova = parse().first { it.title == "Nova Lands" }
+        assertFalse(nova.current)
+        assertEquals("2026-07-09T15:00:00.000Z", nova.startDate)
+        assertEquals("2026-07-16T15:00:00.000Z", nova.endDate)
+    }
+
+    @Test
+    fun `store url prefers a slug and is absolute`() {
+        val rcg = parse().first { it.title == "River City Girls 2" }
+        assertNotNull(rcg.storeUrl)
+        assertTrue(rcg.storeUrl!!.startsWith("https://store.epicgames.com/p/"))
+    }
+
+    @Test
+    fun `element key is stable and falls back off id`() {
+        val rcg = parse().first { it.title == "River City Girls 2" }
+        assertEquals("9bf3d3188d1e498095bc23c0955538d9", rcg.key)
+    }
+
+    @Test
+    fun `date formatting is UTC and deterministic`() {
+        assertEquals("Jul 2, 2026", formatEpicDate("2026-07-02T15:00:00.000Z"))
+        assertNull(formatEpicDate(null))
+        assertNull(formatEpicDate(""))
+        // Unparseable input degrades to the raw string rather than throwing.
+        assertEquals("garbage", formatEpicDate("garbage"))
+    }
+
+    @Test
+    fun `narration reads title, window, price and store link`() {
+        val rcg = parse().first { it.title == "River City Girls 2" }
+        val body = narrateGiveaway(rcg)
+        assertTrue(body.startsWith("River City Girls 2"))
+        assertTrue(body.contains("Free to claim now"))
+        assertTrue(body.contains("from Jul 2, 2026 to Jul 9, 2026"))
+        assertTrue(body.contains("Normally"))
+        assertTrue(body.contains("Published by WayForward"))
+        assertTrue(body.contains("store.epicgames.com/p/"))
+    }
+
+    @Test
+    fun `upcoming chapter title is flagged coming soon`() {
+        val nova = parse().first { it.title == "Nova Lands" }
+        val body = narrateGiveaway(nova)
+        assertTrue(body.contains("Free to claim soon"))
+    }
+
+    @Test
+    fun `empty document parses to no giveaways, never throws`() {
+        val empty = giveaways(api.parsePromotions("""{"data":{"Catalog":{"searchStore":{"elements":[]}}}}"""))
+        assertTrue(empty.isEmpty())
+    }
+
+    @Test
+    fun `unknown and missing fields are tolerated`() {
+        // A totally foreign shape must degrade to empty, not throw — the feed
+        // is unofficial and can reshape without notice.
+        val weird = giveaways(api.parsePromotions("""{"data":{},"unexpected":true}"""))
+        assertTrue(weird.isEmpty())
+    }
+}
+
+/**
+ * A trimmed real `freeGamesPromotions` body:
+ *  - River City Girls 2 — currently free (`promotionalOffers`, 0% pay)
+ *  - Nova Lands — upcoming free (a 0% week bundled among 50% sales)
+ *  - Sale Only Game — a plain 20%-off sale (has promotions, but no 0% offer)
+ *  - No Promo Game — `promotions: null`
+ * The `$` in the localized price strings is escaped for the Kotlin raw string.
+ */
+internal const val EPIC_FIXTURE_BODY: String = """
+{
+  "errors": null,
+  "data": {
+    "Catalog": {
+      "searchStore": {
+        "elements": [
+          {
+            "title": "River City Girls 2",
+            "id": "9bf3d3188d1e498095bc23c0955538d9",
+            "namespace": "973ce75835994a35ab386d56ed2dffa3",
+            "description": "Beat-'em-up sequel — brawl across a sprawling city.",
+            "seller": { "name": "WayForward" },
+            "productSlug": null,
+            "urlSlug": "f6229ed5b32d4e098b930103b6470b49",
+            "keyImages": [
+              { "type": "OfferImageWide", "url": "https://cdn1.epicgames.com/rcg2-wide.png" },
+              { "type": "Thumbnail", "url": "https://cdn1.epicgames.com/rcg2-thumb.png" }
+            ],
+            "price": {
+              "totalPrice": {
+                "discountPrice": 0,
+                "originalPrice": 3999,
+                "fmtPrice": { "originalPrice": "${'$'}39.99" },
+                "currencyCode": "USD"
+              }
+            },
+            "promotions": {
+              "promotionalOffers": [
+                { "promotionalOffers": [
+                  { "startDate": "2026-07-02T15:00:00.000Z", "endDate": "2026-07-09T15:00:00.000Z",
+                    "discountSetting": { "discountType": "PERCENTAGE", "discountPercentage": 0 } }
+                ] }
+              ],
+              "upcomingPromotionalOffers": []
+            },
+            "offerMappings": [ { "pageSlug": "river-city-girls-2-77af3a", "pageType": "productHome" } ],
+            "catalogNs": { "mappings": [ { "pageSlug": "river-city-girls-2-77af3a", "pageType": "productHome" } ] }
+          },
+          {
+            "title": "Nova Lands",
+            "id": "e5da2c017d4d4afab9f4c56525b66100",
+            "namespace": "740ba4a6fbed4062a9c43d52c5996b0b",
+            "description": "Factory-building island management.",
+            "seller": { "name": "Hypetrain Digital" },
+            "productSlug": null,
+            "urlSlug": "acb83bd813054e599598de9e76f6d95d",
+            "keyImages": [
+              { "type": "OfferImageWide", "url": "https://cdn1.epicgames.com/nova-wide.png" }
+            ],
+            "price": {
+              "totalPrice": {
+                "discountPrice": 1999,
+                "originalPrice": 1999,
+                "fmtPrice": { "originalPrice": "${'$'}19.99" },
+                "currencyCode": "USD"
+              }
+            },
+            "promotions": {
+              "promotionalOffers": [],
+              "upcomingPromotionalOffers": [
+                { "promotionalOffers": [
+                  { "startDate": "2026-07-16T15:00:00.000Z", "endDate": "2026-07-30T15:00:00.000Z",
+                    "discountSetting": { "discountType": "PERCENTAGE", "discountPercentage": 50 } },
+                  { "startDate": "2026-07-09T15:00:00.000Z", "endDate": "2026-07-16T15:00:00.000Z",
+                    "discountSetting": { "discountType": "PERCENTAGE", "discountPercentage": 0 } },
+                  { "startDate": "2026-09-03T15:00:00.000Z", "endDate": "2026-09-17T15:00:00.000Z",
+                    "discountSetting": { "discountType": "PERCENTAGE", "discountPercentage": 50 } }
+                ] }
+              ]
+            },
+            "offerMappings": [ { "pageSlug": "nova-lands-4d1788", "pageType": "productHome" } ],
+            "catalogNs": { "mappings": [ { "pageSlug": "nova-lands-4d1788", "pageType": "productHome" } ] }
+          },
+          {
+            "title": "Sale Only Game",
+            "id": "sale0001",
+            "description": "On sale, but never free.",
+            "seller": { "name": "Some Publisher" },
+            "productSlug": "sale-only-game",
+            "price": { "totalPrice": { "discountPrice": 1599, "originalPrice": 1999, "fmtPrice": { "originalPrice": "${'$'}19.99" }, "currencyCode": "USD" } },
+            "promotions": {
+              "promotionalOffers": [
+                { "promotionalOffers": [
+                  { "startDate": "2026-07-02T15:00:00.000Z", "endDate": "2026-07-09T15:00:00.000Z",
+                    "discountSetting": { "discountType": "PERCENTAGE", "discountPercentage": 20 } }
+                ] }
+              ],
+              "upcomingPromotionalOffers": []
+            }
+          },
+          {
+            "title": "No Promo Game",
+            "id": "nopromo1",
+            "description": "Just a catalog entry.",
+            "seller": { "name": "Another Publisher" },
+            "productSlug": "no-promo-game",
+            "price": { "totalPrice": { "discountPrice": 999, "originalPrice": 999, "currencyCode": "USD" } },
+            "promotions": null
+          }
+        ]
+      }
+    }
+  }
+}
+"""


### PR DESCRIPTION
## What & why
Surfaces the **Epic Games Store weekly free-game giveaways** as a listenable source (#1493) — "what's free this week" as narrated items, natural material for the Morning Briefing (#1467) rotation.

Scaffold-built (`scripts/new-source.sh`) + contract-kit verified, same wave as #1492.

### Design
- **Data:** Epic's public no-auth `store-site-backend-static.ak.epicgames.com/freeGamesPromotions` JSON (verified live, HTTP 200). Treated as **fragile vendor JSON** — every wire field nullable-with-default, unknown keys ignored, malformed body → typed `NetworkError`.
- **Reading model:** one fiction *"Epic Free Games"*; each giveaway = one chapter (title, free-claim window, normal price, publisher, store blurb). Current rotation sorts ahead of announced upcoming freebies. `latestUpdates` = current rotation. No auth, no follows, no search (public feed, single rotating fiction).
- **Giveaway filter:** the feed bundles plain % sales alongside actual freebies. An element qualifies only if it carries a promotional offer with `discountPercentage == 0` (Epic's "pay 0%" → free). The free window is picked out of a mix of sale offers.
- **Bonus:** `latestRevisionToken()` returns a cheap current-rotation token so the poll worker detects the weekly flip (Morning Briefing #1467).

## Criteria vs delivered
| Issue criterion | Delivered |
|---|---|
| Public promotions endpoint, no auth | `EpicFreeGamesApi.fetchPromotions()` over the scaffold's IO-pinned `request()` |
| Verify current shape at build time | Probed live; wire types match the real response; trimmed real fixture in tests |
| Fragile-vendor lenient parsing, typed errors | `ignoreUnknownKeys`/`isLenient`/`coerceInputValues`; every field nullable+default; contract kit proves typed failures |
| One fiction, each giveaway a chapter | `EPIC_FICTION_ID` single fiction; `giveaways()` → chapter list |
| free-window dates, current vs upcoming | window formatted (UTC, deterministic); current sorts first, upcoming flagged "(coming soon)" |
| `latestUpdates` = current rotation | ✓ (delegates to the single-fiction page) |
| no auth, no follows | `followsList`/`setFollowed` no-op Success; `supportsFollow=false` |

## Test evidence
- **`EpicFreeGamesContractTest`** (subclasses `FictionSourceContractTest`): IO-pin (#585), 401→AuthRequired, 429→RateLimited, Cloudflare-body→NetworkError, blank-search sanity — all through the real `freeGamesPromotions` request path.
- **`EpicFreeGamesMappingTest`** (9 cases): plain sales dropped, current-before-upcoming ordering, the 0% week picked out of a 50%/0%/50% mix, store-URL building, UTC date formatting + graceful fallback, narration content, empty/foreign-shape documents degrade to empty (never throw).
- Filter logic cross-validated against the live response before writing (see running log).

## Central edits (auto-merge safe)
`settings.gradle.kts` + `app/build.gradle.kts` insert `:source-epic-free-games` alphabetically after `:source-discord` — a distinct anchor line from the four sibling PRs in this wave, so they auto-merge.

## dx: friction
Filed separately (see linked `dx:` issues) — dogfooding the scaffold/kit/guide.

Refs #1493
