### PR TITLE
feat(ocr): gallery import via the system Photo Picker — first-class Google Photos (#1537)

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/ocr/OcrCaptureScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/ocr/OcrCaptureScreen.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.camera.core.ImageCapture
 import androidx.camera.core.ImageCaptureException
@@ -73,10 +74,11 @@ import java.io.ByteArrayOutputStream
  *     CAMERA permission; shows a plain-language rationale before the
  *     prompt and a graceful "use the gallery instead" fallback if the
  *     user declines (so a denied camera never dead-ends the feature).
- *  2. **Gallery** — `ActivityResultContracts.GetContent` for images,
- *     no permission needed. This is the path a screen-reader user who
- *     can't aim a camera, or anyone with an existing photo of a page,
- *     takes — never gate the feature behind the camera.
+ *  2. **Gallery** — the system Photo Picker (`PickVisualMedia`, #1537),
+ *     no permission needed, and it surfaces Google Photos first-class
+ *     (including cloud-only items). This is the path a screen-reader
+ *     user who can't aim a camera, or anyone with an existing photo of
+ *     a page, takes — never gate the feature behind the camera.
  *
  * Captured/picked images are decoded to JPEG bytes and handed to
  * [OcrCaptureViewModel.onImageCaptured], which runs on-device ML Kit
@@ -120,10 +122,12 @@ fun OcrCaptureScreen(
         cameraDenied = !granted
     }
 
-    // Gallery pick — no permission needed (the system photo picker
-    // returns a one-shot read grant for the chosen image).
+    // Gallery pick via the system Photo Picker (#1537) — permissionless
+    // one-shot read grant, and surfaces Google Photos first-class
+    // (including cloud-only items), which the legacy GetContent route
+    // only reached through a device-dependent fallback handler.
     val galleryLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.GetContent(),
+        contract = ActivityResultContracts.PickVisualMedia(),
     ) { uri: Uri? ->
         uri?.let {
             val bytes = readImageBytes(context, it)
@@ -196,7 +200,11 @@ fun OcrCaptureScreen(
             ) {
                 BrassButton(
                     label = stringResource(R.string.ocr_pick_from_gallery),
-                    onClick = { galleryLauncher.launch("image/*") },
+                    onClick = {
+                        galleryLauncher.launch(
+                            PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly),
+                        )
+                    },
                     variant = BrassButtonVariant.Secondary,
                     enabled = !state.isRecognizing && !state.isSaving,
                     modifier = Modifier.weight(1f),


### PR DESCRIPTION
Answers JP's question (2026-07-03): Google Photos is now reachable through the **normal media picker**.

**Before:** `ActivityResultContracts.GetContent()` + `launch("image/*")` — the legacy document-picker route; Google Photos appeared only as an optional legacy handler on some devices. (The kdoc already claimed 'system photo picker' — the code didn't match.)

**After:** `ActivityResultContracts.PickVisualMedia()` + `PickVisualMediaRequest(ImageOnly)` — the Android Photo Picker: still permissionless (one-shot read grant), and surfaces Google Photos first-class including **cloud-only backups** (cloud-media-provider integration on 13+, Play-services backport below). Result URI feeds the exact same `readImageBytes` → OCR pipeline; no other changes.

activity-compose 1.13.0 already includes the contract (needs ≥1.7) — zero dependency changes. One file, +12 −5.

Closes #1537.