### PR TITLE
build: version-catalog mockwebserver alias + drop redundant jvmTarget

### DIFF
--- a/core-llm/build.gradle.kts
+++ b/core-llm/build.gradle.kts
@@ -58,7 +58,7 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.robolectric)
-    testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
+    testImplementation(libs.okhttp.mockwebserver)
     testImplementation("androidx.room:room-testing:2.8.4")
     testImplementation("androidx.test:core:1.7.0")
     testImplementation("androidx.test.ext:junit:1.3.0")

--- a/core-source-testkit/build.gradle.kts
+++ b/core-source-testkit/build.gradle.kts
@@ -14,9 +14,10 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
+    // AGP 9 + `android.builtInKotlin=true` derives the Kotlin jvmTarget
+    // from compileOptions.targetCompatibility, so no explicit
+    // `kotlin { compilerOptions { jvmTarget } }` block is needed here.
 }
-
-kotlin { compilerOptions { jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17) } }
 
 dependencies {
     // The abstract contract test lives in this module's MAIN sourceset
@@ -35,6 +36,6 @@ dependencies {
     implementation(project(":core-playback"))
     api(libs.junit)
     api(libs.okhttp)
-    api("com.squareup.okhttp3:mockwebserver:4.12.0") // no version-catalog alias; matches source-plos/-github/-azure/core-llm
+    api(libs.okhttp.mockwebserver)
     api(libs.kotlinx.coroutines.test)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -196,6 +196,10 @@ play-services-wearable = { module = "com.google.android.gms:play-services-wearab
 # Networking
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 okhttp-logging = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
+# mockwebserver ships in lockstep with okhttp (same com.squareup.okhttp3
+# release train), so it shares the `okhttp` version ref — no separate
+# [versions] entry. Test-only dep for the source/LLM client suites.
+okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp" }
 jsoup = { module = "org.jsoup:jsoup", version.ref = "jsoup" }
 commonmark = { module = "org.commonmark:commonmark", version.ref = "commonmark" }
 readability4j = { module = "net.dankito.readability4j:readability4j", version.ref = "readability4j" }

--- a/source-azure/build.gradle.kts
+++ b/source-azure/build.gradle.kts
@@ -70,5 +70,5 @@ dependencies {
 
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
-    testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
+    testImplementation(libs.okhttp.mockwebserver)
 }

--- a/source-github/build.gradle.kts
+++ b/source-github/build.gradle.kts
@@ -46,8 +46,8 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
     // MockWebServer for DeviceFlowApi + GitHubAuthInterceptor tests (#91).
-    // Pinned to the same OkHttp version that production uses; mirrors the
-    // pattern in :core-llm where the LLM provider tests pull mockwebserver
-    // explicitly because the base okhttp dep is implementation-scoped.
-    testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
+    // Shares the `okhttp` version ref (same release train that production
+    // uses); mirrors the pattern in :core-llm where the LLM provider tests
+    // pull mockwebserver explicitly because okhttp is implementation-scoped.
+    testImplementation(libs.okhttp.mockwebserver)
 }

--- a/source-plos/build.gradle.kts
+++ b/source-plos/build.gradle.kts
@@ -46,5 +46,5 @@ dependencies {
     testImplementation(libs.kotlinx.coroutines.test)
     // #1058 — MockWebServer to pin the search request URL (assert the
     // doc_type:full fq parity between searchRecent and searchQuery).
-    testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
+    testImplementation(libs.okhttp.mockwebserver)
 }

--- a/source-standard-ebooks/build.gradle.kts
+++ b/source-standard-ebooks/build.gradle.kts
@@ -50,6 +50,6 @@ dependencies {
     testImplementation(libs.kotlinx.coroutines.test)
     // #735 — MockWebServer for the EPUB-download interstitial regression
     // test. Same version :source-github and :source-azure already pin.
-    testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
+    testImplementation(libs.okhttp.mockwebserver)
     testImplementation(project(":core-source-testkit"))
 }


### PR DESCRIPTION
Gemini findings on #1488: `core-source-testkit` hardcodes `mockwebserver:4.12.0` (as do `source-plos`/`source-github`/`source-azure`/`core-llm`), and sets an explicit Kotlin `jvmTarget` block that AGP 9 already derives from `compileOptions`.

## Changes
- **Catalog alias**: add `okhttp-mockwebserver` to `gradle/libs.versions.toml`, sharing `version.ref = "okhttp"` — mockwebserver ships on the same `com.squareup.okhttp3` release train as okhttp (both 4.12.0), so no separate `[versions]` entry is warranted and the two stay in lockstep by construction.
- **Migrate consumers** to `libs.okhttp.mockwebserver`: `core-source-testkit` (`api`), `source-plos`, `source-github`, `source-azure`, `core-llm`, **and `source-standard-ebooks`** — the issue named five modules; `source-standard-ebooks` carried the identical hardcoded string, so it's folded in for one clean source of truth (verified: zero `mockwebserver:4.x` string literals remain).
- **Drop redundant jvmTarget**: remove `core-source-testkit`'s `kotlin { compilerOptions { jvmTarget.set(JVM_17) } }`. AGP 9.2.0 + `android.builtInKotlin=true` derives the Kotlin `jvmTarget` from `compileOptions.targetCompatibility` (VERSION_17), so the block is redundant. Kept scoped to the module Gemini flagged; the same redundancy exists project-wide but a 40-module sweep would collide with every sibling build-file PR and is left for a dedicated pass.

## Verification
Build-only change; no source/behavior touched. CI `Build APK` is the gate.

Closes #1505