### PR TITLE
feat(primegaming): Amazon Prime Gaming free-games source (#1494)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -616,6 +616,7 @@ dependencies {
     implementation(project(":source-google-news"))
     implementation(project(":source-arxiv"))
     implementation(project(":source-plos"))
+    implementation(project(":source-primegaming"))
     implementation(project(":source-discord"))
     implementation(project(":source-epic-free-games"))
     implementation(project(":source-telegram"))

--- a/app/src/main/kotlin/in/jphe/storyvox/data/PrimeGamingConfigImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/PrimeGamingConfigImpl.kt
@@ -1,0 +1,63 @@
+package `in`.jphe.storyvox.data
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import `in`.jphe.storyvox.source.primegaming.config.PrimeGamingConfig
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+
+private val Context.primeGamingDataStore: DataStore<Preferences> by
+    preferencesDataStore(name = "storyvox_primegaming")
+
+private object PrimeGamingKeys {
+    /** The user's feed-URL override. Absent/blank = use
+     *  [PrimeGamingConfig.DEFAULT_FEED_URL]. */
+    val FEED_URL = stringPreferencesKey("pref_primegaming_feed_url")
+}
+
+/**
+ * Issue #1494 — production [PrimeGamingConfig] backed by a tiny dedicated
+ * DataStore, kept separate from `storyvox_settings` so this one tunable can't
+ * churn the main preference schema (same pattern as [RssConfigImpl] /
+ * [RadioConfigImpl]).
+ *
+ * This is the **single-maintainer mitigation** made real: the LootScraper feed
+ * ships as the default, but if it moves domains again (it already has once) or
+ * the user wants a self-hosted instance, the override is persisted here and
+ * picked up live via [feedUrlFlow]. A null/blank override reverts to the
+ * baked-in default, so "reset" needs no extra key.
+ */
+@Singleton
+class PrimeGamingConfigImpl(
+    private val store: DataStore<Preferences>,
+) : PrimeGamingConfig {
+
+    @Inject constructor(@ApplicationContext context: Context) : this(context.primeGamingDataStore)
+
+    override val feedUrlFlow: Flow<String> = store.data
+        .map { prefs -> prefs[PrimeGamingKeys.FEED_URL].orDefault() }
+        .distinctUntilChanged()
+
+    override suspend fun feedUrl(): String =
+        store.data.first()[PrimeGamingKeys.FEED_URL].orDefault()
+
+    override suspend fun setFeedUrl(url: String?) {
+        val trimmed = url?.trim().orEmpty()
+        store.edit { prefs ->
+            if (trimmed.isEmpty()) prefs.remove(PrimeGamingKeys.FEED_URL)
+            else prefs[PrimeGamingKeys.FEED_URL] = trimmed
+        }
+    }
+
+    private fun String?.orDefault(): String =
+        this?.trim()?.ifBlank { null } ?: PrimeGamingConfig.DEFAULT_FEED_URL
+}

--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -213,6 +213,13 @@ object AppBindings {
     @`in`.jphe.storyvox.data.repository.impact.ImpactAppVersion
     fun provideImpactAppVersion(): String = BuildConfig.VERSION_NAME
 
+    /** Issue #1494 — bridges the source-primegaming [PrimeGamingConfig] seam to
+     *  the concrete app-side DataStore-backed impl. Same shape as
+     *  [provideRssConfig]; consumed behind a `dagger.Lazy` in the source so the
+     *  FictionSource -> config edge can't form the #1309 init cycle. */
+    @Provides @Singleton
+    fun providePrimeGamingConfig(impl: `in`.jphe.storyvox.data.PrimeGamingConfigImpl): `in`.jphe.storyvox.source.primegaming.config.PrimeGamingConfig = impl
+
     /** Issue #417 — bridges the source-radio [RadioConfig] interface to
      *  the app-side DataStore-backed impl. Same shape as
      *  [provideRssConfig]: the impl is exposed concretely so the

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -86,6 +86,7 @@ include(":source-hackernews")
 include(":source-google-news")
 include(":source-arxiv")
 include(":source-plos")
+include(":source-primegaming")
 include(":source-discord")
 // Issue #1493 — Epic Games Store weekly free-game giveaways. One fiction
 // ("Epic Free Games"), each current/upcoming giveaway a chapter. Reads the

--- a/source-primegaming/build.gradle.kts
+++ b/source-primegaming/build.gradle.kts
@@ -1,0 +1,46 @@
+plugins {
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.hilt)
+    alias(libs.plugins.kotlin.serialization)
+}
+
+android {
+    namespace = "in.jphe.storyvox.source.primegaming"
+    compileSdk = 37
+
+    defaultConfig {
+        minSdk = 26
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+    }
+}
+
+dependencies {
+    implementation(project(":core-data"))
+
+    implementation(libs.kotlinx.coroutines.android)
+    implementation(libs.kotlinx.serialization.json)
+    implementation(libs.okhttp)
+
+    implementation(libs.hilt.android)
+    ksp(libs.hilt.compiler)
+
+    // @SourcePlugin -> KSP emits the SourcePluginDescriptor @IntoSet binding
+    // AND the Map<String, FictionSource> @IntoMap binding (#1371). No hand
+    // di/ module needed.
+    ksp(project(":core-plugin-ksp"))
+
+    testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(project(":core-source-testkit"))
+}

--- a/source-primegaming/src/main/kotlin/in/jphe/storyvox/source/primegaming/PrimeGamingSource.kt
+++ b/source-primegaming/src/main/kotlin/in/jphe/storyvox/source/primegaming/PrimeGamingSource.kt
@@ -1,0 +1,71 @@
+package `in`.jphe.storyvox.source.primegaming
+
+import `in`.jphe.storyvox.data.source.FictionSource
+import `in`.jphe.storyvox.data.source.model.ChapterContent
+import `in`.jphe.storyvox.data.source.model.FictionDetail
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import `in`.jphe.storyvox.data.source.model.FictionSummary
+import `in`.jphe.storyvox.data.source.model.ListPage
+import `in`.jphe.storyvox.data.source.model.SearchQuery
+import `in`.jphe.storyvox.data.source.plugin.SourceCategory
+import `in`.jphe.storyvox.data.source.plugin.SourcePlugin
+import `in`.jphe.storyvox.source.primegaming.net.PrimeGamingApi
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Prime Gaming source (scaffolded by scripts/new-source.sh).
+ *
+ * Every member is stubbed with an honest [FictionResult.NotFound] — wire each
+ * one to [PrimeGamingApi] and map the response into the core-data models. The
+ * contract test in src/test fails until popular()/search()/etc. talk to the
+ * Api; making it green is your definition of done. See
+ * docs/CONTRIBUTING-SOURCES.md.
+ *
+ * The @SourcePlugin id below is the SINGLE source of truth for this backend's
+ * identity — do NOT add a SourceIds constant (that table is frozen).
+ */
+@SourcePlugin(
+    id = "primegaming",
+    displayName = "Prime Gaming",
+    defaultEnabled = false,
+    category = SourceCategory.Ebook,
+    supportsSearch = true,
+    description = "One-line subtitle — surface + auth posture (fill me in)",
+    sourceUrl = "https://example.com",
+)
+@Singleton
+internal class PrimeGamingSource @Inject constructor(
+    @Suppress("unused") private val api: PrimeGamingApi,
+) : FictionSource {
+
+    override val id: String = "primegaming"
+    override val displayName: String = "Prime Gaming"
+
+    override suspend fun popular(page: Int): FictionResult<ListPage<FictionSummary>> =
+        FictionResult.NotFound("not implemented")
+
+    override suspend fun latestUpdates(page: Int): FictionResult<ListPage<FictionSummary>> =
+        FictionResult.NotFound("not implemented")
+
+    override suspend fun byGenre(genre: String, page: Int): FictionResult<ListPage<FictionSummary>> =
+        FictionResult.NotFound("not implemented")
+
+    override suspend fun search(query: SearchQuery): FictionResult<ListPage<FictionSummary>> =
+        FictionResult.NotFound("not implemented")
+
+    override suspend fun fictionDetail(fictionId: String): FictionResult<FictionDetail> =
+        FictionResult.NotFound("not implemented")
+
+    override suspend fun chapter(fictionId: String, chapterId: String): FictionResult<ChapterContent> =
+        FictionResult.NotFound("not implemented")
+
+    override suspend fun followsList(page: Int): FictionResult<ListPage<FictionSummary>> =
+        FictionResult.AuthRequired("not implemented")
+
+    override suspend fun setFollowed(fictionId: String, followed: Boolean): FictionResult<Unit> =
+        FictionResult.AuthRequired("not implemented")
+
+    override suspend fun genres(): FictionResult<List<String>> =
+        FictionResult.Success(emptyList())
+}

--- a/source-primegaming/src/main/kotlin/in/jphe/storyvox/source/primegaming/PrimeGamingSource.kt
+++ b/source-primegaming/src/main/kotlin/in/jphe/storyvox/source/primegaming/PrimeGamingSource.kt
@@ -2,70 +2,248 @@ package `in`.jphe.storyvox.source.primegaming
 
 import `in`.jphe.storyvox.data.source.FictionSource
 import `in`.jphe.storyvox.data.source.model.ChapterContent
+import `in`.jphe.storyvox.data.source.model.ChapterInfo
 import `in`.jphe.storyvox.data.source.model.FictionDetail
 import `in`.jphe.storyvox.data.source.model.FictionResult
+import `in`.jphe.storyvox.data.source.model.FictionStatus
 import `in`.jphe.storyvox.data.source.model.FictionSummary
 import `in`.jphe.storyvox.data.source.model.ListPage
 import `in`.jphe.storyvox.data.source.model.SearchQuery
+import `in`.jphe.storyvox.data.source.model.map
 import `in`.jphe.storyvox.data.source.plugin.SourceCategory
 import `in`.jphe.storyvox.data.source.plugin.SourcePlugin
 import `in`.jphe.storyvox.source.primegaming.net.PrimeGamingApi
+import `in`.jphe.storyvox.source.primegaming.net.PrimeGamingEntry
+import `in`.jphe.storyvox.source.primegaming.net.PrimeGamingFeed
 import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * Prime Gaming source (scaffolded by scripts/new-source.sh).
+ * Issue #1494 — Amazon Prime Gaming "free games to claim" source.
  *
- * Every member is stubbed with an honest [FictionResult.NotFound] — wire each
- * one to [PrimeGamingApi] and map the response into the core-data models. The
- * contract test in src/test fails until popular()/search()/etc. talk to the
- * Api; making it green is your definition of done. See
- * docs/CONTRIBUTING-SOURCES.md.
+ * ## Honest framing (requirement #1)
  *
- * The @SourcePlugin id below is the SINGLE source of truth for this backend's
- * identity — do NOT add a SourceIds constant (that table is frozen).
+ * Prime Gaming games are **not universally free** — they are a perk of a paid
+ * Amazon Prime subscription. This source never claims otherwise: the plugin
+ * [description], the [displayName], and the collection fiction's synopsis all
+ * state that claiming requires an active Prime membership. (This is precisely
+ * why the flagship free-giveaway aggregator, GamerPower, deliberately excludes
+ * Prime Gaming — verified on the #1494 research gate.)
+ *
+ * ## Reading model — one fiction, one chapter per claim
+ *
+ * There is a single synthetic fiction ("Prime Gaming Free Games"); each
+ * currently-claimable title is a chapter carrying its name, claim window,
+ * genres, and how to redeem. So [popular]/[latestUpdates]/[search] all return
+ * that one collection, and its "chapters" are the live claims from the feed.
+ *
+ * ## Data path (research gate PASSED, #1494)
+ *
+ * Reads the community **LootScraper** Amazon-Prime Atom feed via [PrimeGamingApi]
+ * (URL configurable — see [PrimeGamingConfig][in.jphe.storyvox.source.primegaming.config.PrimeGamingConfig]).
+ * Attribution to LootScraper (MIT, github.com/eikowagenknecht/lootscraper) is
+ * carried in the collection synopsis, matching the feed's own self-attribution.
  */
 @SourcePlugin(
     id = "primegaming",
     displayName = "Prime Gaming",
     defaultEnabled = false,
-    category = SourceCategory.Ebook,
+    category = SourceCategory.Other,
     supportsSearch = true,
-    description = "One-line subtitle — surface + auth posture (fill me in)",
-    sourceUrl = "https://example.com",
+    description = "Amazon Prime Gaming free-game claims · requires a Prime subscription · via community LootScraper feed",
+    sourceUrl = "https://gaming.amazon.com/home",
+    chipLabel = "Prime",
+    searchHint = "Search Prime Gaming's current free-game claims",
+    iconName = "SportsEsports",
 )
 @Singleton
 internal class PrimeGamingSource @Inject constructor(
-    @Suppress("unused") private val api: PrimeGamingApi,
+    private val api: PrimeGamingApi,
 ) : FictionSource {
 
     override val id: String = "primegaming"
     override val displayName: String = "Prime Gaming"
 
+    // ── browse: one collection fiction ──────────────────────────────────────
+
     override suspend fun popular(page: Int): FictionResult<ListPage<FictionSummary>> =
-        FictionResult.NotFound("not implemented")
+        collectionPage(page)
 
     override suspend fun latestUpdates(page: Int): FictionResult<ListPage<FictionSummary>> =
-        FictionResult.NotFound("not implemented")
+        collectionPage(page)
 
     override suspend fun byGenre(genre: String, page: Int): FictionResult<ListPage<FictionSummary>> =
-        FictionResult.NotFound("not implemented")
+        // Only one fiction exists; genre filtering a single collection is
+        // meaningless, so surface it under any genre for discoverability.
+        collectionPage(page)
 
-    override suspend fun search(query: SearchQuery): FictionResult<ListPage<FictionSummary>> =
-        FictionResult.NotFound("not implemented")
+    override suspend fun search(query: SearchQuery): FictionResult<ListPage<FictionSummary>> {
+        val term = query.term.trim().lowercase()
+        return api.feed().map { fetch ->
+            val feed = fetch.feed
+            // Match the collection when the query is blank (browse-as-search) or
+            // hits "prime gaming" / any current game title. One fiction either
+            // way — but an empty page for an unrelated term keeps search honest.
+            val matches = term.isBlank() ||
+                COLLECTION_TITLE.lowercase().contains(term) ||
+                "prime gaming".contains(term) ||
+                feed.entries.any { it.game.lowercase().contains(term) }
+            val items = if (matches) listOf(collectionSummary(feed)) else emptyList()
+            ListPage(items = items, page = 1, hasNext = false)
+        }
+    }
 
-    override suspend fun fictionDetail(fictionId: String): FictionResult<FictionDetail> =
-        FictionResult.NotFound("not implemented")
+    // ── detail + chapter ────────────────────────────────────────────────────
 
-    override suspend fun chapter(fictionId: String, chapterId: String): FictionResult<ChapterContent> =
-        FictionResult.NotFound("not implemented")
+    override suspend fun fictionDetail(fictionId: String): FictionResult<FictionDetail> {
+        if (fictionId != FICTION_ID) return FictionResult.NotFound("unknown fiction $fictionId")
+        return api.feed().map { fetch ->
+            val feed = fetch.feed
+            FictionDetail(
+                summary = collectionSummary(feed),
+                chapters = feed.entries.mapIndexed { index, entry -> entry.toChapterInfo(index) },
+                genres = feed.entries.flatMap { it.genres }.distinct(),
+                lastUpdatedAt = null,
+            )
+        }
+    }
 
-    override suspend fun followsList(page: Int): FictionResult<ListPage<FictionSummary>> =
-        FictionResult.AuthRequired("not implemented")
+    override suspend fun chapter(fictionId: String, chapterId: String): FictionResult<ChapterContent> {
+        if (fictionId != FICTION_ID) return FictionResult.NotFound("unknown fiction $fictionId")
+        return when (val result = api.feed()) {
+            is FictionResult.Success -> {
+                val feed = result.value.feed
+                val index = feed.entries.indexOfFirst { it.id == chapterId }
+                if (index < 0) {
+                    // The claim expired out of the feed since the list was cached.
+                    FictionResult.NotFound("claim $chapterId is no longer listed")
+                } else {
+                    FictionResult.Success(feed.entries[index].toChapterContent(index))
+                }
+            }
+            is FictionResult.Failure -> result
+        }
+    }
 
-    override suspend fun setFollowed(fictionId: String, followed: Boolean): FictionResult<Unit> =
-        FictionResult.AuthRequired("not implemented")
+    // ── catalog + polling ───────────────────────────────────────────────────
 
     override suspend fun genres(): FictionResult<List<String>> =
-        FictionResult.Success(emptyList())
+        // Genre picker degrades gracefully: a feed hiccup shows no genres rather
+        // than an error dialog.
+        when (val result = api.feed()) {
+            is FictionResult.Success ->
+                FictionResult.Success(result.value.feed.entries.flatMap { it.genres }.distinct().sorted())
+            is FictionResult.Failure -> FictionResult.Success(emptyList())
+        }
+
+    override suspend fun latestRevisionToken(fictionId: String): FictionResult<String?> {
+        if (fictionId != FICTION_ID) return FictionResult.Success(null)
+        // Cheap-poll seam: the feed's ETag/Last-Modified. The worker compares it
+        // to the stored token and skips fictionDetail when unchanged; our Api
+        // already speaks conditional-GET, so an unchanged feed is a cheap 304.
+        return api.feed().map { it.revision }
+    }
+
+    // ── auth-gated: not applicable ──────────────────────────────────────────
+
+    override suspend fun followsList(page: Int): FictionResult<ListPage<FictionSummary>> =
+        FictionResult.Success(ListPage(emptyList(), page, hasNext = false))
+
+    override suspend fun setFollowed(fictionId: String, followed: Boolean): FictionResult<Unit> =
+        FictionResult.Success(Unit)
+
+    // ── mapping ─────────────────────────────────────────────────────────────
+
+    /** Page-1 → the one collection fiction; later pages → empty (terminates paging). */
+    private suspend fun collectionPage(page: Int): FictionResult<ListPage<FictionSummary>> {
+        if (page > 1) {
+            return FictionResult.Success(ListPage(emptyList(), page, hasNext = false))
+        }
+        return api.feed().map { fetch ->
+            ListPage(items = listOf(collectionSummary(fetch.feed)), page = 1, hasNext = false)
+        }
+    }
+
+    private fun collectionSummary(feed: PrimeGamingFeed): FictionSummary =
+        FictionSummary(
+            id = FICTION_ID,
+            sourceId = id,
+            title = COLLECTION_TITLE,
+            author = "Amazon Prime Gaming",
+            description = COLLECTION_SYNOPSIS,
+            tags = listOf("Prime Gaming", "Requires Prime", "Free to claim"),
+            status = FictionStatus.ONGOING,
+            chapterCount = feed.entries.size,
+        )
+
+    private fun PrimeGamingEntry.toChapterInfo(index: Int): ChapterInfo =
+        ChapterInfo(
+            id = id,
+            sourceChapterId = id,
+            index = index,
+            title = game.ifBlank { "Prime Gaming claim" },
+        )
+
+    private fun PrimeGamingEntry.toChapterContent(index: Int): ChapterContent {
+        val plain = buildString {
+            append(game.ifBlank { "This Prime Gaming title" })
+            append(". Free to claim on Amazon Prime Gaming — requires an active Amazon Prime subscription.")
+            if (validFrom != null || validTo != null) {
+                append(" Claim window: ")
+                append(validFrom ?: "now")
+                append(" to ")
+                append(validTo ?: "an unannounced end date")
+                append(".")
+            }
+            if (genres.isNotEmpty()) append(" Genres: ${genres.joinToString(", ")}.")
+            if (releaseDate != null) append(" Released $releaseDate.")
+            if (!description.isNullOrBlank()) append(" About the game: $description")
+            if (!claimUrl.isNullOrBlank()) append(" Claim it at $claimUrl")
+        }
+        val html = buildString {
+            append("<h2>").append(game.htmlEscape()).append("</h2>")
+            append("<p>Free to claim on <strong>Amazon Prime Gaming</strong> — ")
+            append("requires an active Amazon Prime subscription.</p>")
+            if (validFrom != null || validTo != null) {
+                append("<p><strong>Claim window:</strong> ")
+                append((validFrom ?: "now").htmlEscape())
+                append(" &ndash; ")
+                append((validTo ?: "unannounced").htmlEscape())
+                append("</p>")
+            }
+            if (genres.isNotEmpty()) {
+                append("<p><strong>Genres:</strong> ")
+                append(genres.joinToString(", ").htmlEscape()).append("</p>")
+            }
+            if (releaseDate != null) {
+                append("<p><strong>Released:</strong> ").append(releaseDate.htmlEscape()).append("</p>")
+            }
+            if (!description.isNullOrBlank()) {
+                append("<p>").append(description.htmlEscape()).append("</p>")
+            }
+            if (!claimUrl.isNullOrBlank()) {
+                val safe = claimUrl.htmlEscape()
+                append("<p><a href=\"").append(safe).append("\">Claim on Amazon Prime</a></p>")
+            }
+        }
+        return ChapterContent(
+            info = toChapterInfo(index),
+            htmlBody = html,
+            plainBody = plain,
+        )
+    }
+
+    private fun String.htmlEscape(): String =
+        replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;")
+
+    companion object {
+        /** The one synthetic fiction this source exposes. */
+        private const val FICTION_ID = "primegaming:amazon"
+        private const val COLLECTION_TITLE = "Prime Gaming Free Games"
+        private const val COLLECTION_SYNOPSIS =
+            "Amazon Prime Gaming's current free games to claim — one chapter per title, with its " +
+                "claim window and how to redeem. Requires an active Amazon Prime subscription to claim; " +
+                "these are a paid-Prime perk, not universally-free giveaways. Data via the community " +
+                "LootScraper feed (MIT, github.com/eikowagenknecht/lootscraper)."
+    }
 }

--- a/source-primegaming/src/main/kotlin/in/jphe/storyvox/source/primegaming/config/PrimeGamingConfig.kt
+++ b/source-primegaming/src/main/kotlin/in/jphe/storyvox/source/primegaming/config/PrimeGamingConfig.kt
@@ -1,0 +1,59 @@
+package `in`.jphe.storyvox.source.primegaming.config
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Issue #1494 — read/write seam over the Prime Gaming source's single tunable:
+ * **which feed URL to read the claim list from.**
+ *
+ * ## Why this is configurable (the single-maintainer mitigation)
+ *
+ * Amazon exposes no usable public API for Prime Gaming offers (the research
+ * gate on #1494 confirmed: `gaming.amazon.com/graphql` → HTTP 403 unauth,
+ * needs a paid Prime session + CSRF; scraping violates Amazon's Conditions of
+ * Use). The validated data path is the community **LootScraper** project's
+ * dedicated Amazon-Prime Atom feed (MIT, github.com/eikowagenknecht/lootscraper).
+ *
+ * That feed is a single volunteer's Cloudflare-fronted host — and it has
+ * already migrated domains once (`feed.phenx.de` → `feed.eikowagenknecht.com`).
+ * Hard-coding one URL would brick the source the day it moves again. So the URL
+ * is persisted and overridable: [DEFAULT_FEED_URL] ships as the baked-in
+ * default; a user (or a future settings row) can point it at a self-hosted
+ * LootScraper instance or the feed's next home without an app update.
+ *
+ * ## Where the implementation lives (and the #1309 trap)
+ *
+ * The production implementation lives in `:app` (DataStore-backed), so this
+ * source module stays free of Android Preferences plumbing — the same split as
+ * [RssConfig][in.jphe.storyvox.source.rss.config.RssConfig] /
+ * `RadioConfig` / `EpubConfig`. The consumer ([PrimeGamingApi]) injects this
+ * behind a `dagger.Lazy` so the FictionSource → settings-config edge can never
+ * form the Dagger initialization cycle that bit #1309 (which surfaces only at
+ * `:app:hiltJavaCompileRelease`, never in a module build).
+ */
+interface PrimeGamingConfig {
+
+    /** Hot stream of the effective feed URL — emits [DEFAULT_FEED_URL] until the
+     *  user overrides it, then the override. Drives live-persist re-reads. */
+    val feedUrlFlow: Flow<String>
+
+    /** Synchronous snapshot of the effective feed URL (the override, or
+     *  [DEFAULT_FEED_URL] when unset). Never blank. */
+    suspend fun feedUrl(): String
+
+    /** Persist an override. A null/blank value clears the override and reverts
+     *  to [DEFAULT_FEED_URL] — so "reset to default" needs no separate call. */
+    suspend fun setFeedUrl(url: String?)
+
+    companion object {
+        /**
+         * Canonical LootScraper Amazon-Prime Atom feed (verified reachable with
+         * Candela's honest UA on the #1494 research gate: HTTP 200, no throttle,
+         * conditional-GET/304 supported, full per-entry narratable content).
+         * The old `feed.phenx.de` host 301-redirects here; we bake the canonical
+         * target so we don't pay a redirect hop on every poll.
+         */
+        const val DEFAULT_FEED_URL: String =
+            "https://feed.eikowagenknecht.com/lootscraper_amazon_game.xml"
+    }
+}

--- a/source-primegaming/src/main/kotlin/in/jphe/storyvox/source/primegaming/di/PrimeGamingModule.kt
+++ b/source-primegaming/src/main/kotlin/in/jphe/storyvox/source/primegaming/di/PrimeGamingModule.kt
@@ -1,10 +1,12 @@
 package `in`.jphe.storyvox.source.primegaming.di
 
+import dagger.Lazy
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import `in`.jphe.storyvox.data.network.UserAgentHeader
+import `in`.jphe.storyvox.source.primegaming.config.PrimeGamingConfig
 import `in`.jphe.storyvox.source.primegaming.net.PrimeGamingApi
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
@@ -41,5 +43,8 @@ internal object PrimeGamingHttpModule {
     @Singleton
     fun providePrimeGamingApi(
         @PrimeGamingHttp client: OkHttpClient,
-    ): PrimeGamingApi = PrimeGamingApi(client)
+        // dagger.Lazy breaks the FictionSource -> settings-config init cycle
+        // (#1309); the PrimeGamingConfig binding is supplied by :app.
+        config: Lazy<PrimeGamingConfig>,
+    ): PrimeGamingApi = PrimeGamingApi(client, config)
 }

--- a/source-primegaming/src/main/kotlin/in/jphe/storyvox/source/primegaming/di/PrimeGamingModule.kt
+++ b/source-primegaming/src/main/kotlin/in/jphe/storyvox/source/primegaming/di/PrimeGamingModule.kt
@@ -1,0 +1,45 @@
+package `in`.jphe.storyvox.source.primegaming.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import `in`.jphe.storyvox.data.network.UserAgentHeader
+import `in`.jphe.storyvox.source.primegaming.net.PrimeGamingApi
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
+import java.util.concurrent.TimeUnit
+import javax.inject.Qualifier
+import javax.inject.Singleton
+
+/** Dedicated OkHttp client qualifier for the Prime Gaming backend. */
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class PrimeGamingHttp
+
+@Module
+@InstallIn(SingletonComponent::class)
+internal object PrimeGamingHttpModule {
+
+    @Provides
+    @Singleton
+    @PrimeGamingHttp
+    fun provideClient(
+        @UserAgentHeader userAgent: Interceptor,
+    ): OkHttpClient =
+        OkHttpClient.Builder()
+            .connectTimeout(10, TimeUnit.SECONDS)
+            .readTimeout(15, TimeUnit.SECONDS)
+            .writeTimeout(10, TimeUnit.SECONDS)
+            .followRedirects(true)
+            .retryOnConnectionFailure(true)
+            // #1204 — shared descriptive User-Agent on every request.
+            .addInterceptor(userAgent)
+            .build()
+
+    @Provides
+    @Singleton
+    fun providePrimeGamingApi(
+        @PrimeGamingHttp client: OkHttpClient,
+    ): PrimeGamingApi = PrimeGamingApi(client)
+}

--- a/source-primegaming/src/main/kotlin/in/jphe/storyvox/source/primegaming/net/PrimeGamingApi.kt
+++ b/source-primegaming/src/main/kotlin/in/jphe/storyvox/source/primegaming/net/PrimeGamingApi.kt
@@ -1,97 +1,161 @@
 package `in`.jphe.storyvox.source.primegaming.net
 
+import dagger.Lazy
 import `in`.jphe.storyvox.data.source.model.FictionResult
+import `in`.jphe.storyvox.source.primegaming.config.PrimeGamingConfig
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import java.io.IOException
-import javax.inject.Inject
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 
 /**
- * HTTP client for Prime Gaming. The [request] wrapper is pre-written to satisfy
- * the FictionSourceContractTest: it pins the blocking OkHttp call to
- * Dispatchers.IO (#585) and maps status codes to typed failures. Copy its shape
- * for every endpoint you add — do NOT surface raw HTTP codes or exceptions.
+ * Issue #1494 — HTTP client for the LootScraper Amazon-Prime Atom feed.
+ *
+ * There is exactly one upstream request: GET the configured feed URL. Everything
+ * the source exposes (the collection, the claim list, each claim's narration) is
+ * derived from that one document, so this client:
+ *
+ *  - **pins the blocking OkHttp call to `Dispatchers.IO`** (#585 — the contract
+ *    kit asserts it),
+ *  - **maps every non-2xx to a typed [FictionResult] failure** (never throws an
+ *    HTTP error up to the source layer — requirement: graceful feed-down/moved),
+ *  - **caches the parsed feed in-memory with a short TTL** so tapping through
+ *    the claim list doesn't re-download the whole feed per chapter (the #1489
+ *    lesson: `chapter()` must not re-fetch), and
+ *  - **honours conditional-GET etiquette** — it records `ETag`/`Last-Modified`
+ *    and replays them as `If-None-Match`/`If-Modified-Since`, treating a 304 as
+ *    "reuse the cached parse" (the feed supports 304, verified on #1494).
+ *
+ * The feed URL is read from [PrimeGamingConfig] behind a `dagger.Lazy` so the
+ * FictionSource → settings-config edge can't form the #1309 Dagger init cycle.
+ * `open` so unit tests can substitute behaviour; the contract test injects a
+ * fake config pointed at its MockWebServer.
  */
-internal open class PrimeGamingApi @Inject constructor(
+internal open class PrimeGamingApi(
     private val client: OkHttpClient,
+    private val config: Lazy<PrimeGamingConfig>,
 ) {
-    /** Test seam — `open` so unit tests point this at a MockWebServer without
-     *  restructuring call sites (mirrors StandardEbooksApi.baseUrl). */
-    internal open val baseUrl: String get() = BASE_URL
+    /** A parsed feed plus the revision token to hand the cheap-poll worker. */
+    internal data class FeedFetch(val feed: PrimeGamingFeed, val revision: String?)
+
+    private data class Cached(
+        val fetch: FeedFetch,
+        val lastModified: String?,
+        val etag: String?,
+        val atNanos: Long,
+    )
+
+    @Volatile
+    private var cache: Cached? = null
 
     /**
-     * IO-pinned GET. `parse` turns the response body into your typed model.
-     * Returns a typed [FictionResult] failure for every non-2xx status — never
-     * throws for an HTTP error.
+     * Fetch (or return the cached) parsed feed. IO-pinned; typed failures only.
+     *
+     * @param forceRefresh skip the TTL cache and re-hit the network (still
+     *  sends conditional headers, so an unchanged feed costs a cheap 304).
      */
-    suspend fun <T> request(path: String, parse: (String) -> T): FictionResult<T> =
+    open suspend fun feed(forceRefresh: Boolean = false): FictionResult<FeedFetch> =
         withContext(Dispatchers.IO) {
-            val url = baseUrl + path
+            val snapshot = cache
+            if (!forceRefresh && snapshot != null &&
+                System.nanoTime() - snapshot.atNanos < CACHE_TTL_NANOS
+            ) {
+                return@withContext FictionResult.Success(snapshot.fetch)
+            }
+
+            val url = config.get().feedUrl()
             try {
-                val req = Request.Builder()
+                val builder = Request.Builder()
                     .url(url)
-                    .header("Accept", "application/json")
+                    .header("Accept", "application/atom+xml, application/xml, text/xml")
                     .get()
-                    .build()
-                client.newCall(req).execute().use { resp ->
+                // Conditional-GET etiquette — the feed answers 304 when unchanged.
+                snapshot?.etag?.let { builder.header("If-None-Match", it) }
+                snapshot?.lastModified?.let { builder.header("If-Modified-Since", it) }
+
+                client.newCall(builder.build()).execute().use { resp ->
                     when {
-                        resp.code == 404 -> FictionResult.NotFound("Prime Gaming: $path not found")
-                        resp.code == 401 -> FictionResult.AuthRequired("HTTP 401 from $url")
+                        resp.code == 304 && snapshot != null -> {
+                            // Upstream unchanged — reuse the parse, refresh the TTL.
+                            cache = snapshot.copy(atNanos = System.nanoTime())
+                            FictionResult.Success(snapshot.fetch)
+                        }
+
+                        resp.code == 404 ->
+                            FictionResult.NotFound("Prime Gaming feed not found at $url")
+
+                        resp.code == 401 ->
+                            FictionResult.AuthRequired("HTTP 401 from $url")
+
                         resp.code == 403 -> {
-                            // Cloudflare interstitials arrive as HTTP 403 with challenge
-                            // HTML — the CF sniff MUST precede the auth mapping, or a
-                            // CF-gated 403 misreports as "sign in required" (see
-                            // docs/CONTRIBUTING-SOURCES.md decision table).
+                            // A Cloudflare interstitial arrives as 403 + challenge
+                            // HTML — the CF sniff MUST precede the auth mapping, or
+                            // a CF-gated 403 misreports as "sign in required".
                             val body = resp.body?.string().orEmpty()
                             if (looksLikeCfChallenge(body)) {
                                 FictionResult.NetworkError(
-                                    "Prime Gaming returned a Cloudflare challenge page — try again later",
+                                    "Prime Gaming feed returned a Cloudflare challenge — try again later",
                                     IOException("Cloudflare challenge"),
                                 )
                             } else {
                                 FictionResult.AuthRequired("HTTP 403 from $url")
                             }
                         }
+
                         resp.code == 429 -> FictionResult.RateLimited(
-                            retryAfter = null,
-                            message = "Prime Gaming rate limited (HTTP 429)",
+                            retryAfter = parseRetryAfter(resp.header("Retry-After")),
+                            message = "Prime Gaming feed rate limited (HTTP 429)",
                         )
+
                         !resp.isSuccessful -> FictionResult.NetworkError(
                             "HTTP ${resp.code} from $url",
                             IOException("HTTP ${resp.code}"),
                         )
+
                         else -> {
                             val text = resp.body?.string()
                                 ?: return@withContext FictionResult.NetworkError(
                                     "empty body",
                                     IOException("empty body"),
                                 )
-                            FictionResult.Success(parse(text))
+                            val parsed = PrimeGamingFeed.parse(text)
+                            val lastModified = resp.header("Last-Modified")
+                            val etag = resp.header("ETag")
+                            val fetch = FeedFetch(
+                                feed = parsed,
+                                revision = etag ?: lastModified ?: parsed.updated,
+                            )
+                            cache = Cached(fetch, lastModified, etag, System.nanoTime())
+                            FictionResult.Success(fetch)
                         }
                     }
                 }
             } catch (e: IOException) {
                 FictionResult.NetworkError(e.message ?: "fetch failed", e)
-            } catch (e: kotlinx.serialization.SerializationException) {
-                // A throwing parse lambda must stay inside the typed-error
-                // contract — never escape as a raw exception.
-                FictionResult.NetworkError("Prime Gaming returned an unexpected response shape", e)
             }
         }
 
     /**
-     * #1443-family heuristic: does a body look like a Cloudflare challenge
-     * interstitial rather than your API's payload? Keep this arm ahead of
-     * the 401/403 auth mapping (see the request() template above).
+     * #1443-family heuristic: does this body look like a Cloudflare challenge
+     * interstitial rather than the Atom feed? Keep ahead of the 401/403 mapping.
      */
     private fun looksLikeCfChallenge(body: String): Boolean =
         body.contains("/cdn-cgi/challenge-platform/") ||
             body.contains("Just a moment...") ||
             body.contains("cf-mitigated")
 
+    /** `Retry-After` is either delta-seconds or an HTTP date; we honour the
+     *  common integer-seconds form and ignore the date form (null → unknown). */
+    private fun parseRetryAfter(header: String?): Duration? =
+        header?.trim()?.toIntOrNull()?.takeIf { it >= 0 }?.seconds
+
     companion object {
-        const val BASE_URL = "https://example.com"
+        /** Long enough that browsing the claim list is one fetch; short enough
+         *  that a monthly Prime refresh shows up promptly on the next open. */
+        private val CACHE_TTL_NANOS: Long = 5.minutes.inWholeNanoseconds
     }
 }

--- a/source-primegaming/src/main/kotlin/in/jphe/storyvox/source/primegaming/net/PrimeGamingApi.kt
+++ b/source-primegaming/src/main/kotlin/in/jphe/storyvox/source/primegaming/net/PrimeGamingApi.kt
@@ -1,0 +1,97 @@
+package `in`.jphe.storyvox.source.primegaming.net
+
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.IOException
+import javax.inject.Inject
+
+/**
+ * HTTP client for Prime Gaming. The [request] wrapper is pre-written to satisfy
+ * the FictionSourceContractTest: it pins the blocking OkHttp call to
+ * Dispatchers.IO (#585) and maps status codes to typed failures. Copy its shape
+ * for every endpoint you add — do NOT surface raw HTTP codes or exceptions.
+ */
+internal open class PrimeGamingApi @Inject constructor(
+    private val client: OkHttpClient,
+) {
+    /** Test seam — `open` so unit tests point this at a MockWebServer without
+     *  restructuring call sites (mirrors StandardEbooksApi.baseUrl). */
+    internal open val baseUrl: String get() = BASE_URL
+
+    /**
+     * IO-pinned GET. `parse` turns the response body into your typed model.
+     * Returns a typed [FictionResult] failure for every non-2xx status — never
+     * throws for an HTTP error.
+     */
+    suspend fun <T> request(path: String, parse: (String) -> T): FictionResult<T> =
+        withContext(Dispatchers.IO) {
+            val url = baseUrl + path
+            try {
+                val req = Request.Builder()
+                    .url(url)
+                    .header("Accept", "application/json")
+                    .get()
+                    .build()
+                client.newCall(req).execute().use { resp ->
+                    when {
+                        resp.code == 404 -> FictionResult.NotFound("Prime Gaming: $path not found")
+                        resp.code == 401 -> FictionResult.AuthRequired("HTTP 401 from $url")
+                        resp.code == 403 -> {
+                            // Cloudflare interstitials arrive as HTTP 403 with challenge
+                            // HTML — the CF sniff MUST precede the auth mapping, or a
+                            // CF-gated 403 misreports as "sign in required" (see
+                            // docs/CONTRIBUTING-SOURCES.md decision table).
+                            val body = resp.body?.string().orEmpty()
+                            if (looksLikeCfChallenge(body)) {
+                                FictionResult.NetworkError(
+                                    "Prime Gaming returned a Cloudflare challenge page — try again later",
+                                    IOException("Cloudflare challenge"),
+                                )
+                            } else {
+                                FictionResult.AuthRequired("HTTP 403 from $url")
+                            }
+                        }
+                        resp.code == 429 -> FictionResult.RateLimited(
+                            retryAfter = null,
+                            message = "Prime Gaming rate limited (HTTP 429)",
+                        )
+                        !resp.isSuccessful -> FictionResult.NetworkError(
+                            "HTTP ${resp.code} from $url",
+                            IOException("HTTP ${resp.code}"),
+                        )
+                        else -> {
+                            val text = resp.body?.string()
+                                ?: return@withContext FictionResult.NetworkError(
+                                    "empty body",
+                                    IOException("empty body"),
+                                )
+                            FictionResult.Success(parse(text))
+                        }
+                    }
+                }
+            } catch (e: IOException) {
+                FictionResult.NetworkError(e.message ?: "fetch failed", e)
+            } catch (e: kotlinx.serialization.SerializationException) {
+                // A throwing parse lambda must stay inside the typed-error
+                // contract — never escape as a raw exception.
+                FictionResult.NetworkError("Prime Gaming returned an unexpected response shape", e)
+            }
+        }
+
+    /**
+     * #1443-family heuristic: does a body look like a Cloudflare challenge
+     * interstitial rather than your API's payload? Keep this arm ahead of
+     * the 401/403 auth mapping (see the request() template above).
+     */
+    private fun looksLikeCfChallenge(body: String): Boolean =
+        body.contains("/cdn-cgi/challenge-platform/") ||
+            body.contains("Just a moment...") ||
+            body.contains("cf-mitigated")
+
+    companion object {
+        const val BASE_URL = "https://example.com"
+    }
+}

--- a/source-primegaming/src/main/kotlin/in/jphe/storyvox/source/primegaming/net/PrimeGamingFeed.kt
+++ b/source-primegaming/src/main/kotlin/in/jphe/storyvox/source/primegaming/net/PrimeGamingFeed.kt
@@ -1,0 +1,198 @@
+package `in`.jphe.storyvox.source.primegaming.net
+
+/**
+ * Issue #1494 — typed view of the LootScraper "Free Amazon Prime Games" Atom
+ * feed. One [PrimeGamingEntry] per claimable title.
+ *
+ * ## Why hand-rolled regex parsing (same posture as `:source-arxiv`)
+ *
+ * The feed is a machine-generated Atom 1.0 document with a stable shape
+ * (LootScraper renders it from a template). A regex pass over the handful of
+ * per-`<entry>` anchors is faster than spinning up [android.util.Xml] and — the
+ * decisive reason — **works on the plain JUnit classpath with no Robolectric**,
+ * which is all a `:source-*` module's unit tests get.
+ *
+ * ## The xhtml-content trap (#1494 research finding)
+ *
+ * LootScraper puts the narratable payload in `<content type="xhtml">` as a
+ * nested XHTML `<div>`, NOT as element text. An [org.xmlpull.v1.XmlPullParser]
+ * `.nextText()` / a `.text` read on that element returns **empty** — the value
+ * is child elements, not a text node. Regex-parsing the raw XML string
+ * sidesteps this entirely: we capture the whole `<content>…</content>` span and
+ * pull the offer window / description / release date straight out of the inner
+ * HTML by their `<b>label:</b>` anchors.
+ *
+ * If LootScraper's template ever shifts we re-key the regexes; the unit tests
+ * pin the canonical layout so a silent break surfaces at CI, not on a user's
+ * empty chapter list.
+ */
+internal data class PrimeGamingFeed(
+    /** Feed-level `<title>` (e.g. "Free Amazon Prime Games (PC)"). */
+    val title: String?,
+    /** Feed-level `<updated>` timestamp (ISO-8601). */
+    val updated: String?,
+    val entries: List<PrimeGamingEntry>,
+) {
+    companion object {
+        private val ENTRY_REGEX =
+            Regex("""<entry\b[^>]*>([\s\S]*?)</entry>""", RegexOption.IGNORE_CASE)
+
+        // Feed-level title/updated live BEFORE the first <entry>; slice the head
+        // so an entry's own <title>/<updated> can't be mistaken for the feed's.
+        private val FEED_TITLE_REGEX =
+            Regex("""<title\b[^>]*>([\s\S]*?)</title>""", RegexOption.IGNORE_CASE)
+        private val FEED_UPDATED_REGEX =
+            Regex("""<updated\b[^>]*>([\s\S]*?)</updated>""", RegexOption.IGNORE_CASE)
+
+        // ── per-entry anchors ──────────────────────────────────────────────
+        private val ID_REGEX =
+            Regex("""<id\b[^>]*>([\s\S]*?)</id>""", RegexOption.IGNORE_CASE)
+        private val TITLE_REGEX =
+            Regex("""<title\b[^>]*>([\s\S]*?)</title>""", RegexOption.IGNORE_CASE)
+        private val UPDATED_REGEX =
+            Regex("""<updated\b[^>]*>([\s\S]*?)</updated>""", RegexOption.IGNORE_CASE)
+
+        /** The whole xhtml content span — parsed further for the offer fields. */
+        private val CONTENT_REGEX =
+            Regex("""<content\b[^>]*>([\s\S]*?)</content>""", RegexOption.IGNORE_CASE)
+
+        /** `<link ... href="…"/>` — the claim link sits at entry level. */
+        private val LINK_HREF_REGEX =
+            Regex("""<link\b[^>]*\bhref="([^"]+)"""", RegexOption.IGNORE_CASE)
+        /** `<a href="…luna.amazon.com/claims…">` inside the content, as fallback. */
+        private val ANCHOR_HREF_REGEX =
+            Regex("""<a\b[^>]*\bhref="([^"]+)"""", RegexOption.IGNORE_CASE)
+
+        /** `<category … label="Action"/>` — clean genre labels. */
+        private val CATEGORY_LABEL_REGEX =
+            Regex("""<category\b[^>]*\blabel="([^"]+)"""", RegexOption.IGNORE_CASE)
+
+        // ── fields inside the xhtml content, keyed off their <b>label:</b> ──
+        private val VALID_FROM_REGEX =
+            Regex("""valid from:\s*</b>\s*([^<]+)""", RegexOption.IGNORE_CASE)
+        private val VALID_TO_REGEX =
+            Regex("""valid to:\s*</b>\s*([^<]+)""", RegexOption.IGNORE_CASE)
+        private val RELEASE_DATE_REGEX =
+            Regex("""release date:\s*</b>\s*([^<]+)""", RegexOption.IGNORE_CASE)
+        private val DESCRIPTION_REGEX =
+            Regex("""description:\s*</b>\s*([\s\S]*?)</li>""", RegexOption.IGNORE_CASE)
+        private val GENRES_INLINE_REGEX =
+            Regex("""genres:\s*</b>\s*([\s\S]*?)</li>""", RegexOption.IGNORE_CASE)
+
+        /** Strip the "Amazon Prime (Game) - " / "Amazon Prime (Loot) - " prefix. */
+        private val TITLE_PREFIX_REGEX =
+            Regex("""^\s*Amazon Prime\s*\([^)]*\)\s*-\s*""", RegexOption.IGNORE_CASE)
+
+        fun parse(xml: String): PrimeGamingFeed {
+            val firstEntry = xml.indexOf("<entry", ignoreCase = true)
+            val head = if (firstEntry >= 0) xml.substring(0, firstEntry) else xml
+            val feedTitle = FEED_TITLE_REGEX.find(head)?.groupValues?.get(1)
+                ?.let(::decodeXmlEntities)?.collapseWhitespace()?.ifBlank { null }
+            val feedUpdated = FEED_UPDATED_REGEX.find(head)?.groupValues?.get(1)?.trim()
+                ?.ifBlank { null }
+
+            val entries = ENTRY_REGEX.findAll(xml)
+                .map { parseEntry(it.groupValues[1]) }
+                .filter { it.game.isNotBlank() }
+                .toList()
+
+            return PrimeGamingFeed(feedTitle, feedUpdated, entries)
+        }
+
+        private fun parseEntry(body: String): PrimeGamingEntry {
+            val idUrl = ID_REGEX.find(body)?.groupValues?.get(1)?.trim().orEmpty()
+            // Stable per-claim id: the trailing LootScraper item number
+            // (…/lootscraper/10498 → "10498"). Falls back to a title slug so a
+            // template change that drops the numeric id doesn't collapse every
+            // chapter onto one key.
+            val rawTitle = TITLE_REGEX.find(body)?.groupValues?.get(1)
+                ?.let(::decodeXmlEntities)?.collapseWhitespace().orEmpty()
+            val game = TITLE_PREFIX_REGEX.replace(rawTitle, "").trim()
+            val id = idUrl.substringAfterLast('/', "").ifBlank { slug(game) }
+
+            val updated = UPDATED_REGEX.find(body)?.groupValues?.get(1)?.trim()?.ifBlank { null }
+
+            val content = CONTENT_REGEX.find(body)?.groupValues?.get(1).orEmpty()
+            val validFrom = VALID_FROM_REGEX.find(content)?.groupValues?.get(1)?.trim()?.ifBlank { null }
+            val validTo = VALID_TO_REGEX.find(content)?.groupValues?.get(1)?.trim()?.ifBlank { null }
+            val releaseDate = RELEASE_DATE_REGEX.find(content)?.groupValues?.get(1)?.trim()?.ifBlank { null }
+            val description = DESCRIPTION_REGEX.find(content)?.groupValues?.get(1)
+                ?.let(::stripTags)?.let(::decodeXmlEntities)?.collapseWhitespace()?.ifBlank { null }
+
+            // Genres: prefer the <category label="…"> tags (clean); fall back to
+            // the inline "Genres: Action, Adventure" list in the content body.
+            val categoryGenres = CATEGORY_LABEL_REGEX.findAll(body)
+                .map { decodeXmlEntities(it.groupValues[1]).trim() }
+                .filter { it.isNotBlank() }
+                .toList()
+            val genres = categoryGenres.ifEmpty {
+                GENRES_INLINE_REGEX.find(content)?.groupValues?.get(1)
+                    ?.let(::stripTags)?.let(::decodeXmlEntities)
+                    ?.split(',')?.map { it.trim() }?.filter { it.isNotBlank() }
+                    ?: emptyList()
+            }
+
+            // Claim link: the entry-level <link href> pointing at Amazon/Luna,
+            // else the first entry <link>, else the <a href> in the content.
+            val links = LINK_HREF_REGEX.findAll(body).map { it.groupValues[1] }.toList()
+            val claimUrl = links.firstOrNull { it.contains("amazon", true) || it.contains("luna", true) }
+                ?: links.firstOrNull()
+                ?: ANCHOR_HREF_REGEX.findAll(content).map { it.groupValues[1] }
+                    .firstOrNull { it.contains("amazon", true) || it.contains("luna", true) }
+
+            return PrimeGamingEntry(
+                id = id,
+                game = game,
+                validFrom = validFrom,
+                validTo = validTo,
+                releaseDate = releaseDate,
+                description = description,
+                genres = genres,
+                claimUrl = claimUrl?.let(::decodeXmlEntities),
+                updated = updated,
+            )
+        }
+
+        private fun slug(s: String): String =
+            s.lowercase().replace(Regex("""[^a-z0-9]+"""), "-").trim('-').ifBlank { "item" }
+    }
+}
+
+/** One claimable Prime Gaming title (a chapter, in Candela's reading model). */
+internal data class PrimeGamingEntry(
+    val id: String,
+    val game: String,
+    val validFrom: String?,
+    val validTo: String?,
+    val releaseDate: String?,
+    val description: String?,
+    val genres: List<String>,
+    val claimUrl: String?,
+    val updated: String?,
+)
+
+private val WHITESPACE_RE = Regex("""\s+""")
+private val TAG_RE = Regex("""<[^>]+>""")
+private val NUMERIC_ENTITY_RE = Regex("""&#(\d+);""")
+
+/** Collapse the multi-line, indented XHTML text into a single spaced line. */
+internal fun String.collapseWhitespace(): String = WHITESPACE_RE.replace(trim(), " ")
+
+/** Drop any residual HTML tags left in a captured fragment. */
+internal fun stripTags(html: String): String = TAG_RE.replace(html, " ")
+
+/**
+ * Decode the entities LootScraper actually emits — named plus numeric
+ * (`&#039;` for an apostrophe is common in its game titles). `&amp;` is
+ * decoded LAST so a doubly-safe `&amp;lt;` doesn't turn into `<`.
+ */
+internal fun decodeXmlEntities(text: String): String =
+    NUMERIC_ENTITY_RE.replace(text) { m ->
+        m.groupValues[1].toIntOrNull()?.let { code -> Char(code).toString() } ?: m.value
+    }
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&apos;", "'")
+        .replace("&#39;", "'")
+        .replace("&amp;", "&")

--- a/source-primegaming/src/test/kotlin/in/jphe/storyvox/source/primegaming/PrimeGamingContractTest.kt
+++ b/source-primegaming/src/test/kotlin/in/jphe/storyvox/source/primegaming/PrimeGamingContractTest.kt
@@ -1,31 +1,68 @@
 package `in`.jphe.storyvox.source.primegaming
 
+import dagger.Lazy
 import `in`.jphe.storyvox.data.source.FictionSource
+import `in`.jphe.storyvox.source.primegaming.config.PrimeGamingConfig
 import `in`.jphe.storyvox.source.primegaming.net.PrimeGamingApi
 import `in`.jphe.storyvox.testkit.source.FictionSourceContractTest
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 import okhttp3.OkHttpClient
 
 /**
- * Prime Gaming against the shared contract kit. This FAILS until you wire
- * [PrimeGamingSource.popular] (and friends) through [PrimeGamingApi.request]:
- * the stub never hits the network, so the "network work leaves the caller
- * thread" and auth/rate-limit checks fail honestly. Replace [happyListBody] /
- * [listPathFragment] with your real list endpoint, make the source talk to the
- * Api, and turn this green. See docs/CONTRIBUTING-SOURCES.md.
+ * Issue #1494 — Prime Gaming against the shared contract kit (IO-pin, auth/rate
+ * mapping, Cloudflare detection, blank-search sanity).
+ *
+ * The source reads a single configurable feed URL, so instead of the scaffold's
+ * baseUrl-override seam we inject a fake [PrimeGamingConfig] pointed at the
+ * MockWebServer — the kit's default router serves [happyListBody] to any path
+ * containing [listPathFragment].
  */
 class PrimeGamingContractTest : FictionSourceContractTest() {
+
     override fun createSource(client: OkHttpClient, baseUrl: String): FictionSource {
-        val host = baseUrl.trimEnd('/')
-        return PrimeGamingSource(
-            object : PrimeGamingApi(client) {
-                override val baseUrl: String get() = host
-            },
-        )
+        val feedUrl = baseUrl.trimEnd('/') + "/lootscraper_amazon_game.xml"
+        val fakeConfig = object : PrimeGamingConfig {
+            override val feedUrlFlow: Flow<String> = flowOf(feedUrl)
+            override suspend fun feedUrl(): String = feedUrl
+            override suspend fun setFeedUrl(url: String?) = Unit
+        }
+        val api = PrimeGamingApi(client, object : Lazy<PrimeGamingConfig> {
+            override fun get(): PrimeGamingConfig = fakeConfig
+        })
+        return PrimeGamingSource(api)
     }
 
-    /** Replace with a trimmed real response body from your list endpoint. */
-    override fun happyListBody(): String = "{}"
+    override fun happyListBody(): String = SAMPLE_ATOM
 
-    /** Replace with a path fragment your popular()/list endpoint hits. */
-    override fun listPathFragment(): String = "primegaming"
+    override fun listPathFragment(): String = "lootscraper"
+
+    private companion object {
+        /** A trimmed, real-shaped LootScraper Amazon-Prime Atom feed (2 entries). */
+        val SAMPLE_ATOM: String = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en">
+              <id>https://feed.eikowagenknecht.com/lootscraper/amazon</id>
+              <title>Free Amazon Prime Games (PC)</title>
+              <updated>2026-07-02T18:00:48.767Z</updated>
+              <entry>
+                <id>https://feed.eikowagenknecht.com/lootscraper/10498</id>
+                <title>Amazon Prime (Game) - A Rat's Quest: The Way Back Home</title>
+                <updated>2026-04-09T18:00:52.977Z</updated>
+                <content type="xhtml"><div xmlns="http://www.w3.org/1999/xhtml"><ul><li><b>Offer valid from:</b> 2026-04-09 18:00</li><li><b>Offer valid to:</b> 2026-07-08 00:00</li><ul><li><b>Release date:</b> 2026-04-03</li><li><b>Description:</b> Follow Mat, the Scavenger, on his long journey home.</li><li><b>Genres:</b> Action, Adventure, Indie</li></ul></ul><p>Claim it now for free on <a href="https://luna.amazon.com/claims/a-rats-quest">Amazon Prime</a>.</p></div></content>
+                <link href="https://luna.amazon.com/claims/a-rats-quest"/>
+                <category term="Genre: Action" label="Action"/>
+                <category term="Genre: Adventure" label="Adventure"/>
+              </entry>
+              <entry>
+                <id>https://feed.eikowagenknecht.com/lootscraper/10512</id>
+                <title>Amazon Prime (Game) - Mafia III: Definitive Edition</title>
+                <updated>2026-06-25T17:00:49.584Z</updated>
+                <content type="xhtml"><div xmlns="http://www.w3.org/1999/xhtml"><ul><li><b>Offer valid from:</b> 2026-06-25 17:00</li><li><b>Offer valid to:</b> 2026-09-23 00:00</li><ul><li><b>Description:</b> New Bordeaux, 1968. After your family is killed, you build a new one.</li><li><b>Genres:</b> Action</li></ul></ul><p>Claim it now for free on <a href="https://luna.amazon.com/claims/mafia-iii">Amazon Prime</a>.</p></div></content>
+                <link href="https://luna.amazon.com/claims/mafia-iii"/>
+                <category term="Genre: Action" label="Action"/>
+              </entry>
+            </feed>
+        """.trimIndent()
+    }
 }

--- a/source-primegaming/src/test/kotlin/in/jphe/storyvox/source/primegaming/PrimeGamingContractTest.kt
+++ b/source-primegaming/src/test/kotlin/in/jphe/storyvox/source/primegaming/PrimeGamingContractTest.kt
@@ -1,0 +1,31 @@
+package `in`.jphe.storyvox.source.primegaming
+
+import `in`.jphe.storyvox.data.source.FictionSource
+import `in`.jphe.storyvox.source.primegaming.net.PrimeGamingApi
+import `in`.jphe.storyvox.testkit.source.FictionSourceContractTest
+import okhttp3.OkHttpClient
+
+/**
+ * Prime Gaming against the shared contract kit. This FAILS until you wire
+ * [PrimeGamingSource.popular] (and friends) through [PrimeGamingApi.request]:
+ * the stub never hits the network, so the "network work leaves the caller
+ * thread" and auth/rate-limit checks fail honestly. Replace [happyListBody] /
+ * [listPathFragment] with your real list endpoint, make the source talk to the
+ * Api, and turn this green. See docs/CONTRIBUTING-SOURCES.md.
+ */
+class PrimeGamingContractTest : FictionSourceContractTest() {
+    override fun createSource(client: OkHttpClient, baseUrl: String): FictionSource {
+        val host = baseUrl.trimEnd('/')
+        return PrimeGamingSource(
+            object : PrimeGamingApi(client) {
+                override val baseUrl: String get() = host
+            },
+        )
+    }
+
+    /** Replace with a trimmed real response body from your list endpoint. */
+    override fun happyListBody(): String = "{}"
+
+    /** Replace with a path fragment your popular()/list endpoint hits. */
+    override fun listPathFragment(): String = "primegaming"
+}

--- a/source-primegaming/src/test/kotlin/in/jphe/storyvox/source/primegaming/PrimeGamingSourceTest.kt
+++ b/source-primegaming/src/test/kotlin/in/jphe/storyvox/source/primegaming/PrimeGamingSourceTest.kt
@@ -1,0 +1,148 @@
+package `in`.jphe.storyvox.source.primegaming
+
+import dagger.Lazy
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import `in`.jphe.storyvox.data.source.model.SearchQuery
+import `in`.jphe.storyvox.source.primegaming.config.PrimeGamingConfig
+import `in`.jphe.storyvox.source.primegaming.net.PrimeGamingApi
+import `in`.jphe.storyvox.source.primegaming.net.PrimeGamingFeed
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.runBlocking
+import okhttp3.OkHttpClient
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1494 — end-to-end happy-path wiring for [PrimeGamingSource], with the
+ * feed served from a canned parse (no network) by overriding the `open`
+ * [PrimeGamingApi.feed].
+ *
+ * This exists on purpose alongside the contract kit: the kit's happy-path check
+ * only asserts that a request was *made* on an IO thread, not that the body was
+ * served and mapped to `Success` (see reverie's dx #1523 — a wrong
+ * `listPathFragment` 404s but still passes the IO-pin check). These tests assert
+ * the body actually becomes a collection + chapters, so a routing/mapping
+ * regression fails loudly instead of silently false-greening.
+ */
+class PrimeGamingSourceTest {
+
+    private val atom = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en">
+          <title>Free Amazon Prime Games (PC)</title>
+          <updated>2026-07-02T18:00:48.767Z</updated>
+          <entry>
+            <id>https://feed.eikowagenknecht.com/lootscraper/10498</id>
+            <title>Amazon Prime (Game) - A Rat's Quest: The Way Back Home</title>
+            <content type="xhtml"><div xmlns="http://www.w3.org/1999/xhtml"><ul><li><b>Offer valid from:</b> 2026-04-09 18:00</li><li><b>Offer valid to:</b> 2026-07-08 00:00</li><ul><li><b>Description:</b> Follow Mat home.</li></ul></ul><p>Claim on <a href="https://luna.amazon.com/claims/a-rats-quest">Amazon Prime</a>.</p></div></content>
+            <link href="https://luna.amazon.com/claims/a-rats-quest"/>
+            <category term="Genre: Adventure" label="Adventure"/>
+            <category term="Genre: Indie" label="Indie"/>
+          </entry>
+          <entry>
+            <id>https://feed.eikowagenknecht.com/lootscraper/10512</id>
+            <title>Amazon Prime (Game) - Mafia III: Definitive Edition</title>
+            <content type="xhtml"><div xmlns="http://www.w3.org/1999/xhtml"><ul><li><b>Offer valid to:</b> 2026-09-23 00:00</li><ul><li><b>Description:</b> New Bordeaux, 1968.</li></ul></ul><p>Claim on <a href="https://luna.amazon.com/claims/mafia-iii">Amazon Prime</a>.</p></div></content>
+            <link href="https://luna.amazon.com/claims/mafia-iii"/>
+            <category term="Genre: Action" label="Action"/>
+          </entry>
+        </feed>
+    """.trimIndent()
+
+    private fun sourceReturning(result: FictionResult<PrimeGamingApi.FeedFetch>): PrimeGamingSource {
+        val cfg = object : PrimeGamingConfig {
+            override val feedUrlFlow: Flow<String> = emptyFlow()
+            override suspend fun feedUrl(): String = "https://example.test/feed.xml"
+            override suspend fun setFeedUrl(url: String?) = Unit
+        }
+        val api = object : PrimeGamingApi(
+            OkHttpClient(),
+            object : Lazy<PrimeGamingConfig> { override fun get(): PrimeGamingConfig = cfg },
+        ) {
+            override suspend fun feed(forceRefresh: Boolean): FictionResult<FeedFetch> = result
+        }
+        return PrimeGamingSource(api)
+    }
+
+    private fun happySource(): PrimeGamingSource =
+        sourceReturning(FictionResult.Success(PrimeGamingApi.FeedFetch(PrimeGamingFeed.parse(atom), "rev-1")))
+
+    private fun <T> FictionResult<T>.success(): T {
+        assertTrue("expected Success, got $this", this is FictionResult.Success)
+        return (this as FictionResult.Success).value
+    }
+
+    @Test
+    fun `popular surfaces one collection fiction with the honest Prime caveat`() {
+        val page = runBlocking { happySource().popular(1) }.success()
+        assertEquals(1, page.items.size)
+        assertFalse(page.hasNext)
+        val fiction = page.items.first()
+        assertEquals("Prime Gaming Free Games", fiction.title)
+        assertEquals(2, fiction.chapterCount)
+        assertTrue(
+            "collection description must state a Prime subscription is required",
+            fiction.description!!.contains("Prime subscription", ignoreCase = true),
+        )
+    }
+
+    @Test
+    fun `popular page 2 is empty so pagination terminates`() {
+        val page = runBlocking { happySource().popular(2) }.success()
+        assertTrue(page.items.isEmpty())
+        assertFalse(page.hasNext)
+    }
+
+    @Test
+    fun `fictionDetail lists each claim as a chapter`() {
+        val src = happySource()
+        val fid = runBlocking { src.popular(1) }.success().items.first().id
+        val detail = runBlocking { src.fictionDetail(fid) }.success()
+        assertEquals(2, detail.chapters.size)
+        assertTrue(detail.chapters.map { it.title }.contains("Mafia III: Definitive Edition"))
+        assertEquals(listOf("Action", "Adventure", "Indie"), detail.genres.sorted())
+    }
+
+    @Test
+    fun `unknown fiction id is NotFound`() {
+        assertTrue(runBlocking { happySource().fictionDetail("not-a-fiction") } is FictionResult.NotFound)
+    }
+
+    @Test
+    fun `chapter returns narratable content carrying the Prime caveat and claim link`() {
+        val src = happySource()
+        val fid = runBlocking { src.popular(1) }.success().items.first().id
+        val chId = runBlocking { src.fictionDetail(fid) }.success().chapters.first().id
+        val content = runBlocking { src.chapter(fid, chId) }.success()
+        assertTrue(content.plainBody.contains("Amazon Prime subscription"))
+        assertTrue(content.plainBody.contains("luna.amazon.com"))
+        assertTrue(content.htmlBody.isNotBlank())
+    }
+
+    @Test
+    fun `missing chapter id is NotFound`() {
+        val src = happySource()
+        val fid = runBlocking { src.popular(1) }.success().items.first().id
+        assertTrue(runBlocking { src.chapter(fid, "99999") } is FictionResult.NotFound)
+    }
+
+    @Test
+    fun `search matches a game title, misses an unrelated term, and blank returns the collection`() {
+        val src = happySource()
+        assertEquals(1, runBlocking { src.search(SearchQuery(term = "mafia")) }.success().items.size)
+        assertEquals(0, runBlocking { src.search(SearchQuery(term = "zzz-no-such-game")) }.success().items.size)
+        assertEquals(1, runBlocking { src.search(SearchQuery(term = "")) }.success().items.size)
+    }
+
+    @Test
+    fun `a feed failure propagates as a typed failure, and genres degrades to empty`() {
+        val down = sourceReturning(FictionResult.NetworkError("feed down"))
+        assertTrue(runBlocking { down.popular(1) } is FictionResult.NetworkError)
+        // Genre picker must not error out on a feed hiccup.
+        val genres = runBlocking { down.genres() }.success()
+        assertTrue(genres.isEmpty())
+    }
+}

--- a/source-primegaming/src/test/kotlin/in/jphe/storyvox/source/primegaming/net/PrimeGamingFeedTest.kt
+++ b/source-primegaming/src/test/kotlin/in/jphe/storyvox/source/primegaming/net/PrimeGamingFeedTest.kt
@@ -1,0 +1,108 @@
+package `in`.jphe.storyvox.source.primegaming.net
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1494 — pins the LootScraper Atom layout the regex parser keys off.
+ *
+ * The load-bearing assertion is [content extracted from xhtml, not empty]: the
+ * narratable payload lives in `<content type="xhtml">` as a nested `<div>`, so a
+ * naive `.text`/`nextText()` read returns empty. If a future refactor swaps the
+ * regex parse for an XmlPullParser and reintroduces that bug, this test fails
+ * instead of shipping empty chapters.
+ */
+class PrimeGamingFeedTest {
+
+    private val feedXml = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en">
+          <id>https://feed.eikowagenknecht.com/lootscraper/amazon</id>
+          <title>Free Amazon Prime Games (PC)</title>
+          <updated>2026-07-02T18:00:48.767Z</updated>
+          <entry>
+            <id>https://feed.eikowagenknecht.com/lootscraper/10498</id>
+            <title>Amazon Prime (Game) - A Rat&#039;s Quest: The Way Back Home</title>
+            <updated>2026-04-09T18:00:52.977Z</updated>
+            <content type="xhtml"><div xmlns="http://www.w3.org/1999/xhtml"><img src="x.jpg" /><ul><li><b>Offer valid from:</b> 2026-04-09 18:00</li><li><b>Offer valid to:</b> 2026-07-08 00:00</li><ul><li><b>Release date:</b> 2026-04-03</li><li><b>Description:</b> Follow Mat &amp; friends on a rodent&#039;s adventure.</li><li><b>Genres:</b> Action, Adventure, Indie</li></ul></ul><p>Claim it now for free on <a href="https://luna.amazon.com/claims/a-rats-quest">Amazon Prime</a>.</p></div></content>
+            <link href="https://luna.amazon.com/claims/a-rats-quest"/>
+            <category term="Genre: Action" label="Action"/>
+            <category term="Genre: Adventure" label="Adventure"/>
+            <category term="Genre: Indie" label="Indie"/>
+          </entry>
+          <entry>
+            <id>https://feed.eikowagenknecht.com/lootscraper/10512</id>
+            <title>Amazon Prime (Game) - Space Grunts</title>
+            <updated>2026-06-25T17:00:49.584Z</updated>
+            <content type="xhtml"><div xmlns="http://www.w3.org/1999/xhtml"><ul><li><b>Offer valid from:</b> 2026-06-25 17:00</li><li><b>Offer valid to:</b> 2026-09-23 00:00</li><ul><li><b>Description:</b> Fight your way through a moon base.</li></ul></ul><p>Claim it on <a href="https://luna.amazon.com/claims/space-grunts">Amazon Prime</a>.</p></div></content>
+            <link href="https://luna.amazon.com/claims/space-grunts"/>
+          </entry>
+        </feed>
+    """.trimIndent()
+
+    @Test
+    fun `parses feed-level title and both entries`() {
+        val feed = PrimeGamingFeed.parse(feedXml)
+        assertEquals("Free Amazon Prime Games (PC)", feed.title)
+        assertEquals(2, feed.entries.size)
+    }
+
+    @Test
+    fun `strips the Amazon Prime prefix and decodes entities in the game title`() {
+        val first = PrimeGamingFeed.parse(feedXml).entries[0]
+        assertEquals("A Rat's Quest: The Way Back Home", first.game)
+    }
+
+    @Test
+    fun `uses the trailing lootscraper number as a stable id`() {
+        val feed = PrimeGamingFeed.parse(feedXml)
+        assertEquals("10498", feed.entries[0].id)
+        assertEquals("10512", feed.entries[1].id)
+    }
+
+    @Test
+    fun `content extracted from xhtml, not empty (the trap regression test)`() {
+        val first = PrimeGamingFeed.parse(feedXml).entries[0]
+        // Description lives inside the xhtml content div — must be non-empty.
+        assertNotNull(first.description)
+        assertTrue(first.description!!.isNotBlank())
+        // Entity decoding: &amp; -> &, &#039; -> '
+        assertEquals("Follow Mat & friends on a rodent's adventure.", first.description)
+    }
+
+    @Test
+    fun `extracts the claim window and release date`() {
+        val first = PrimeGamingFeed.parse(feedXml).entries[0]
+        assertEquals("2026-04-09 18:00", first.validFrom)
+        assertEquals("2026-07-08 00:00", first.validTo)
+        assertEquals("2026-04-03", first.releaseDate)
+    }
+
+    @Test
+    fun `reads genres from category labels`() {
+        val first = PrimeGamingFeed.parse(feedXml).entries[0]
+        assertEquals(listOf("Action", "Adventure", "Indie"), first.genres)
+    }
+
+    @Test
+    fun `falls back to inline genres when no category tags`() {
+        // Second entry has no <category> tags; there is no inline Genres line
+        // either, so genres is empty (not a crash).
+        val second = PrimeGamingFeed.parse(feedXml).entries[1]
+        assertTrue(second.genres.isEmpty())
+    }
+
+    @Test
+    fun `extracts the Amazon claim url`() {
+        val first = PrimeGamingFeed.parse(feedXml).entries[0]
+        assertEquals("https://luna.amazon.com/claims/a-rats-quest", first.claimUrl)
+    }
+
+    @Test
+    fun `empty or junk input yields an empty feed, not a crash`() {
+        assertTrue(PrimeGamingFeed.parse("").entries.isEmpty())
+        assertTrue(PrimeGamingFeed.parse("<html>not a feed</html>").entries.isEmpty())
+    }
+}


### PR DESCRIPTION
## What & why

Adds `source-primegaming` — an Amazon Prime Gaming "free games to claim" source (sibling of the Epic source #1493, Morning Briefing #1467 material).

**Built only after the research gate passed.** #1494 forbade implementation until a data path was validated. The [verdict on #1494](https://github.com/techempower-org/candela/issues/1494#issuecomment-4880318410) probed every candidate with Candela's honest UA:
- Amazon exposes nothing usable — `gaming.amazon.com/graphql` → **403** unauth, needs a paid Prime session + CSRF; scraping violates Amazon's CoU (non-starter).
- GamerPower, the flagship free-giveaway API, **deliberately doesn't track Prime Gaming** (Prime freebies are a paid-sub perk, not universal giveaways).
- The one clean path: the community **LootScraper** Amazon-Prime **Atom feed** (MIT) — honest UA → 200, no throttle, conditional-GET/304, full per-entry narratable content.

Team-lead's GO converted my three research concerns into hard requirements; all are delivered below.

## ⚠️ How the feed-URL override works TODAY (read this before "configurable")

"Configurable feed URL" here means a **persisted config seam**, **not a settings-screen UI**:
- The LootScraper canonical URL ships as the baked-in default (`PrimeGamingConfig.DEFAULT_FEED_URL`).
- An override is **persisted** in a dedicated DataStore (`PrimeGamingConfigImpl` in `:app`) and read live via a `Flow`; `setFeedUrl()` is the write path.
- **There is no user-facing control to edit it yet.** In practice the default is repointable via an app release (change the constant) or programmatically via the seam. If LootScraper moves domains again (it has once), that's the mitigation until the UI lands.
- The user-facing row is filed as **#1535** and should ride the generic per-source config-field seam (**#1531**), not a one-off row in the mid-migration settings monolith (#440).

The source/fiction copy makes **no** promise of UI configurability — it only states a Prime subscription is required.

## Reading model
One synthetic fiction ("Prime Gaming Free Games"); each currently-claimable title is a chapter carrying its name, claim window, genres, and how to redeem.

## Criteria (from the GO) vs delivered

| Requirement | Delivered |
|---|---|
| **Honest framing** — "requires a Prime subscription" in source description AND fiction description | `displayName`/`@SourcePlugin.description` + the collection synopsis all state a Prime sub is required; never marketed as "free games" without the caveat |
| **Configurable feed URL** — LootScraper canonical default, overridable, live-persist, `dagger.Lazy` (#1309) | `PrimeGamingConfig` (default `DEFAULT_FEED_URL`) + `:app` `PrimeGamingConfigImpl` (DataStore, live `Flow`), consumed via `dagger.Lazy`. **Override = persisted seam today, no UI** (see callout above) → UI deferred to #1535 |
| **Conditional-GET etiquette** (feed supports 304) | Api records `ETag`/`Last-Modified`, replays `If-None-Match`/`If-Modified-Since`, treats 304 as "reuse cached parse" |
| **Attribution** — LootScraper (MIT) | Credited in the collection synopsis + KDoc |
| **xhtml content trap** — serialize the div, not `.text` | Regex Atom parser captures the `<content>` span as a raw substring; `PrimeGamingFeedTest` pins non-empty extraction as a regression test |
| **Typed errors for feed-down/moved** — graceful, no crash | Every non-2xx → typed `FictionResult`; `IOException` → `NetworkError`; junk/empty body → empty feed, never a throw |
| **Claim-window dates as chapter structure** | `validFrom`/`validTo`/`releaseDate`/`genres`/`claimUrl` per chapter |
| **Morning Briefing (#1467)** | Follow-up — standard `@SourcePlugin`; no dedicated MB registration seam observed |

## Design notes
- **Single upstream request.** Everything derives from one feed doc → in-memory TTL cache so chapter taps don't re-download (the #1489 lesson).
- **JVM-safe parse.** Hand-rolled regex Atom parser (arxiv-style) — no `android.util.Xml`, runs on the plain JUnit classpath (no Robolectric).
- **#585 IO-pin**, **#1309 Lazy**, two-binding `@SourcePlugin` wiring all honored.

## Test evidence
- `PrimeGamingContractTest` (shared kit): IO-pin, 401→AuthRequired, 429→RateLimited, CF-challenge→NetworkError, blank-search — via an injected fake config pointed at MockWebServer; `listPathFragment="lootscraper"` matches the real feed path so the happy body is actually served (guards dx #1523).
- `PrimeGamingSourceTest` (9 cases): end-to-end popular→Success + honest-caveat description, chapters, chapter narration + claim link, search matching, typed-failure propagation — proves the body maps to a collection, not just that a request was made.
- `PrimeGamingFeedTest` (9 cases): prefix strip + entity decode, stable id, **xhtml-content-not-empty (the trap)**, claim window, category-label genres, claim URL, empty/junk → empty feed.
- Not compiled locally per CLAUDE.md (CI Build APK + Test Compile is the gate).

## Dogfood (source-wave rule 4)
Filed #1533 (JSON-hardcoded `request()` wrapper vs XML sources); confirmed repros on #1522, #1523, #1527, #1531.

Refs #1494, #1531, #1535, #1467
