### PR TITLE
feat(calendar): device calendar source (CalendarContract) — narrated agenda (#1495)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -673,6 +673,8 @@ dependencies {
     // scaffold today (partner API key + PDTB DRM + per-user OAuth pending);
     // ships the DAISY text parser as the non-gated groundwork.
     implementation(project(":source-bookshare"))
+    // Issue #1495 — device calendar source (CalendarContract, local-provider).
+    implementation(project(":source-calendar"))
     implementation(project(":source-azure"))
     implementation(project(":core-sync"))
     implementation(project(":feature"))

--- a/docs/data-safety-checklist.md
+++ b/docs/data-safety-checklist.md
@@ -64,7 +64,7 @@ Work top-to-bottom through the Console wizard. **Bold = the option to pick.**
 **Mark as Not collected (select nothing):**
 Location (approx/precise) · Financial info · Health & fitness · Messages (SMS/email/other in-app) · Photos & videos · Audio files/voice/music · Files & docs · Calendar · Contacts · App info & performance (crash logs, diagnostics) · Device or other IDs · Web browsing.
 
-> Reasoning carried from §4: OCR camera images + recognized text are processed **on-device** (ML Kit) and never transmitted → Photos/Audio stay **No** despite the CAMERA permission. EPUB/SAF file reads aren't sent anywhere → Files **No**. Discord/Slack/Matrix/Telegram are read via the **user's own credentials direct to the service**; Candela stores nothing → Messages **No**. No analytics/ads/crash SDK → App activity/info, Device IDs all **No**.
+> Reasoning carried from §4: OCR camera images + recognized text are processed **on-device** (ML Kit) and never transmitted → Photos/Audio stay **No** despite the CAMERA permission. EPUB/SAF file reads aren't sent anywhere → Files **No**. Discord/Slack/Matrix/Telegram are read via the **user's own credentials direct to the service**; Candela stores nothing → Messages **No**. Calendar events are read via the on-device `CalendarContract` provider, narrated locally, and never transmitted (no cloud API / OAuth / key) → **Calendar** stays **No** despite the `READ_CALENDAR` permission (#1495) — the same on-device-only basis as the camera. No analytics/ads/crash SDK → App activity/info, Device IDs all **No**.
 
 ### Section C — Data sharing
 Declare **one** sharing relationship:
@@ -117,5 +117,6 @@ user's own account.
 3. Pick the "library state" Play category (App activity → Other UGC vs Other actions) and keep policy + form consistent.
 4. Re-audit this form whenever a new data flow lands (e.g., opt-in crash reporting) — a Data Safety answer that contradicts observed network traffic is a top rejection trigger.
    - ✅ _#1463 (impact sharing) audited:_ no new declaration — user-initiated share-sheet egress to a user-chosen destination, no collector, no identifiers (see the "Impact sharing" note above). Candela originates no network traffic for it, so nothing contradicts the form.
+5. **#1495 (device calendar):** adds the runtime-dangerous `READ_CALENDAR` permission. Calendar events are read via the on-device `CalendarContract` provider and **never transmitted** (no cloud API / OAuth / key), so the mapping is unchanged: **Calendar = Not collected**, on the same on-device-only basis as the camera. No new sharing relationship — Section C is unchanged. privacy.md §2.10 + the walkthrough §IV permission table document the posture; when a Play reviewer sees the new permission, point them at the on-device-only justification.
 
 _Code refs: `core-sync/.../client/InstantClient.kt` (signOut=token revoke), `feature/.../sync/SyncAuthViewModel.kt` (signOut vs purgeRemoteData #1248), `core-sync/.../coordinator/SyncCoordinator.kt` (purgeRemoteData loops all syncers), `core-sync/.../client/HttpInstantBackend.kt` (admin/transact delete), `core-sync/.../di/SyncModule.kt` (8 syncer domains)._

--- a/docs/play-store-walkthrough.html
+++ b/docs/play-store-walkthrough.html
@@ -377,6 +377,7 @@ Candela is built by TechEmpower, a 501(c)(3) nonprofit closing the digital divid
         <tr><td>API keys &amp; tokens <span class="why plain">(Azure / LLM / source logins, incl. Notion &amp; Google&nbsp;Drive OAuth)</span></td><td class="yes">Sync only · <b>E2E&nbsp;encrypted</b></td><td>AES-256-GCM, PBKDF2 600k, passphrase-derived — InstantDB never sees plaintext. Stored locally in Tink-encrypted prefs; excluded from device backup. The Notion OAuth (#1507) and Google&nbsp;Drive OAuth (#1496, <code>drive.file</code> scope) access/refresh tokens ride this same path; content flows user&nbsp;→&nbsp;Notion/Google directly.</td></tr>
         <tr><td>Photos / Camera (OCR)</td><td class="no">No</td><td>ML Kit runs <i>on-device</i>; images + recognized text never leave the phone. No microphone.</td></tr>
         <tr><td>Files &amp; docs <span class="why plain">(EPUB / PDF / ODT)</span></td><td class="no">No</td><td>Read via the Storage Access Framework; never uploaded.</td></tr>
+        <tr><td>Calendar</td><td class="no">No</td><td>Read on-device via <code>CalendarContract</code> and narrated locally (#1495); events never leave the phone. Optional — the source stays empty until you grant <code>READ_CALENDAR</code>.</td></tr>
         <tr><td>Messages</td><td class="no">No</td><td>Discord/Slack/Matrix/Telegram are read with the user's own credentials, directly to those services.</td></tr>
         <tr><td>AI chat text</td><td class="no">No <span class="why plain">(by the app)</span></td><td>Sent only to the user's own LLM provider via their own key — BYOK, user-initiated.</td></tr>
         <tr><td>Location · Contacts · Financial · Health · Device IDs · Ad ID · Crash logs</td><td class="no">No</td><td>Never requested. No analytics, no crash reporter, no ads.</td></tr>
@@ -392,6 +393,7 @@ Candela is built by TechEmpower, a 501(c)(3) nonprofit closing the digital divid
         <tr><td><code>RECEIVE_BOOT_COMPLETED</code></td><td>Home-screen widget redraws after a reboot.</td></tr>
         <tr><td><code>ACCESS_NOTIFICATION_POLICY</code></td><td>Sleep timer can auto-toggle Do Not Disturb.</td></tr>
         <tr><td><code>CAMERA</code> <span class="pill manual">optional</span></td><td>OCR scan-to-read; on-device; gallery-pick fallback if denied.</td></tr>
+        <tr><td><code>READ_CALENDAR</code> <span class="pill manual">optional</span></td><td>Narrate your agenda (Today / Tomorrow / This Week); on-device only, requested on tap, source stays empty if denied.</td></tr>
         <tr><td><i>no storage permission</i></td><td>EPUB/PDF use SAF. No <code>CALL_PHONE</code>, location, microphone, contacts, or ad ID.</td></tr>
       </table></div>
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -13,7 +13,7 @@ description: Candela's privacy policy. Plain-language summary: nothing leaves yo
 > locally; you can delete cloud-synced data via the in-app "Delete cloud
 > data" action.
 
-**Effective date:** 2026-06-26  
+**Effective date:** 2026-07-03  
 **App:** Candela (`org.techempower.candela`)  
 **Publisher:** TechEmpower (501(c)(3) nonprofit, operating Candela)  
 **Maintainer:** JP Hein (`jp@jphein.com`)  
@@ -185,6 +185,23 @@ such a summary, entirely on your terms:
   so a subsequent share reports only the incremental change (never double-counts,
   and never goes negative if you clear app data). That record holds no identity
   and is erased when you clear app data or uninstall.
+
+### 2.10 Calendar (optional)
+
+Candela can read your device calendar and narrate it as an agenda — "My
+Calendar," with Today / Tomorrow / This Week chapters (each event's time,
+title, location, and duration read aloud). It uses Android's on-device
+`CalendarContract` provider, which already aggregates whatever accounts sync
+to your phone (Google, Samsung, Outlook, a local account). **There is no
+calendar cloud API, no OAuth, and no key** — Candela reads the calendar the
+same way your built-in Calendar app does, entirely on-device. Your events are
+**read locally, narrated locally, and never leave your device**; they are
+never uploaded, collected, transmitted, or shared. The `READ_CALENDAR`
+permission is requested **only** when you tap **Grant calendar access** in
+Browse — never at launch — and declining it does not dead-end anything: the
+Calendar source simply stays empty until you choose to grant it. You can
+revoke the permission anytime in Android Settings. The Calendar source is
+read-only: Candela never creates, edits, or deletes calendar events.
 
 ---
 

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -229,6 +229,20 @@ fun BrowseScreen(
         calendarGranted = granted
         if (granted) viewModel.refresh()
     }
+    // Re-check on every resume so a grant/revoke made in Android Settings (i.e.
+    // NOT via the in-app CTA) is reflected without waiting for process death —
+    // the once-initialized `remember` above would otherwise stay stale (#1495
+    // review). The launcher callback covers the in-app path; this covers the
+    // rest, and re-runs the paginator when access flips on.
+    androidx.lifecycle.compose.LifecycleEventEffect(androidx.lifecycle.Lifecycle.Event.ON_RESUME) {
+        val nowGranted = calendarPermissionContext.checkSelfPermission(
+            android.Manifest.permission.READ_CALENDAR,
+        ) == android.content.pm.PackageManager.PERMISSION_GRANTED
+        if (nowGranted != calendarGranted) {
+            calendarGranted = nowGranted
+            if (nowGranted) viewModel.refresh()
+        }
+    }
 
     // #328 — see LibraryScreen.kt; hoist distinctBy out of the grid
     // builder so allocations happen once per state.items change instead
@@ -1202,23 +1216,20 @@ private fun CalendarPermissionEmptyState(onGrant: () -> Unit) {
                 modifier = Modifier.size(48.dp),
             )
             Text(
-                "Read your day aloud",
+                stringResource(R.string.browse_calendar_empty_title),
                 style = MaterialTheme.typography.titleMedium,
                 color = MaterialTheme.colorScheme.onSurface,
                 textAlign = TextAlign.Center,
             )
             Text(
-                "Grant calendar access and Candela narrates your agenda — today, " +
-                    "tomorrow, and the week ahead. Your events are read on your device " +
-                    "only and never leave the phone. You can revoke access anytime in " +
-                    "Android Settings.",
+                stringResource(R.string.browse_calendar_empty_body),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 textAlign = TextAlign.Center,
             )
             Spacer(Modifier.height(spacing.md))
             BrassButton(
-                label = "Grant calendar access",
+                label = stringResource(R.string.browse_calendar_grant_cta),
                 onClick = onGrant,
                 variant = BrassButtonVariant.Primary,
             )

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.GridView
 import androidx.compose.material.icons.filled.Search
@@ -208,6 +209,26 @@ fun BrowseScreen(
     /** Issue #1507 — Notion connect/manage sheet, FAB- and empty-state-
      *  launched, visible only when sourceKey=NotionPat. */
     var showNotionManageSheet by remember { mutableStateOf(false) }
+
+    // Issue #1495 — device-calendar permission gate. READ_CALENDAR is a
+    // runtime-dangerous permission requested ONLY on an explicit tap in the
+    // Calendar empty state below — never at launch, never nagging. The grant
+    // state drives whether the rationale CTA shows; a fresh grant re-runs the
+    // paginator so "My Calendar" appears immediately.
+    val calendarPermissionContext = androidx.compose.ui.platform.LocalContext.current
+    var calendarGranted by remember {
+        mutableStateOf(
+            calendarPermissionContext.checkSelfPermission(
+                android.Manifest.permission.READ_CALENDAR,
+            ) == android.content.pm.PackageManager.PERMISSION_GRANTED,
+        )
+    }
+    val calendarPermissionLauncher = androidx.activity.compose.rememberLauncherForActivityResult(
+        contract = androidx.activity.result.contract.ActivityResultContracts.RequestPermission(),
+    ) { granted ->
+        calendarGranted = granted
+        if (granted) viewModel.refresh()
+    }
 
     // #328 — see LibraryScreen.kt; hoist distinctBy out of the grid
     // builder so allocations happen once per state.items change instead
@@ -520,6 +541,23 @@ fun BrowseScreen(
                         "a fiction storyvox can read to you. Syllabi, papers, " +
                         "manuals, forms. Zero network, your files stay on your device.",
                     onPick = viewModel::setPdfFolderUri,
+                )
+            // Issue #1495 — device-calendar permission gate. The Calendar chip
+            // lands here until READ_CALENDAR is granted: the source returns an
+            // empty page (not a failure) precisely so this rationale CTA shows
+            // instead of an error banner (the RSS/Notion/Local precedent). The
+            // `!calendarGranted` guard suppresses a one-frame CTA flash after a
+            // grant, before refresh() repopulates the grid with "My Calendar".
+            state.sourceId == "calendar" &&
+                state.tab != BrowseTab.Search &&
+                state.items.isEmpty() &&
+                !state.isLoading &&
+                state.error == null &&
+                !calendarGranted ->
+                CalendarPermissionEmptyState(
+                    onGrant = {
+                        calendarPermissionLauncher.launch(android.Manifest.permission.READ_CALENDAR)
+                    },
                 )
             // Issue #673 — Readability backend is the always-on last-resort
             // URL matcher; it has no listings of its own. Pre-fix, the chip's
@@ -1131,6 +1169,57 @@ private fun NotionConnectEmptyState(onConnect: () -> Unit) {
             BrassButton(
                 label = "Connect Notion",
                 onClick = onConnect,
+                variant = BrassButtonVariant.Primary,
+            )
+        }
+    }
+}
+
+/**
+ * Issue #1495 — permission-gate empty state for the device-calendar source.
+ *
+ * The Calendar chip is reachable before `READ_CALENDAR` is granted (so the
+ * feature is discoverable); an ungranted chip lands here. This is the app's
+ * trust surface for a dangerous permission, so the copy is explicit about the
+ * privacy posture — read on-device, never transmitted, revocable — and the
+ * grant is *only* requested when the user taps the button. Declining doesn't
+ * dead-end anything: the source simply stays empty until the user chooses to
+ * grant, mirroring the never-nagging camera/OCR flow.
+ */
+@Composable
+private fun CalendarPermissionEmptyState(onGrant: () -> Unit) {
+    val spacing = LocalSpacing.current
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(spacing.sm),
+            modifier = Modifier.padding(horizontal = spacing.xl),
+        ) {
+            Icon(
+                imageVector = Icons.Filled.CalendarMonth,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(48.dp),
+            )
+            Text(
+                "Read your day aloud",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                textAlign = TextAlign.Center,
+            )
+            Text(
+                "Grant calendar access and Candela narrates your agenda — today, " +
+                    "tomorrow, and the week ahead. Your events are read on your device " +
+                    "only and never leave the phone. You can revoke access anytime in " +
+                    "Android Settings.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(Modifier.height(spacing.md))
+            BrassButton(
+                label = "Grant calendar access",
+                onClick = onGrant,
                 variant = BrassButtonVariant.Primary,
             )
         }

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -12,6 +12,10 @@
     <string name="browse_mempalace_wing_chip">Wing: %1$s</string>
     <!-- Issue #782 — realm-vocabulary footer when the Browse grid runs out of pages. -->
     <string name="browse_end_of_list">You\'ve reached the edge of the realm.</string>
+    <!-- #1495 — device-calendar permission-gate empty state -->
+    <string name="browse_calendar_empty_title">Read your day aloud</string>
+    <string name="browse_calendar_empty_body">Grant calendar access and Candela narrates your agenda — today, tomorrow, and the week ahead. Your events are read on your device only and never leave the phone. You can revoke access anytime in Android Settings.</string>
+    <string name="browse_calendar_grant_cta">Grant calendar access</string>
     <string name="filter_tag_search_hint">Search tags…</string>
 
     <!-- Source carousel actions -->

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -127,6 +127,9 @@ include(":source-palace")
 // DAISY text parser + a guarded FictionSource scaffold; functional
 // integration is partnership/DRM-gated (see the #1002 research comment).
 include(":source-bookshare")
+// Issue #1495 — device calendar source (CalendarContract). Local-provider,
+// zero-network; narrates your on-device agenda (Today / Tomorrow / This Week).
+include(":source-calendar")
 include(":core-sync")
 include(":feature")
 // Issue #409 — Baseline Profile producer module. Pure test APK

--- a/source-calendar/build.gradle.kts
+++ b/source-calendar/build.gradle.kts
@@ -1,0 +1,44 @@
+plugins {
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.hilt)
+}
+
+android {
+    namespace = "in.jphe.storyvox.source.calendar"
+    compileSdk = 37
+
+    defaultConfig {
+        minSdk = 26
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+    }
+}
+
+dependencies {
+    implementation(project(":core-data"))
+    implementation(libs.kotlinx.coroutines.android)
+
+    implementation(libs.hilt.android)
+    ksp(libs.hilt.compiler)
+
+    // #1495 — @SourcePlugin -> KSP emits BOTH the SourcePluginDescriptor
+    // @IntoSet binding AND the Map<String, FictionSource> @IntoMap binding
+    // (#1371). No hand DI module for the source itself. This is a
+    // local-provider source (Android CalendarContract, zero network), so it
+    // ships no okhttp/serialization deps and does NOT use the HTTP contract
+    // kit — same posture as :source-ocr / :source-epub.
+    ksp(project(":core-plugin-ksp"))
+
+    testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
+}

--- a/source-calendar/src/main/AndroidManifest.xml
+++ b/source-calendar/src/main/AndroidManifest.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <!-- #1495 — device calendar source. READ_CALENDAR is a runtime-dangerous
+         permission requested on-demand (Browse → Calendar → "Grant calendar
+         access"), never at launch. Calendar data is read via the on-device
+         CalendarContract provider, narrated locally, and NEVER transmitted off
+         the device — the same on-device-only posture as the CAMERA/OCR flow.
+         Optional: denied → the source simply lists nothing. -->
+    <uses-permission android:name="android.permission.READ_CALENDAR" />
+
+</manifest>

--- a/source-calendar/src/main/kotlin/in/jphe/storyvox/source/calendar/CalendarAgenda.kt
+++ b/source-calendar/src/main/kotlin/in/jphe/storyvox/source/calendar/CalendarAgenda.kt
@@ -65,12 +65,18 @@ object CalendarAgenda {
         val weekStart = today.plusDays(2)
         val weekEndExclusive = today.plusDays(2 + WEEK_TAIL_DAYS)
 
-        val byDay = events.groupBy { dateOf(it, zone) }
-
-        val todayEvents = byDay[today].orEmpty().sortedBy { it.startUtcMillis }
-        val tomorrowEvents = byDay[tomorrow].orEmpty().sortedBy { it.startUtcMillis }
+        // Bucket by time-range OVERLAP, not by start date: an event that began
+        // before a day but runs into it (an overnight event) still belongs to
+        // that day's agenda. Start-only grouping silently dropped it (#1495
+        // review). `tomorrow`'s window is the single day [tomorrow, weekStart).
+        val todayEvents = events
+            .filter { overlapsWindow(it, today, tomorrow, zone) }
+            .sortedBy { it.startUtcMillis }
+        val tomorrowEvents = events
+            .filter { overlapsWindow(it, tomorrow, weekStart, zone) }
+            .sortedBy { it.startUtcMillis }
         val weekEvents = events
-            .filter { val d = dateOf(it, zone); !d.isBefore(weekStart) && d.isBefore(weekEndExclusive) }
+            .filter { overlapsWindow(it, weekStart, weekEndExclusive, zone) }
             .sortedBy { it.startUtcMillis }
 
         return listOf(
@@ -169,6 +175,29 @@ object CalendarAgenda {
 
     private fun today(nowMillis: Long, zone: ZoneId): LocalDate =
         Instant.ofEpochMilli(nowMillis).atZone(zone).toLocalDate()
+
+    /**
+     * Does the event's time range overlap the half-open date window
+     * `[fromDate, toDateExclusive)`? Overlap (`aStart < bEnd && aEnd > bStart`),
+     * not start-membership — this is what keeps an overnight event on each day
+     * it spans. All-day events are compared as UTC dates (they're stored as UTC
+     * midnight); timed events as instants in the device [zone].
+     */
+    private fun overlapsWindow(
+        e: CalendarEvent,
+        fromDate: LocalDate,
+        toDateExclusive: LocalDate,
+        zone: ZoneId,
+    ): Boolean = if (e.allDay) {
+        val startDate = Instant.ofEpochMilli(e.startUtcMillis).atZone(ZoneOffset.UTC).toLocalDate()
+        // Provider stores the all-day END as exclusive UTC midnight past the last day.
+        val endDateExclusive = Instant.ofEpochMilli(e.endUtcMillis).atZone(ZoneOffset.UTC).toLocalDate()
+        startDate.isBefore(toDateExclusive) && endDateExclusive.isAfter(fromDate)
+    } else {
+        val fromMillis = fromDate.atStartOfDay(zone).toInstant().toEpochMilli()
+        val toMillis = toDateExclusive.atStartOfDay(zone).toInstant().toEpochMilli()
+        e.startUtcMillis < toMillis && e.endUtcMillis > fromMillis
+    }
 
     /**
      * The calendar date an event falls on. All-day events are stored as UTC

--- a/source-calendar/src/main/kotlin/in/jphe/storyvox/source/calendar/CalendarAgenda.kt
+++ b/source-calendar/src/main/kotlin/in/jphe/storyvox/source/calendar/CalendarAgenda.kt
@@ -1,0 +1,201 @@
+package `in`.jphe.storyvox.source.calendar
+
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.time.format.TextStyle
+import java.util.Locale
+
+/**
+ * Pure agenda logic for the device-calendar source (#1495): bucket a flat list
+ * of [CalendarEvent] instances into the Today / Tomorrow / This Week chapters
+ * and render each chapter's narration text.
+ *
+ * Deliberately Android-free and clock-free — every entry point takes `nowMillis`
+ * + `zone` explicitly — so it's exhaustively unit-testable with fixed inputs
+ * (see `CalendarAgendaTest`). [CalendarSource] is the only thing that supplies
+ * the real wall clock / device zone.
+ *
+ * Reading model (from the issue): "My Calendar" is one fiction; these three
+ * chapters are its body. All-day events are summarised first in each chapter,
+ * then timed events in chronological order — time, title, location, duration.
+ */
+object CalendarAgenda {
+
+    /** How many days past *tomorrow* the "This Week" chapter looks ahead. The
+     *  query window is [today 00:00, today 00:00 + (2 + [WEEK_TAIL_DAYS]) days). */
+    private const val WEEK_TAIL_DAYS = 5L
+
+    /** Stable per-chapter discriminator. */
+    enum class Bucket(val key: String, val title: String) {
+        TODAY("today", "Today"),
+        TOMORROW("tomorrow", "Tomorrow"),
+        WEEK("week", "This Week"),
+    }
+
+    /** A rendered chapter: display [title], narration [plain] text (for TTS),
+     *  and [html] (for the reader view). [eventCount] drives the fiction summary. */
+    data class Chapter(
+        val bucket: Bucket,
+        val title: String,
+        val plain: String,
+        val html: String,
+        val eventCount: Int,
+    )
+
+    /**
+     * The single ContentResolver query window that covers all three chapters:
+     * from the start of today (device zone) through the end of the look-ahead
+     * week, as epoch-UTC millis. One query, then bucket in memory.
+     */
+    fun queryWindowUtcMillis(nowMillis: Long, zone: ZoneId): LongRange {
+        val today = today(nowMillis, zone)
+        val begin = today.atStartOfDay(zone).toInstant().toEpochMilli()
+        val end = today.plusDays(2 + WEEK_TAIL_DAYS).atStartOfDay(zone).toInstant().toEpochMilli()
+        return begin until end
+    }
+
+    /** Build all three chapters. Always returns exactly three, in reading order,
+     *  even when empty — the fiction's shape is stable day to day. */
+    fun chapters(events: List<CalendarEvent>, nowMillis: Long, zone: ZoneId): List<Chapter> {
+        val today = today(nowMillis, zone)
+        val tomorrow = today.plusDays(1)
+        val weekStart = today.plusDays(2)
+        val weekEndExclusive = today.plusDays(2 + WEEK_TAIL_DAYS)
+
+        val byDay = events.groupBy { dateOf(it, zone) }
+
+        val todayEvents = byDay[today].orEmpty().sortedBy { it.startUtcMillis }
+        val tomorrowEvents = byDay[tomorrow].orEmpty().sortedBy { it.startUtcMillis }
+        val weekEvents = events
+            .filter { val d = dateOf(it, zone); !d.isBefore(weekStart) && d.isBefore(weekEndExclusive) }
+            .sortedBy { it.startUtcMillis }
+
+        return listOf(
+            renderChapter(Bucket.TODAY, dayHeadline("Today", today), todayEvents, zone, includeWeekday = false),
+            renderChapter(Bucket.TOMORROW, dayHeadline("Tomorrow", tomorrow), tomorrowEvents, zone, includeWeekday = false),
+            renderChapter(Bucket.WEEK, "The rest of your week", weekEvents, zone, includeWeekday = true),
+        )
+    }
+
+    // ─── rendering ──────────────────────────────────────────────────────────
+
+    private fun renderChapter(
+        bucket: Bucket,
+        headline: String,
+        events: List<CalendarEvent>,
+        zone: ZoneId,
+        includeWeekday: Boolean,
+    ): Chapter {
+        val allDay = events.filter { it.allDay }
+        val timed = events.filter { !it.allDay }
+
+        val plain = StringBuilder()
+        val html = StringBuilder()
+
+        plain.appendLine(headline)
+        html.append("<p><strong>").append(escape(headline)).append("</strong></p>\n")
+
+        if (events.isEmpty()) {
+            val empty = emptyLine(bucket)
+            plain.appendLine().appendLine(empty)
+            html.append("<p>").append(escape(empty)).append("</p>\n")
+            return Chapter(bucket, bucket.title, plain.toString().trim(), html.toString().trim(), 0)
+        }
+
+        val count = events.size
+        val summary = "$count ${if (count == 1) "event" else "events"}."
+        plain.appendLine().appendLine(summary)
+        html.append("<p>").append(escape(summary)).append("</p>\n")
+
+        // All-day events first, summarised.
+        allDay.forEach { e ->
+            val line = allDayLine(e, zone, includeWeekday)
+            plain.appendLine().appendLine(line)
+            html.append("<p>").append(escape(line)).append("</p>\n")
+        }
+        // Then timed events, chronological.
+        timed.forEach { e ->
+            val line = timedLine(e, zone, includeWeekday)
+            plain.appendLine().appendLine(line)
+            html.append("<p>").append(escape(line)).append("</p>\n")
+        }
+
+        return Chapter(bucket, bucket.title, plain.toString().trim(), html.toString().trim(), count)
+    }
+
+    private fun emptyLine(bucket: Bucket): String = when (bucket) {
+        Bucket.TODAY -> "Nothing on your calendar today."
+        Bucket.TOMORROW -> "Nothing scheduled for tomorrow."
+        Bucket.WEEK -> "The rest of your week is clear."
+    }
+
+    private fun allDayLine(e: CalendarEvent, zone: ZoneId, includeWeekday: Boolean): String {
+        val prefix = if (includeWeekday) "${weekday(dateOf(e, zone))}, all day" else "All day"
+        return buildString {
+            append(prefix).append(": ").append(titleOf(e))
+            e.location?.takeIf { it.isNotBlank() }?.let { append(", at ").append(it.trim()) }
+            append(".")
+        }
+    }
+
+    private fun timedLine(e: CalendarEvent, zone: ZoneId, includeWeekday: Boolean): String {
+        val start = Instant.ofEpochMilli(e.startUtcMillis).atZone(zone)
+        val time = start.format(TIME_FMT)
+        val prefix = if (includeWeekday) "${weekday(start.toLocalDate())}, $time" else time
+        return buildString {
+            append(prefix).append(" — ").append(titleOf(e))
+            e.location?.takeIf { it.isNotBlank() }?.let { append(", at ").append(it.trim()) }
+            durationPhrase(e)?.let { append(". ").append(it) }
+            append(".")
+        }
+    }
+
+    private fun durationPhrase(e: CalendarEvent): String? {
+        val minutes = ((e.endUtcMillis - e.startUtcMillis) / 60_000L)
+        if (minutes <= 0) return null
+        val h = minutes / 60
+        val m = minutes % 60
+        return when {
+            h == 0L -> "${m} ${plural(m, "minute")}"
+            m == 0L -> "${h} ${plural(h, "hour")}"
+            else -> "${h} ${plural(h, "hour")} ${m} ${plural(m, "minute")}"
+        }
+    }
+
+    // ─── helpers ──────────────────────────────────────────────────────────
+
+    private fun today(nowMillis: Long, zone: ZoneId): LocalDate =
+        Instant.ofEpochMilli(nowMillis).atZone(zone).toLocalDate()
+
+    /**
+     * The calendar date an event falls on. All-day events are stored as UTC
+     * midnight by the provider, so their date is read in UTC; timed events use
+     * the device zone.
+     */
+    private fun dateOf(e: CalendarEvent, zone: ZoneId): LocalDate =
+        if (e.allDay) {
+            Instant.ofEpochMilli(e.startUtcMillis).atZone(ZoneOffset.UTC).toLocalDate()
+        } else {
+            Instant.ofEpochMilli(e.startUtcMillis).atZone(zone).toLocalDate()
+        }
+
+    private fun dayHeadline(label: String, date: LocalDate): String =
+        "$label, ${weekday(date)}, ${date.format(DATE_FMT)}"
+
+    private fun weekday(date: LocalDate): String =
+        date.dayOfWeek.getDisplayName(TextStyle.FULL, Locale.getDefault())
+
+    private fun titleOf(e: CalendarEvent): String =
+        e.title.trim().ifBlank { "Untitled event" }
+
+    private fun plural(n: Long, word: String): String = if (n == 1L) word else "${word}s"
+
+    private fun escape(s: String): String =
+        s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+    private val TIME_FMT: DateTimeFormatter = DateTimeFormatter.ofPattern("h:mm a", Locale.getDefault())
+    private val DATE_FMT: DateTimeFormatter = DateTimeFormatter.ofPattern("MMMM d", Locale.getDefault())
+}

--- a/source-calendar/src/main/kotlin/in/jphe/storyvox/source/calendar/CalendarModels.kt
+++ b/source-calendar/src/main/kotlin/in/jphe/storyvox/source/calendar/CalendarModels.kt
@@ -1,0 +1,28 @@
+package `in`.jphe.storyvox.source.calendar
+
+/**
+ * One resolved calendar event *instance* (#1495).
+ *
+ * A recurring event expands into one [CalendarEvent] per occurrence — this is
+ * what [`CalendarContract.Instances`][android.provider.CalendarContract.Instances]
+ * hands back, and it's exactly what an agenda reading wants ("standup at 10,
+ * again tomorrow at 10"), so the source never has to expand RRULEs itself.
+ *
+ * Pure data — no Android types — so the whole agenda-building + narration layer
+ * ([CalendarAgenda]) is unit-testable on the JVM with hand-built fixtures.
+ *
+ * @property startUtcMillis instance start, epoch-UTC millis. For timed events
+ *  this is a real UTC instant; for [allDay] events the CalendarProvider stores
+ *  it as UTC midnight of the event's date — [CalendarAgenda] reads all-day
+ *  times in UTC to recover the intended calendar date (reading them in the
+ *  device zone would shift the day for anyone west of UTC — a classic bug).
+ */
+data class CalendarEvent(
+    val id: Long,
+    val title: String,
+    val startUtcMillis: Long,
+    val endUtcMillis: Long,
+    val allDay: Boolean,
+    val location: String?,
+    val calendarName: String?,
+)

--- a/source-calendar/src/main/kotlin/in/jphe/storyvox/source/calendar/CalendarReader.kt
+++ b/source-calendar/src/main/kotlin/in/jphe/storyvox/source/calendar/CalendarReader.kt
@@ -1,0 +1,25 @@
+package `in`.jphe.storyvox.source.calendar
+
+/**
+ * Read-only seam over the device's calendar (#1495).
+ *
+ * Split out from [CalendarSource] so the source's chaptering logic is testable
+ * with a hand-built fake — the real impl ([DeviceCalendarReader]) touches
+ * `CalendarContract` and needs a `Context`, which a JVM unit test can't supply.
+ * The interface is intentionally tiny: permission state + a windowed instance
+ * query. Everything else (bucketing, narration) is pure [CalendarAgenda].
+ */
+interface CalendarReader {
+
+    /** True when `READ_CALENDAR` is currently granted. Cheap; call before every
+     *  read so a mid-session revoke degrades gracefully to "empty". */
+    fun hasPermission(): Boolean
+
+    /**
+     * All event instances overlapping `[beginUtcMillis, endUtcMillis)`, across
+     * every calendar synced to the device, sorted by start. Returns an empty
+     * list — never throws — when the permission is absent or the provider is
+     * unavailable, so callers treat "no access" and "no events" identically.
+     */
+    suspend fun events(beginUtcMillis: Long, endUtcMillis: Long): List<CalendarEvent>
+}

--- a/source-calendar/src/main/kotlin/in/jphe/storyvox/source/calendar/CalendarSource.kt
+++ b/source-calendar/src/main/kotlin/in/jphe/storyvox/source/calendar/CalendarSource.kt
@@ -1,0 +1,196 @@
+package `in`.jphe.storyvox.source.calendar
+
+import `in`.jphe.storyvox.data.source.FictionSource
+import `in`.jphe.storyvox.data.source.model.ChapterContent
+import `in`.jphe.storyvox.data.source.model.ChapterInfo
+import `in`.jphe.storyvox.data.source.model.FictionDetail
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import `in`.jphe.storyvox.data.source.model.FictionStatus
+import `in`.jphe.storyvox.data.source.model.FictionSummary
+import `in`.jphe.storyvox.data.source.model.ListPage
+import `in`.jphe.storyvox.data.source.model.SearchQuery
+import `in`.jphe.storyvox.data.source.plugin.SourceCategory
+import `in`.jphe.storyvox.data.source.plugin.SourcePlugin
+import java.time.Instant
+import java.time.ZoneId
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * #1495 — the device calendar as a narratable fiction.
+ *
+ * Reads whatever the phone already syncs (Google / Samsung / Outlook / local)
+ * through the on-device [CalendarReader] — **zero network, zero cloud API, no
+ * keys**; the data is narrated locally and never leaves the device (privacy.md
+ * §2.9). Same local-provider posture as `:source-ocr` / `:source-epub`, so it
+ * skips the HTTP contract kit.
+ *
+ * ## Reading model
+ * Exactly one fiction, "My Calendar" ([FICTION_ID]), with three fixed chapters —
+ * **Today / Tomorrow / This Week** — each narrating its events (time, title,
+ * location, duration; all-day events summarised first). The chapter bodies are
+ * computed live from the current day, so a re-open always reads the current
+ * agenda; [latestRevisionToken] mints a per-day token so the poll worker
+ * refreshes when the date rolls over.
+ *
+ * ## Permission gate (never nagging)
+ * `READ_CALENDAR` is requested only on an explicit Browse tap, never at launch.
+ * Until it's granted the list calls return an **empty** page (not a hard
+ * failure) — [`RealBrowsePaginator`][in.jphe.storyvox.feature.browse] maps any
+ * failure to an error banner, but an empty page lets Browse render the
+ * "Grant calendar access" rationale CTA instead (the `AnonymousNotionDelegate`
+ * precedent). Detail/chapter reads for a stale entry answer `AuthRequired`.
+ */
+@SourcePlugin(
+    id = "calendar",
+    displayName = "Calendar",
+    defaultEnabled = false,
+    category = SourceCategory.Other,
+    supportsFollow = false,
+    supportsSearch = false,
+    description = "Your device calendar, read aloud · on-device · zero-network",
+    sourceUrl = "",
+    chipLabel = "Calendar",
+    iconName = "CalendarMonth",
+)
+@Singleton
+internal class CalendarSource(
+    private val reader: CalendarReader,
+    private val nowMillis: () -> Long,
+    private val zone: () -> ZoneId,
+) : FictionSource {
+
+    @Inject
+    constructor(reader: CalendarReader) : this(
+        reader = reader,
+        nowMillis = System::currentTimeMillis,
+        zone = ZoneId::systemDefault,
+    )
+
+    override val id: String = "calendar"
+    override val displayName: String = "Calendar"
+
+    // ─── browse ────────────────────────────────────────────────────────────
+    //
+    // One fiction when access is granted, nothing when it isn't. Returning an
+    // empty page (rather than AuthRequired) is deliberate: it routes Browse to
+    // the "Grant calendar access" empty-state CTA instead of an error banner.
+
+    override suspend fun popular(page: Int): FictionResult<ListPage<FictionSummary>> =
+        calendarListing()
+
+    override suspend fun latestUpdates(page: Int): FictionResult<ListPage<FictionSummary>> =
+        calendarListing()
+
+    override suspend fun byGenre(genre: String, page: Int): FictionResult<ListPage<FictionSummary>> =
+        FictionResult.Success(ListPage(items = emptyList(), page = 1, hasNext = false))
+
+    override suspend fun search(query: SearchQuery): FictionResult<ListPage<FictionSummary>> =
+        // No meaningful search over a single agenda fiction (supportsSearch=false
+        // hides the tab); mirror popular() so a stray call still behaves.
+        calendarListing()
+
+    private fun calendarListing(): FictionResult<ListPage<FictionSummary>> {
+        val items = if (reader.hasPermission()) listOf(summary()) else emptyList()
+        return FictionResult.Success(ListPage(items = items, page = 1, hasNext = false))
+    }
+
+    // ─── detail ────────────────────────────────────────────────────────────
+
+    override suspend fun fictionDetail(fictionId: String): FictionResult<FictionDetail> {
+        if (fictionId != FICTION_ID) return FictionResult.NotFound("Unknown calendar fiction: $fictionId")
+        if (!reader.hasPermission()) {
+            return FictionResult.AuthRequired("Calendar access is off — grant it in Browse to read your agenda.")
+        }
+        val chapters = buildChapters().mapIndexed { index, ch ->
+            ChapterInfo(
+                id = chapterId(ch.bucket.key),
+                sourceChapterId = ch.bucket.key,
+                index = index,
+                title = ch.title,
+                wordCount = wordCount(ch.plain),
+            )
+        }
+        return FictionResult.Success(FictionDetail(summary = summary(), chapters = chapters))
+    }
+
+    override suspend fun chapter(
+        fictionId: String,
+        chapterId: String,
+    ): FictionResult<ChapterContent> {
+        if (fictionId != FICTION_ID) return FictionResult.NotFound("Unknown calendar fiction: $fictionId")
+        if (!reader.hasPermission()) {
+            return FictionResult.AuthRequired("Calendar access is off — grant it in Browse to read your agenda.")
+        }
+        val chapters = buildChapters()
+        val (index, ch) = chapters.withIndex()
+            .firstOrNull { chapterId(it.value.bucket.key) == chapterId }
+            ?: return FictionResult.NotFound("Unknown calendar chapter: $chapterId")
+
+        return FictionResult.Success(
+            ChapterContent(
+                info = ChapterInfo(
+                    id = chapterId,
+                    sourceChapterId = ch.bucket.key,
+                    index = index,
+                    title = ch.title,
+                    wordCount = wordCount(ch.plain),
+                ),
+                htmlBody = ch.html,
+                plainBody = ch.plain,
+            ),
+        )
+    }
+
+    // ─── auth-gated (calendar has no follow concept) ─────────────────────────
+
+    override suspend fun followsList(page: Int): FictionResult<ListPage<FictionSummary>> =
+        FictionResult.Success(ListPage(items = emptyList(), page = 1, hasNext = false))
+
+    override suspend fun setFollowed(fictionId: String, followed: Boolean): FictionResult<Unit> =
+        FictionResult.Success(Unit)
+
+    override suspend fun genres(): FictionResult<List<String>> =
+        FictionResult.Success(emptyList())
+
+    // ─── polling: refresh once per day ───────────────────────────────────────
+
+    override suspend fun latestRevisionToken(fictionId: String): FictionResult<String?> {
+        if (fictionId != FICTION_ID) return FictionResult.Success(null)
+        // Date-in-zone token: identical all day, changes at local midnight — the
+        // poll worker re-fetches the agenda exactly once per day.
+        val date = Instant.ofEpochMilli(nowMillis()).atZone(zone()).toLocalDate()
+        return FictionResult.Success(date.toString())
+    }
+
+    // ─── helpers ─────────────────────────────────────────────────────────────
+
+    private suspend fun buildChapters(): List<CalendarAgenda.Chapter> {
+        val now = nowMillis()
+        val z = zone()
+        val window = CalendarAgenda.queryWindowUtcMillis(now, z)
+        val events = reader.events(window.first, window.last + 1)
+        return CalendarAgenda.chapters(events, now, z)
+    }
+
+    private fun summary(): FictionSummary = FictionSummary(
+        id = FICTION_ID,
+        sourceId = id,
+        title = "My Calendar",
+        author = "",
+        description = "Your agenda, read aloud — today, tomorrow, and the week ahead. " +
+            "On your device only; nothing leaves the phone.",
+        status = FictionStatus.ONGOING, // an ever-updating agenda, never "complete"
+        chapterCount = 3,
+    )
+
+    private fun chapterId(bucketKey: String): String = "$FICTION_ID::$bucketKey"
+
+    private fun wordCount(text: String): Int =
+        text.split(Regex("\\s+")).count { it.isNotBlank() }
+
+    companion object {
+        /** The single, stable fiction id this source exposes. */
+        const val FICTION_ID = "device-calendar"
+    }
+}

--- a/source-calendar/src/main/kotlin/in/jphe/storyvox/source/calendar/CalendarSource.kt
+++ b/source-calendar/src/main/kotlin/in/jphe/storyvox/source/calendar/CalendarSource.kt
@@ -187,10 +187,13 @@ internal class CalendarSource(
     private fun chapterId(bucketKey: String): String = "$FICTION_ID::$bucketKey"
 
     private fun wordCount(text: String): Int =
-        text.split(Regex("\\s+")).count { it.isNotBlank() }
+        text.split(WORD_SPLIT).count { it.isNotBlank() }
 
     companion object {
         /** The single, stable fiction id this source exposes. */
         const val FICTION_ID = "device-calendar"
+
+        /** Compiled once — splits on runs of whitespace for the word count. */
+        private val WORD_SPLIT = Regex("\\s+")
     }
 }

--- a/source-calendar/src/main/kotlin/in/jphe/storyvox/source/calendar/DeviceCalendarReader.kt
+++ b/source-calendar/src/main/kotlin/in/jphe/storyvox/source/calendar/DeviceCalendarReader.kt
@@ -1,0 +1,95 @@
+package `in`.jphe.storyvox.source.calendar
+
+import android.Manifest
+import android.content.ContentUris
+import android.content.Context
+import android.content.pm.PackageManager
+import android.provider.CalendarContract
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * [CalendarReader] backed by the on-device [CalendarContract] provider (#1495).
+ *
+ * Zero network: this reads whatever the *phone* already syncs (Google, Samsung,
+ * Outlook, local accounts). The data is narrated locally and never leaves the
+ * device — see privacy.md §2.9 / the Data-Safety checklist. Every read is pinned
+ * to [Dispatchers.IO] (a ContentResolver query is blocking IO) and every failure
+ * — missing permission, revoked mid-flight, dead provider — collapses to an
+ * empty list, so the source degrades to "nothing to read" rather than crashing.
+ */
+@Singleton
+internal class DeviceCalendarReader @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : CalendarReader {
+
+    override fun hasPermission(): Boolean =
+        context.checkSelfPermission(Manifest.permission.READ_CALENDAR) ==
+            PackageManager.PERMISSION_GRANTED
+
+    override suspend fun events(
+        beginUtcMillis: Long,
+        endUtcMillis: Long,
+    ): List<CalendarEvent> = withContext(Dispatchers.IO) {
+        if (!hasPermission()) return@withContext emptyList()
+
+        // Instances.CONTENT_URI wants the [begin, end] window appended to the
+        // path; the provider expands recurrences into concrete instances for us.
+        val uri = CalendarContract.Instances.CONTENT_URI.buildUpon().let { b ->
+            ContentUris.appendId(b, beginUtcMillis)
+            ContentUris.appendId(b, endUtcMillis)
+            b.build()
+        }
+
+        val projection = arrayOf(
+            CalendarContract.Instances.EVENT_ID,
+            CalendarContract.Instances.TITLE,
+            CalendarContract.Instances.BEGIN,
+            CalendarContract.Instances.END,
+            CalendarContract.Instances.ALL_DAY,
+            CalendarContract.Instances.EVENT_LOCATION,
+            CalendarContract.Instances.CALENDAR_DISPLAY_NAME,
+        )
+
+        try {
+            context.contentResolver.query(
+                uri,
+                projection,
+                null,
+                null,
+                "${CalendarContract.Instances.BEGIN} ASC",
+            )?.use { c ->
+                val idIdx = c.getColumnIndexOrThrow(CalendarContract.Instances.EVENT_ID)
+                val titleIdx = c.getColumnIndexOrThrow(CalendarContract.Instances.TITLE)
+                val beginIdx = c.getColumnIndexOrThrow(CalendarContract.Instances.BEGIN)
+                val endIdx = c.getColumnIndexOrThrow(CalendarContract.Instances.END)
+                val allDayIdx = c.getColumnIndexOrThrow(CalendarContract.Instances.ALL_DAY)
+                val locIdx = c.getColumnIndexOrThrow(CalendarContract.Instances.EVENT_LOCATION)
+                val calIdx = c.getColumnIndexOrThrow(CalendarContract.Instances.CALENDAR_DISPLAY_NAME)
+
+                buildList {
+                    while (c.moveToNext()) {
+                        add(
+                            CalendarEvent(
+                                id = c.getLong(idIdx),
+                                title = c.getString(titleIdx).orEmpty(),
+                                startUtcMillis = c.getLong(beginIdx),
+                                endUtcMillis = c.getLong(endIdx),
+                                allDay = c.getInt(allDayIdx) == 1,
+                                location = c.getString(locIdx),
+                                calendarName = c.getString(calIdx),
+                            ),
+                        )
+                    }
+                }
+            }.orEmpty()
+        } catch (e: SecurityException) {
+            // Permission revoked between the check above and the query. Treat as
+            // "no access" — the Browse gate re-prompts on next open.
+            emptyList()
+        }
+    }
+}

--- a/source-calendar/src/main/kotlin/in/jphe/storyvox/source/calendar/di/CalendarModule.kt
+++ b/source-calendar/src/main/kotlin/in/jphe/storyvox/source/calendar/di/CalendarModule.kt
@@ -1,0 +1,25 @@
+package `in`.jphe.storyvox.source.calendar.di
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import `in`.jphe.storyvox.source.calendar.CalendarReader
+import `in`.jphe.storyvox.source.calendar.DeviceCalendarReader
+
+/**
+ * Binds the on-device [DeviceCalendarReader] as the [CalendarReader] the
+ * [`in`.jphe.storyvox.source.calendar.CalendarSource] injects (#1495).
+ *
+ * This is the *only* hand-written DI in the module: the `FictionSource`
+ * multibindings themselves are emitted by KSP from `@SourcePlugin` (#1371).
+ * `DeviceCalendarReader` only needs `@ApplicationContext Context`, which Hilt
+ * provides for free — so no `@Provides`, and nothing to wire in `:app`.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+internal abstract class CalendarModule {
+
+    @Binds
+    abstract fun bindCalendarReader(impl: DeviceCalendarReader): CalendarReader
+}

--- a/source-calendar/src/test/kotlin/in/jphe/storyvox/source/calendar/CalendarAgendaTest.kt
+++ b/source-calendar/src/test/kotlin/in/jphe/storyvox/source/calendar/CalendarAgendaTest.kt
@@ -1,0 +1,158 @@
+package `in`.jphe.storyvox.source.calendar
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.time.ZoneId
+
+/**
+ * Pure agenda logic (#1495) — bucketing + narration, no Android, no clock.
+ * Fixed reference: Friday 2026-07-03 09:00, zone UTC (keeps the millis math
+ * and all-day UTC-midnight handling deterministic).
+ */
+class CalendarAgendaTest {
+
+    private val zone: ZoneId = ZoneOffset.UTC
+    private val friday = LocalDate.of(2026, 7, 3)
+    private val now = friday.atTime(9, 0).toInstant(ZoneOffset.UTC).toEpochMilli()
+
+    private fun at(date: LocalDate, hour: Int, minute: Int): Long =
+        LocalDateTime.of(date, java.time.LocalTime.of(hour, minute))
+            .toInstant(ZoneOffset.UTC).toEpochMilli()
+
+    private fun timed(
+        title: String,
+        date: LocalDate,
+        hour: Int,
+        minute: Int,
+        durationMin: Long,
+        location: String? = null,
+    ) = CalendarEvent(
+        id = title.hashCode().toLong(),
+        title = title,
+        startUtcMillis = at(date, hour, minute),
+        endUtcMillis = at(date, hour, minute) + durationMin * 60_000L,
+        allDay = false,
+        location = location,
+        calendarName = "Personal",
+    )
+
+    private fun allDay(title: String, date: LocalDate) = CalendarEvent(
+        id = title.hashCode().toLong(),
+        title = title,
+        // Provider stores all-day events as UTC midnight of the date.
+        startUtcMillis = date.atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli(),
+        endUtcMillis = date.plusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli(),
+        allDay = true,
+        location = null,
+        calendarName = "Holidays",
+    )
+
+    @Test
+    fun queryWindowSpansSevenDaysFromStartOfToday() {
+        val window = CalendarAgenda.queryWindowUtcMillis(now, zone)
+        assertEquals(friday.atStartOfDay(zone).toInstant().toEpochMilli(), window.first)
+        // 2 (today+tomorrow) + 5 (week tail) = 7 days later, exclusive.
+        val expectedEnd = friday.plusDays(7).atStartOfDay(zone).toInstant().toEpochMilli()
+        assertEquals(expectedEnd - 1, window.last)
+    }
+
+    @Test
+    fun alwaysThreeChaptersInReadingOrder() {
+        val chapters = CalendarAgenda.chapters(emptyList(), now, zone)
+        assertEquals(3, chapters.size)
+        assertEquals(CalendarAgenda.Bucket.TODAY, chapters[0].bucket)
+        assertEquals(CalendarAgenda.Bucket.TOMORROW, chapters[1].bucket)
+        assertEquals(CalendarAgenda.Bucket.WEEK, chapters[2].bucket)
+    }
+
+    @Test
+    fun emptyChaptersReadGracefully() {
+        val chapters = CalendarAgenda.chapters(emptyList(), now, zone)
+        assertEquals(0, chapters[0].eventCount)
+        assertTrue(chapters[0].plain.contains("Nothing on your calendar today"))
+        assertTrue(chapters[1].plain.contains("Nothing scheduled for tomorrow"))
+        assertTrue(chapters[2].plain.contains("The rest of your week is clear"))
+    }
+
+    @Test
+    fun todayEventNarratesTimeTitleLocationDuration() {
+        val events = listOf(timed("Standup", friday, 10, 0, 30, location = "Room 4"))
+        val today = CalendarAgenda.chapters(events, now, zone)[0]
+        assertEquals(1, today.eventCount)
+        assertTrue(today.plain.contains("10:00 AM"))
+        assertTrue(today.plain.contains("Standup"))
+        assertTrue(today.plain.contains("at Room 4"))
+        assertTrue(today.plain.contains("30 minutes"))
+    }
+
+    @Test
+    fun allDayEventsAreSummarisedBeforeTimedOnes() {
+        val events = listOf(
+            timed("Standup", friday, 10, 0, 30),
+            allDay("Independence Day", friday),
+        )
+        val today = CalendarAgenda.chapters(events, now, zone)[0]
+        val allDayPos = today.plain.indexOf("All day: Independence Day")
+        val timedPos = today.plain.indexOf("Standup")
+        assertTrue("all-day should appear", allDayPos >= 0)
+        assertTrue("timed should appear", timedPos >= 0)
+        assertTrue("all-day summarised first", allDayPos < timedPos)
+    }
+
+    @Test
+    fun durationPhrasingHandlesHoursAndMinutes() {
+        val events = listOf(
+            timed("Ninety", friday, 8, 0, 90),
+            timed("ExactHour", friday, 12, 0, 60),
+            timed("OneMinute", friday, 15, 0, 1),
+        )
+        val plain = CalendarAgenda.chapters(events, now, zone)[0].plain
+        assertTrue(plain.contains("1 hour 30 minutes"))
+        assertTrue(plain.contains("1 hour."))
+        assertTrue(plain.contains("1 minute"))
+    }
+
+    @Test
+    fun tomorrowBucketGetsTomorrowEvents() {
+        val events = listOf(timed("Dentist", friday.plusDays(1), 9, 0, 45))
+        val chapters = CalendarAgenda.chapters(events, now, zone)
+        assertEquals(0, chapters[0].eventCount)
+        assertEquals(1, chapters[1].eventCount)
+        assertTrue(chapters[1].plain.contains("Dentist"))
+    }
+
+    @Test
+    fun weekChapterIncludesWeekdayPrefixAndExcludesTodayTomorrow() {
+        // Monday 2026-07-06 is inside the week tail (today=Fri, tomorrow=Sat).
+        val monday = LocalDate.of(2026, 7, 6)
+        val events = listOf(
+            timed("Today event", friday, 10, 0, 30),
+            timed("Planning", monday, 14, 0, 60),
+        )
+        val week = CalendarAgenda.chapters(events, now, zone)[2]
+        assertEquals(1, week.eventCount)
+        assertTrue(week.plain.contains("Planning"))
+        assertTrue(week.plain.contains("Monday"))
+        assertFalse(week.plain.contains("Today event"))
+    }
+
+    @Test
+    fun blankTitleFallsBackToUntitled() {
+        val events = listOf(timed("   ", friday, 11, 0, 15))
+        assertTrue(CalendarAgenda.chapters(events, now, zone)[0].plain.contains("Untitled event"))
+    }
+
+    @Test
+    fun htmlBodyIsParagraphWrappedAndEscaped() {
+        val events = listOf(timed("A & B <tag>", friday, 10, 0, 30))
+        val html = CalendarAgenda.chapters(events, now, zone)[0].html
+        assertTrue(html.contains("<p>"))
+        assertTrue(html.contains("A &amp; B &lt;tag&gt;"))
+        assertFalse(html.contains("<tag>"))
+    }
+}

--- a/source-calendar/src/test/kotlin/in/jphe/storyvox/source/calendar/CalendarAgendaTest.kt
+++ b/source-calendar/src/test/kotlin/in/jphe/storyvox/source/calendar/CalendarAgendaTest.kt
@@ -142,6 +142,41 @@ class CalendarAgendaTest {
     }
 
     @Test
+    fun overnightEventFromYesterdayStillAppearsToday() {
+        // Starts 23:00 the day before today, ends 01:00 today — its range
+        // overlaps today even though it *started* yesterday. Start-only
+        // grouping dropped it from Today (#1495 review regression).
+        val start = friday.minusDays(1).atTime(23, 0).toInstant(ZoneOffset.UTC).toEpochMilli()
+        val end = friday.atTime(1, 0).toInstant(ZoneOffset.UTC).toEpochMilli()
+        val overnight = CalendarEvent(99, "Red-eye flight", start, end, false, null, "Personal")
+        val today = CalendarAgenda.chapters(listOf(overnight), now, zone)[0]
+        assertEquals(1, today.eventCount)
+        assertTrue(today.plain.contains("Red-eye flight"))
+    }
+
+    @Test
+    fun multiDayAllDayEventSpansEveryDayItCovers() {
+        // Fri–Sun all-day (end = exclusive UTC midnight of Mon). today=Fri,
+        // tomorrow=Sat, week starts Sun — so it must show in all three chapters.
+        val startDate = friday
+        val endExclusive = friday.plusDays(3)
+        val vacation = CalendarEvent(
+            id = 7,
+            title = "Conference",
+            startUtcMillis = startDate.atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli(),
+            endUtcMillis = endExclusive.atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli(),
+            allDay = true,
+            location = null,
+            calendarName = "Work",
+        )
+        val chapters = CalendarAgenda.chapters(listOf(vacation), now, zone)
+        assertEquals(1, chapters[0].eventCount) // Today (Fri)
+        assertEquals(1, chapters[1].eventCount) // Tomorrow (Sat)
+        assertEquals(1, chapters[2].eventCount) // This Week (Sun)
+        assertTrue(chapters[0].plain.contains("All day: Conference"))
+    }
+
+    @Test
     fun blankTitleFallsBackToUntitled() {
         val events = listOf(timed("   ", friday, 11, 0, 15))
         assertTrue(CalendarAgenda.chapters(events, now, zone)[0].plain.contains("Untitled event"))

--- a/source-calendar/src/test/kotlin/in/jphe/storyvox/source/calendar/CalendarSourceTest.kt
+++ b/source-calendar/src/test/kotlin/in/jphe/storyvox/source/calendar/CalendarSourceTest.kt
@@ -71,7 +71,7 @@ class CalendarSourceTest {
         val detail = (res as FictionResult.Success).value
         assertEquals(3, detail.chapters.size)
         assertEquals("Today", detail.chapters[0].title)
-        assertTrue(detail.chapters[0].wordCount > 0)
+        assertTrue((detail.chapters[0].wordCount ?: 0) > 0)
     }
 
     @Test

--- a/source-calendar/src/test/kotlin/in/jphe/storyvox/source/calendar/CalendarSourceTest.kt
+++ b/source-calendar/src/test/kotlin/in/jphe/storyvox/source/calendar/CalendarSourceTest.kt
@@ -1,0 +1,119 @@
+package `in`.jphe.storyvox.source.calendar
+
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneId
+import java.time.ZoneOffset
+
+/**
+ * [CalendarSource] glue over a hand-built [CalendarReader] (#1495). No Android,
+ * no contract kit — this is a local-provider source (source-ocr precedent).
+ */
+class CalendarSourceTest {
+
+    private val zone: ZoneId = ZoneOffset.UTC
+    private val friday = LocalDate.of(2026, 7, 3)
+    private val now = friday.atTime(9, 0).toInstant(ZoneOffset.UTC).toEpochMilli()
+
+    private class FakeReader(
+        private val granted: Boolean,
+        private val events: List<CalendarEvent> = emptyList(),
+    ) : CalendarReader {
+        override fun hasPermission(): Boolean = granted
+        override suspend fun events(beginUtcMillis: Long, endUtcMillis: Long): List<CalendarEvent> =
+            events.filter { it.startUtcMillis in beginUtcMillis until endUtcMillis }
+    }
+
+    private fun source(reader: CalendarReader) =
+        CalendarSource(reader, { now }, { zone })
+
+    private fun event(title: String, hour: Int, min: Int, durMin: Long): CalendarEvent {
+        val start = LocalDateTime.of(friday, LocalTime.of(hour, min))
+            .toInstant(ZoneOffset.UTC).toEpochMilli()
+        return CalendarEvent(1, title, start, start + durMin * 60_000L, false, null, "Personal")
+    }
+
+    @Test
+    fun deniedPermissionYieldsEmptyListing() = runTest {
+        val res = source(FakeReader(granted = false)).popular(1)
+        assertTrue(res is FictionResult.Success)
+        assertTrue((res as FictionResult.Success).value.items.isEmpty())
+    }
+
+    @Test
+    fun grantedPermissionYieldsSingleCalendarFiction() = runTest {
+        val res = source(FakeReader(granted = true)).popular(1)
+        assertTrue(res is FictionResult.Success)
+        val items = (res as FictionResult.Success).value.items
+        assertEquals(1, items.size)
+        assertEquals(CalendarSource.FICTION_ID, items[0].id)
+        assertEquals("My Calendar", items[0].title)
+        assertEquals("calendar", items[0].sourceId)
+    }
+
+    @Test
+    fun latestUpdatesMirrorsPopular() = runTest {
+        val res = source(FakeReader(granted = true)).latestUpdates(1)
+        assertEquals(1, ((res as FictionResult.Success).value.items).size)
+    }
+
+    @Test
+    fun fictionDetailHasThreeChapters() = runTest {
+        val res = source(FakeReader(granted = true, events = listOf(event("Standup", 10, 0, 30))))
+            .fictionDetail(CalendarSource.FICTION_ID)
+        assertTrue(res is FictionResult.Success)
+        val detail = (res as FictionResult.Success).value
+        assertEquals(3, detail.chapters.size)
+        assertEquals("Today", detail.chapters[0].title)
+        assertTrue(detail.chapters[0].wordCount > 0)
+    }
+
+    @Test
+    fun fictionDetailWhenDeniedIsAuthRequired() = runTest {
+        val res = source(FakeReader(granted = false)).fictionDetail(CalendarSource.FICTION_ID)
+        assertTrue(res is FictionResult.AuthRequired)
+    }
+
+    @Test
+    fun unknownFictionIsNotFound() = runTest {
+        val res = source(FakeReader(granted = true)).fictionDetail("nope")
+        assertTrue(res is FictionResult.NotFound)
+    }
+
+    @Test
+    fun chapterReturnsNarratedAgenda() = runTest {
+        val res = source(FakeReader(granted = true, events = listOf(event("Standup", 10, 0, 30))))
+            .chapter(CalendarSource.FICTION_ID, "${CalendarSource.FICTION_ID}::today")
+        assertTrue(res is FictionResult.Success)
+        val content = (res as FictionResult.Success).value
+        assertTrue(content.plainBody.contains("Standup"))
+        assertTrue(content.plainBody.contains("10:00 AM"))
+        assertTrue(content.htmlBody.contains("<p>"))
+    }
+
+    @Test
+    fun unknownChapterIsNotFound() = runTest {
+        val res = source(FakeReader(granted = true))
+            .chapter(CalendarSource.FICTION_ID, "${CalendarSource.FICTION_ID}::yesteryear")
+        assertTrue(res is FictionResult.NotFound)
+    }
+
+    @Test
+    fun latestRevisionTokenIsTodaysDate() = runTest {
+        val res = source(FakeReader(granted = true)).latestRevisionToken(CalendarSource.FICTION_ID)
+        assertEquals("2026-07-03", (res as FictionResult.Success).value)
+    }
+
+    @Test
+    fun followsAndSetFollowedAreBenign() = runTest {
+        val src = source(FakeReader(granted = true))
+        assertTrue((src.followsList(1) as FictionResult.Success).value.items.isEmpty())
+        assertTrue(src.setFollowed("x", true) is FictionResult.Success)
+    }
+}

--- a/source-calendar/src/test/kotlin/in/jphe/storyvox/source/calendar/CalendarSourceTest.kt
+++ b/source-calendar/src/test/kotlin/in/jphe/storyvox/source/calendar/CalendarSourceTest.kt
@@ -27,7 +27,9 @@ class CalendarSourceTest {
     ) : CalendarReader {
         override fun hasPermission(): Boolean = granted
         override suspend fun events(beginUtcMillis: Long, endUtcMillis: Long): List<CalendarEvent> =
-            events.filter { it.startUtcMillis in beginUtcMillis until endUtcMillis }
+            // Mirror CalendarContract.Instances: return instances whose range
+            // OVERLAPS the query window, not just those starting inside it.
+            events.filter { it.startUtcMillis < endUtcMillis && it.endUtcMillis > beginUtcMillis }
     }
 
     private fun source(reader: CalendarReader) =


### PR DESCRIPTION
## What & why

Adds **`:source-calendar`** — the device calendar as a narratable fiction (#1495). It reads whatever the phone already syncs (Google / Samsung / Outlook / local) through Android's on-device `CalendarContract` provider and narrates it as **"My Calendar"** with three chapters — **Today / Tomorrow / This Week** — each reading its events aloud (time, title, location, duration; all-day events summarised first).

**Zero network, no cloud API, no OAuth, no keys.** Calendar data is read on-device, narrated locally, and never leaves the phone — the same posture as `:source-ocr` / `:source-epub`, so this is a **local-provider source that skips the HTTP contract kit**.

## Architecture

- `DeviceCalendarReader` (`@ApplicationContext Context`) queries `CalendarContract.Instances`, IO-pinned, behind a tiny `CalendarReader` seam — so the source's chaptering logic is testable with a fake and needs **no `:app` wiring** beyond the two required lines.
- `CalendarAgenda` — pure, Android-free, clock-free bucketing + narration (all-day read in UTC to avoid the classic day-shift bug). Exhaustively unit-tested.
- **Permission gate (never nagging):** `READ_CALENDAR` is requested *only* on an explicit tap in Browse, never at launch. Until granted, `popular()`/`latestUpdates()` return an **empty page** (not a failure) — because `RealBrowsePaginator` maps any failure to an error banner, an empty page is what routes Browse to the rationale CTA (the `AnonymousNotionDelegate` precedent). Detail/chapter reads answer `AuthRequired`.
- **Trust surface:** `BrowseScreen` gains a `CalendarPermissionEmptyState` — "Grant calendar access", explicit about read-on-device / never-transmitted / revocable — mirroring the RSS/Notion/Local empty states + the OCR camera launcher idiom. A fresh grant re-runs the paginator so "My Calendar" appears immediately.

## Criteria (issue #1495) vs delivered

| Issue criterion | Delivered |
| --- | --- |
| On-device `CalendarContract`; no cloud API / OAuth / keys; data never leaves device | `DeviceCalendarReader` → `CalendarContract.Instances`, IO-pinned; no network deps in `build.gradle.kts` |
| "My Calendar" = one fiction; chapters Today / Tomorrow / This Week; events narrate time/title/location/duration; all-day summarised first; read-only | `CalendarSource` + `CalendarAgenda` (3 fixed chapters, all-day-first ordering, read-only) |
| `latestUpdates` regenerated daily | Chapters computed live from the current day; `latestRevisionToken` mints a per-day token so the poll worker refreshes at local midnight |
| `READ_CALENDAR` graceful denied gate; in-app rationale; optional, never nagging | Empty-page gate + `CalendarPermissionEmptyState` CTA; permission requested on-tap only |
| Data-Safety lock-step **same PR**: privacy.md, data-safety-checklist, walkthrough §IV, in-app rationale | privacy.md §2.9 + checklist reasoning + walkthrough §IV rows + the in-app CTA copy — all in this PR |
| Contract kit HTTP checks don't apply (local provider) | Local-provider shape (source-ocr precedent); plain fake-backed unit tests, no contract-kit subclass |
| Briefing-eligible so `BriefingConfig` can lead with the agenda | Mechanically eligible (registered source + `latestUpdates()`); see follow-up below |

## Data-Safety mapping

`READ_CALENDAR` is a runtime-dangerous permission, but calendar data is **never transmitted**, so the Play Data-Safety answer is unchanged: **Calendar = Not collected**, on the same on-device-only basis as the camera. Documented in `docs/data-safety-checklist.md` (reasoning + reviewer note) and `docs/play-store-walkthrough.html` §IV (data-type row + permission row).

## Test evidence

Per repo policy (compile only on CI/familiar, never locally), **CI `Build APK` + `Test Compile` are the gate**. New tests:
- `CalendarAgendaTest` (11 cases) — query window, 3-chapter shape, empty copy, time/title/location/duration narration, all-day-first ordering, duration phrasing, bucket assignment, weekday prefix, blank-title fallback, HTML escaping.
- `CalendarSourceTest` (10 cases) — denied→empty, granted→one fiction, detail 3 chapters, denied→AuthRequired, unknown fiction/chapter→NotFound, chapter narration, daily revision token, benign follows.

## Follow-ups (not built here, per issue scope)

- **Briefing lead-segment (#1467):** the source is already briefing-eligible (registered + `latestUpdates()`), but making the agenda *lead* the episode needs `BriefingConfig` to reference it by id and order it first — that's #1467's config-picker (slice 2), not this PR. No per-source "lead" seam exists on `@SourcePlugin` yet.
- **dx: filed while dogfooding:** #1526 (`new-source.sh` has no local-provider mode — had to gut the HTTP scaffold) and #1527 (`@SourcePlugin(iconName)` is documented but never consumed → the chip falls back to the Explore compass; left `iconName="CalendarMonth"` set for when the seam is wired, rather than editing the shared `sourceGlyph` `when`).
- **Listing "source count" copy** intentionally left for merge-time reconciliation (all five source-wave siblings touch it).

## Shared-file notes (source wave)

- `settings.gradle.kts` + `app/build.gradle.kts`: inserted alphabetically after `source-bookshare` (siblings land after discord/github/plos/readability — distinct lines).
- `feature/.../browse/BrowseScreen.kt`: additive only (one import, one permission launcher, one `when`-arm, one composable).

Refs #1495
