### PR TITLE
fix(primegaming): supplementary-plane numeric entities (emoji) no longer throw (#1539)

### DIFF
--- a/source-primegaming/src/main/kotlin/in/jphe/storyvox/source/primegaming/net/PrimeGamingFeed.kt
+++ b/source-primegaming/src/main/kotlin/in/jphe/storyvox/source/primegaming/net/PrimeGamingFeed.kt
@@ -188,7 +188,13 @@ internal fun stripTags(html: String): String = TAG_RE.replace(html, " ")
  */
 internal fun decodeXmlEntities(text: String): String =
     NUMERIC_ENTITY_RE.replace(text) { m ->
-        m.groupValues[1].toIntOrNull()?.let { code -> Char(code).toString() } ?: m.value
+        m.groupValues[1].toIntOrNull()
+            // Supplementary-plane chars (emoji in game descriptions, e.g.
+            // &#128512;) need Character.toChars — Char(code) throws above
+            // 0xFFFF. Out-of-range and surrogate code points stay literal.
+            ?.takeIf { it in 0..0x10FFFF && it !in 0xD800..0xDFFF }
+            ?.let { code -> String(Character.toChars(code)) }
+            ?: m.value
     }
         .replace("&lt;", "<")
         .replace("&gt;", ">")

--- a/source-primegaming/src/test/kotlin/in/jphe/storyvox/source/primegaming/net/PrimeGamingFeedTest.kt
+++ b/source-primegaming/src/test/kotlin/in/jphe/storyvox/source/primegaming/net/PrimeGamingFeedTest.kt
@@ -105,4 +105,16 @@ class PrimeGamingFeedTest {
         assertTrue(PrimeGamingFeed.parse("").entries.isEmpty())
         assertTrue(PrimeGamingFeed.parse("<html>not a feed</html>").entries.isEmpty())
     }
+
+    @Test
+    fun `numeric entities decode across planes and never throw`() {
+        // BMP apostrophe — the common LootScraper case.
+        assertEquals("Rat's Quest", decodeXmlEntities("Rat&#039;s Quest"))
+        // Supplementary plane: emoji must decode via a surrogate pair,
+        // not throw (Char(code) IAE above 0xFFFF — the #1539 regression).
+        assertEquals("Fun 😀!", decodeXmlEntities("Fun &#128512;!"))
+        // Out-of-Unicode-range and surrogate code points stay literal.
+        assertEquals("bad &#1114112; ref", decodeXmlEntities("bad &#1114112; ref"))
+        assertEquals("lone &#55296; ref", decodeXmlEntities("lone &#55296; ref"))
+    }
 }


### PR DESCRIPTION
Post-merge verification of Gemini's HIGH on #1536 confirmed it real — and stronger than reported: `Char(Int)` requires a UTF-16 code unit, so any numeric entity above 0xFFFF throws. An emoji in a game description (`&#128512;`) is plausible LootScraper data, not adversarial input.

Fix: `Character.toChars` (surrogate-pair aware) with an explicit `0..0x10FFFF` minus-surrogates guard — never throws; invalid refs pass through literally. Tests: BMP apostrophe (existing behavior), emoji via surrogate pair, out-of-range literal, lone-surrogate literal.

Closes #1539.