### PR TITLE
fix(ao3): CF WAF/1020 block 403s → retryable NetworkError

### DIFF
--- a/source-ao3/src/main/kotlin/in/jphe/storyvox/source/ao3/net/Ao3Api.kt
+++ b/source-ao3/src/main/kotlin/in/jphe/storyvox/source/ao3/net/Ao3Api.kt
@@ -189,10 +189,29 @@ internal open class Ao3Api @Inject constructor(
                 val ctype = resp.header("Content-Type").orEmpty()
                 when {
                     resp.code == 404 -> FictionResult.NotFound("EPUB not available for work $workId")
-                    resp.code == 401 || resp.code == 403 ->
-                        FictionResult.AuthRequired(
-                            "AO3 sign-in required for work $workId (likely Archive-Warning gated)",
-                        )
+                    // #1502 — a 403/401 here may be a genuine Archive-Warning /
+                    // auth gate OR Cloudflare fronting AO3. Sniff the body before
+                    // committing to the terminal AuthRequired path (a sign-in
+                    // prompt can't clear a CF block): an interactive challenge
+                    // escalates to the WebView resolver (Cloudflare), a WAF/1020
+                    // block is transient + IP-scoped so it must be a retryable
+                    // NetworkError, and only a real gate stays AuthRequired.
+                    resp.code == 401 || resp.code == 403 -> {
+                        val body = resp.body?.string().orEmpty()
+                        when {
+                            looksLikeCfChallenge(body) -> FictionResult.Cloudflare(
+                                challengeUrl = url,
+                                message = "AO3 returned a Cloudflare challenge for EPUB download (work $workId)",
+                            )
+                            looksLikeCfBlock(body) -> FictionResult.NetworkError(
+                                "AO3 returned a Cloudflare block page for EPUB download (work $workId, HTTP ${resp.code})",
+                                IOException("HTTP ${resp.code} (Cloudflare block)"),
+                            )
+                            else -> FictionResult.AuthRequired(
+                                "AO3 sign-in required for work $workId (likely Archive-Warning gated)",
+                            )
+                        }
+                    }
                     !resp.isSuccessful -> FictionResult.NetworkError(
                         "HTTP ${resp.code} downloading AO3 EPUB",
                         IOException("HTTP ${resp.code}"),
@@ -329,6 +348,17 @@ internal open class Ao3Api @Inject constructor(
                             looksLikeCfChallenge(body) -> FictionResult.Cloudflare(
                                 challengeUrl = baseUrl + path,
                                 message = "AO3 returned a Cloudflare challenge for $path (HTTP ${resp.code})",
+                            )
+                            // #1502 — a Cloudflare WAF / Error-1020 block page
+                            // also arrives as a 403 but carries none of the
+                            // interactive-challenge markers above. There is no
+                            // challenge to solve, so it must NOT fall through to
+                            // the terminal AuthRequired arm; a WAF block is
+                            // transient + IP-scoped, so surface it as a retryable
+                            // NetworkError. Must precede the 401/403 arm.
+                            looksLikeCfBlock(body) -> FictionResult.NetworkError(
+                                "AO3 returned a Cloudflare block page for $path (HTTP ${resp.code})",
+                                IOException("HTTP ${resp.code} (Cloudflare block)"),
                             )
                             resp.code == 401 || resp.code == 403 -> FictionResult.AuthRequired(
                                 "HTTP ${resp.code} from $url",
@@ -521,6 +551,42 @@ internal open class Ao3Api @Inject constructor(
                 body.substringAfter("<title>").substringBefore("</title>")
                     .contains("Just a moment", ignoreCase = true)
             return hasChallengeTitle && body.length < 20_000
+        }
+
+        /**
+         * #1502 — Cheap signal that a NON-success response body is a
+         * Cloudflare WAF / firewall *block* page (typically HTTP 403 —
+         * "Error 1020: Access denied", "Sorry, you have been blocked",
+         * "Attention Required!") rather than the interactive JS challenge
+         * [looksLikeCfChallenge] sniffs for.
+         *
+         * The distinction drives routing. A challenge can be *solved*
+         * (escalate to the WebView resolver via [FictionResult.Cloudflare]);
+         * a WAF block cannot — the CDN refused the request outright on
+         * IP/ASN reputation, with no challenge to complete. Left mapped to
+         * the 401/403 -> [FictionResult.AuthRequired] arm, such a block is
+         * TERMINAL in ChapterDownloadWorker (FAILED + a sign-in prompt that
+         * can never clear a WAF block). Routing it here instead yields a
+         * retryable [FictionResult.NetworkError], which is correct: these
+         * blocks are transient and IP-scoped, so a later retry can succeed.
+         *
+         * Guarded on the literal "cloudflare" token so genuine AO3 403s
+         * (real auth gates, "You must agree" interstitials) never match, and
+         * paired with block-specific phrases so a page merely *mentioning*
+         * Cloudflare (e.g. a fic that quotes an error page) can't
+         * false-positive. Must run AFTER [looksLikeCfChallenge] at the call
+         * site so an interactive challenge still wins the WebView path.
+         */
+        internal fun looksLikeCfBlock(body: String): Boolean {
+            if (!body.contains("cloudflare", ignoreCase = true)) return false
+            return body.contains("error 1020", ignoreCase = true) ||
+                body.contains("error code: 1020", ignoreCase = true) ||
+                body.contains("sorry, you have been blocked", ignoreCase = true) ||
+                body.contains("attention required", ignoreCase = true) ||
+                (
+                    body.contains("access denied", ignoreCase = true) &&
+                        body.contains("ray id", ignoreCase = true)
+                    )
         }
     }
 }

--- a/source-ao3/src/test/kotlin/in/jphe/storyvox/source/ao3/Ao3CfBlockTest.kt
+++ b/source-ao3/src/test/kotlin/in/jphe/storyvox/source/ao3/Ao3CfBlockTest.kt
@@ -1,0 +1,161 @@
+package `in`.jphe.storyvox.source.ao3
+
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import `in`.jphe.storyvox.source.ao3.net.Ao3Api
+import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * #1502 — a Cloudflare WAF / firewall *block* page (HTTP 403, "Error 1020:
+ * Access denied", "Sorry, you have been blocked") carries NONE of the
+ * interactive-challenge markers [Ao3Api.looksLikeCfChallenge] sniffs for, so
+ * it used to fall through to the 401/403 -> [FictionResult.AuthRequired] arm.
+ * That arm is TERMINAL in ChapterDownloadWorker (FAILED + a sign-in prompt
+ * that can never clear a WAF block) where a retryable [FictionResult.NetworkError]
+ * would let WorkManager back off and retry. These tests pin the new
+ * classification and the end-to-end routing on both network paths
+ * ([Ao3Api.tagFeed] via `requestText`, and [Ao3Api.downloadEpub]).
+ */
+class Ao3CfBlockTest {
+
+    private lateinit var server: MockWebServer
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    /** A representative Cloudflare Error-1020 WAF block page (403, no JS challenge). */
+    private fun cfBlockBody(): String =
+        """
+        <!DOCTYPE html>
+        <html lang="en-US">
+        <head><title>Attention Required! | Cloudflare</title></head>
+        <body>
+          <h1>Sorry, you have been blocked</h1>
+          <h2>You are unable to access archiveofourown.org</h2>
+          <p>Error 1020: Access denied</p>
+          <p>Cloudflare Ray ID: 8b0f0c0a0b0c0d0e</p>
+          <p>Performance &amp; security by Cloudflare</p>
+        </body>
+        </html>
+        """.trimIndent()
+
+    private fun api(): Ao3Api {
+        val host = server.url("/").toString().trimEnd('/')
+        val client = OkHttpClient()
+        return object : Ao3Api(client, client) {
+            override val baseUrl: String get() = host
+        }
+    }
+
+    // ─── classification (pure) ────────────────────────────────────────────
+
+    @Test
+    fun `looksLikeCfBlock matches the 1020 WAF page`() {
+        assertTrue(Ao3Api.looksLikeCfBlock(cfBlockBody()))
+    }
+
+    @Test
+    fun `looksLikeCfBlock matches common block phrasings`() {
+        assertTrue(
+            "error code: 1020 variant",
+            Ao3Api.looksLikeCfBlock("Cloudflare — error code: 1020 Access denied"),
+        )
+        assertTrue(
+            "access denied + ray id pair",
+            Ao3Api.looksLikeCfBlock("<p>Access denied</p><p>Cloudflare Ray ID: abc123</p>"),
+        )
+    }
+
+    @Test
+    fun `looksLikeCfBlock rejects real AO3 content and login form`() {
+        // Real content has no "cloudflare" token at all.
+        assertFalse(
+            Ao3Api.looksLikeCfBlock(
+                """<ol class="work index group"><li class="work blurb">A fic</li></ol>""",
+            ),
+        )
+        // An expired-session login form is a genuine auth signal, not a WAF block.
+        assertFalse(Ao3Api.looksLikeCfBlock("""<form id="new_user" class="new_user">"""))
+    }
+
+    @Test
+    fun `looksLikeCfBlock does not fire on a mere mention of cloudflare`() {
+        // A fic body that quotes the word must not be reclassified as a block.
+        assertFalse(
+            Ao3Api.looksLikeCfBlock(
+                "The sysadmin muttered about Cloudflare outages while sipping coffee.",
+            ),
+        )
+    }
+
+    @Test
+    fun `classification split - a WAF block is not an interactive challenge`() {
+        // The two sniffs are mutually exclusive on a pure WAF page: the block
+        // must not be routed to the WebView challenge resolver.
+        assertTrue(Ao3Api.looksLikeCfBlock(cfBlockBody()))
+        assertFalse(Ao3Api.looksLikeCfChallenge(cfBlockBody()))
+    }
+
+    // ─── end-to-end routing ───────────────────────────────────────────────
+
+    @Test
+    fun `tagFeed maps a CF WAF 403 to a retryable NetworkError`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(403).setBody(cfBlockBody()))
+        val result = api().tagFeed(tagId = 414093L)
+        assertTrue(
+            "CF WAF block must be retryable NetworkError, got $result",
+            result is FictionResult.NetworkError,
+        )
+    }
+
+    @Test
+    fun `tagFeed still maps a genuine 403 to AuthRequired`() = runTest {
+        // A 403 with no Cloudflare block markers is a real auth gate and must
+        // stay terminal AuthRequired — the fix must not swallow that.
+        server.enqueue(
+            MockResponse().setResponseCode(403).setBody("<html><body>Forbidden</body></html>"),
+        )
+        val result = api().tagFeed(tagId = 414093L)
+        assertTrue(
+            "plain 403 must stay AuthRequired, got $result",
+            result is FictionResult.AuthRequired,
+        )
+    }
+
+    @Test
+    fun `downloadEpub maps a CF WAF 403 to a retryable NetworkError`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(403).setBody(cfBlockBody()))
+        val result = api().downloadEpub(workId = 12345L)
+        assertTrue(
+            "CF WAF block on EPUB download must be retryable NetworkError, got $result",
+            result is FictionResult.NetworkError,
+        )
+    }
+
+    @Test
+    fun `downloadEpub still maps a genuine 403 to AuthRequired`() = runTest {
+        server.enqueue(
+            MockResponse().setResponseCode(403).setBody("<html><body>You must agree</body></html>"),
+        )
+        val result = api().downloadEpub(workId = 12345L)
+        assertTrue(
+            "plain 403 on EPUB download must stay AuthRequired, got $result",
+            result is FictionResult.AuthRequired,
+        )
+    }
+}


### PR DESCRIPTION
## What

A Cloudflare WAF / firewall **block** page (HTTP 403 — "Error 1020: Access denied", "Sorry, you have been blocked", "Attention Required!") carries **none** of the interactive JS-challenge markers `looksLikeCfChallenge` sniffs for, so it fell through to the `401/403 -> AuthRequired` arm.

That arm is **terminal** in `ChapterDownloadWorker` (`Result.failure()` → FAILED + a sign-in prompt that can never clear a WAF block), whereas a WAF block is transient and IP-scoped and should be retried (`NetworkError` → `Result.retry()`).

## Change

- Add `Ao3Api.looksLikeCfBlock()` — classifies the block page, guarded on the literal `"cloudflare"` token **plus** block-specific phrases so genuine auth 403s and mere prose mentions never false-positive.
- Route a detected block to a retryable `NetworkError` on **both** network paths — `requestText()` (tagFeed/subscriptions/search) and `downloadEpub()` (the AO3 chapter-download path, via `ensureParsed`). Ordering: interactive challenge still wins the WebView resolver; real auth gates still map to `AuthRequired`.

## Tests

Plain-JVM only (no new deps): classification cases + end-to-end MockWebServer routing for both paths (WAF-403 → NetworkError, genuine-403 → AuthRequired, block ≠ challenge).

Closes #1502