### PR TITLE
dx: polish epic paragraph split + impact determinism (#1525)

### DIFF
--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/impact/ImpactReportJson.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/impact/ImpactReportJson.kt
@@ -14,16 +14,20 @@ package `in`.jphe.storyvox.data.repository.impact
  */
 object ImpactReportJson {
 
-    /** Encode [report] as pretty, deterministic JSON. */
+    /** Encode [report] as pretty, deterministic JSON.
+     *
+     *  #1525 — line breaks are written as an explicit `\n` (not `appendLine`)
+     *  so the byte-for-byte determinism contract in the class KDoc is
+     *  self-evident and can never regress to a platform line separator. */
     fun encode(report: ImpactReport): String = buildString {
         append("{\n")
-        appendLine("  ${quote("schema")}: ${report.schema},")
-        appendLine("  ${quote("period")}: ${quote(report.period)},")
-        appendLine("  ${quote("app_version")}: ${quote(report.appVersion)},")
-        appendLine("  ${quote("hours_listened_bucket")}: ${report.hoursListenedBucket},")
-        appendLine("  ${quote("chapters_completed_bucket")}: ${report.chaptersCompletedBucket},")
-        appendLine("  ${quote("books_completed_bucket")}: ${report.booksCompletedBucket},")
-        appendLine("  ${quote("sources_used")}: ${encodeStringArray(report.sourcesUsed)}")
+        append("  ${quote("schema")}: ${report.schema},\n")
+        append("  ${quote("period")}: ${quote(report.period)},\n")
+        append("  ${quote("app_version")}: ${quote(report.appVersion)},\n")
+        append("  ${quote("hours_listened_bucket")}: ${report.hoursListenedBucket},\n")
+        append("  ${quote("chapters_completed_bucket")}: ${report.chaptersCompletedBucket},\n")
+        append("  ${quote("books_completed_bucket")}: ${report.booksCompletedBucket},\n")
+        append("  ${quote("sources_used")}: ${encodeStringArray(report.sourcesUsed)}\n")
         append("}")
     }
 

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/impact/ImpactReportJsonTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/impact/ImpactReportJsonTest.kt
@@ -55,4 +55,13 @@ class ImpactReportJsonTest {
         val report = ImpactReport(1, "2026-07", "1.9", 5, 10, 1, listOf("ao3"))
         assertEquals(ImpactReportJson.encode(report), ImpactReportJson.encode(report))
     }
+
+    @Test
+    fun `line breaks are always LF, never a platform CRLF`() {
+        // #1525 — the byte-for-byte contract requires `\n` line breaks on every
+        // platform; a stray `\r` would mean the preview no longer matches the
+        // shared bytes.
+        val report = ImpactReport(1, "2026-07", "1.9", 5, 10, 1, listOf("ao3"))
+        assertTrue(ImpactReportJson.encode(report).none { it == '\r' })
+    }
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/stats/ImpactShareCard.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/stats/ImpactShareCard.kt
@@ -105,10 +105,13 @@ fun ImpactShareCard(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
 
-            if (data.lastSharedPeriod != null) {
+            // #1525 — bind to a local val: a cross-module property can't be
+            // smart-cast after a null check, so read once and drop the `!!`.
+            val lastSharedPeriod = data.lastSharedPeriod
+            if (lastSharedPeriod != null) {
                 Spacer(Modifier.height(8.dp))
                 Text(
-                    text = stringResource(R.string.impact_card_last_shared, data.lastSharedPeriod!!),
+                    text = stringResource(R.string.impact_card_last_shared, lastSharedPeriod),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )

--- a/source-epic-free-games/src/main/kotlin/in/jphe/storyvox/source/epicfreegames/EpicFreeGamesSource.kt
+++ b/source-epic-free-games/src/main/kotlin/in/jphe/storyvox/source/epicfreegames/EpicFreeGamesSource.kt
@@ -262,7 +262,12 @@ internal fun giveaways(resp: PromotionsResponse): List<Giveaway> {
             else -> continue // plain sale / not a giveaway
         }
         out += Giveaway(
-            key = el.id ?: el.namespace ?: title,
+            // #1525 — a present-but-blank id/namespace is non-null, so a bare
+            // Elvis chain would keep the "" and never fall through. Guard each
+            // link with isNotBlank so the fallback reaches a usable value.
+            key = el.id?.takeIf { it.isNotBlank() }
+                ?: el.namespace?.takeIf { it.isNotBlank() }
+                ?: title,
             title = title,
             description = el.description?.trim().orEmpty(),
             seller = el.seller?.name?.trim()?.takeIf { it.isNotBlank() },
@@ -293,11 +298,15 @@ private fun List<OfferGroup>.firstFreeOffer(): PromotionalOffer? =
  * carries no usable slug.
  */
 internal fun storeUrlFor(el: StoreElement): String? {
+    // #1525 — a present-but-blank pageSlug is non-null, so a bare Elvis chain
+    // would keep the "" and emit a broken ".../p/" URL instead of falling
+    // through. Guard every pageSlug with isNotBlank so the chain reaches a
+    // usable slug (or null).
     val slug = el.productSlug?.substringBefore('/')?.takeIf { it.isNotBlank() }
-        ?: el.offerMappings.firstOrNull { it.pageType == "productHome" }?.pageSlug
-        ?: el.offerMappings.firstOrNull()?.pageSlug
-        ?: el.catalogNs?.mappings?.firstOrNull { it.pageType == "productHome" }?.pageSlug
-        ?: el.catalogNs?.mappings?.firstOrNull()?.pageSlug
+        ?: el.offerMappings.firstOrNull { it.pageType == "productHome" }?.pageSlug?.takeIf { it.isNotBlank() }
+        ?: el.offerMappings.firstOrNull()?.pageSlug?.takeIf { it.isNotBlank() }
+        ?: el.catalogNs?.mappings?.firstOrNull { it.pageType == "productHome" }?.pageSlug?.takeIf { it.isNotBlank() }
+        ?: el.catalogNs?.mappings?.firstOrNull()?.pageSlug?.takeIf { it.isNotBlank() }
         ?: return null
     return "https://store.epicgames.com/p/$slug"
 }
@@ -354,9 +363,16 @@ internal fun formatEpicDate(iso: String?): String? {
     }
 }
 
-/** Split the plain body on blank lines into `<p>` blocks for the reader view. */
+/** Split the plain body on blank lines into `<p>` blocks for the reader view.
+ *  #1525 — normalise CRLF / lone-CR line endings to `\n` and collapse runs of
+ *  3+ newlines to a single blank-line separator first, so a body that arrives
+ *  with `\r\n` (or extra blank lines) still splits into paragraphs instead of
+ *  collapsing into one `<p>`. */
 internal fun String.toHtmlParagraphs(): String =
-    split("\n\n")
+    replace("\r\n", "\n")
+        .replace('\r', '\n')
+        .replace(Regex("\n{3,}"), "\n\n")
+        .split("\n\n")
         .filter { it.isNotBlank() }
         .joinToString("") { "<p>${escapeHtml(it).replace("\n", "<br/>")}</p>" }
 

--- a/source-epic-free-games/src/test/kotlin/in/jphe/storyvox/source/epicfreegames/EpicFreeGamesMappingTest.kt
+++ b/source-epic-free-games/src/test/kotlin/in/jphe/storyvox/source/epicfreegames/EpicFreeGamesMappingTest.kt
@@ -103,7 +103,105 @@ class EpicFreeGamesMappingTest {
         val weird = giveaways(api.parsePromotions("""{"data":{},"unexpected":true}"""))
         assertTrue(weird.isEmpty())
     }
+
+    // ─── #1525 polish: blank fields must not defeat the Elvis fallbacks ────
+
+    @Test
+    fun `blank id and namespace fall through to the title for the key`() {
+        // A present-but-empty id/namespace is non-null, so a bare Elvis chain
+        // would keep "" as the key. isNotBlank guards must reach the title.
+        val g = giveaways(api.parsePromotions(BLANK_FIELDS_FIXTURE))
+            .first { it.title == "Blank Fields Game" }
+        assertEquals("Blank Fields Game", g.key)
+    }
+
+    @Test
+    fun `blank offerMappings slug falls through to a non-blank catalogNs slug`() {
+        val g = giveaways(api.parsePromotions(BLANK_FIELDS_FIXTURE))
+            .first { it.title == "Blank Fields Game" }
+        assertEquals("https://store.epicgames.com/p/blank-fields-game-abc", g.storeUrl)
+    }
+
+    @Test
+    fun `all-blank slugs yield a null store url, never a bare p slash`() {
+        val g = giveaways(api.parsePromotions(BLANK_FIELDS_FIXTURE))
+            .first { it.title == "All Blank Slugs Game" }
+        assertNull(g.storeUrl)
+    }
+
+    @Test
+    fun `toHtmlParagraphs normalises CRLF and collapses extra blank lines`() {
+        val body = "Title line\r\n\r\nDetails paragraph\r\nwith a soft wrap\r\n\r\n\r\nClaim it here"
+        assertEquals(
+            "<p>Title line</p>" +
+                "<p>Details paragraph<br/>with a soft wrap</p>" +
+                "<p>Claim it here</p>",
+            body.toHtmlParagraphs(),
+        )
+    }
+
+    @Test
+    fun `toHtmlParagraphs still splits a plain LF body`() {
+        // Regression guard: the LF-only path the code always handled is intact.
+        assertEquals(
+            "<p>One</p><p>Two</p>",
+            "One\n\nTwo".toHtmlParagraphs(),
+        )
+    }
 }
+
+/**
+ * #1525 — two currently-free elements exercising the blank-field fallbacks:
+ *  - "Blank Fields Game": empty id/namespace (key → title) and an empty
+ *    offerMappings slug (store URL → catalogNs slug).
+ *  - "All Blank Slugs Game": every slug blank (store URL → null).
+ */
+internal const val BLANK_FIELDS_FIXTURE: String = """
+{
+  "data": {
+    "Catalog": {
+      "searchStore": {
+        "elements": [
+          {
+            "title": "Blank Fields Game",
+            "id": "",
+            "namespace": "",
+            "productSlug": null,
+            "promotions": {
+              "promotionalOffers": [
+                { "promotionalOffers": [
+                  { "startDate": "2026-07-02T15:00:00.000Z", "endDate": "2026-07-09T15:00:00.000Z",
+                    "discountSetting": { "discountType": "PERCENTAGE", "discountPercentage": 0 } }
+                ] }
+              ],
+              "upcomingPromotionalOffers": []
+            },
+            "offerMappings": [ { "pageSlug": "", "pageType": "productHome" } ],
+            "catalogNs": { "mappings": [ { "pageSlug": "blank-fields-game-abc", "pageType": "productHome" } ] }
+          },
+          {
+            "title": "All Blank Slugs Game",
+            "id": "allblank1",
+            "namespace": "allblankns",
+            "productSlug": null,
+            "promotions": {
+              "promotionalOffers": [
+                { "promotionalOffers": [
+                  { "startDate": "2026-07-02T15:00:00.000Z", "endDate": "2026-07-09T15:00:00.000Z",
+                    "discountSetting": { "discountType": "PERCENTAGE", "discountPercentage": 0 } }
+                ] }
+              ],
+              "upcomingPromotionalOffers": []
+            },
+            "offerMappings": [ { "pageSlug": "", "pageType": "productHome" } ],
+            "catalogNs": { "mappings": [ { "pageSlug": "", "pageType": "productHome" } ] }
+          }
+        ]
+      }
+    }
+  }
+}
+"""
 
 /**
  * A trimmed real `freeGamesPromotions` body:


### PR DESCRIPTION
Three low-risk polish findings triaged as non-blocking on earlier PRs (Gemini mediums from #1521 plus two review nits).

## source-epic-free-games
- **`toHtmlParagraphs()`** — normalise `\r\n` / lone `\r` to `\n` and collapse runs of 3+ newlines before splitting on `\n\n`. A body arriving with CRLF used to collapse into a single `<p>`.
- **Elvis chains guarded with `takeIf { isNotBlank() }`** — a present-but-empty `id`/`namespace` (giveaway `key`) or `pageSlug` (store URL) is non-null, so it defeated the fallback and produced a blank key or a bare `https://store.epicgames.com/p/` URL. Now each link falls through to a usable value (or `null`).

## impact
- **`ImpactReportJson.encode()`** — write line breaks as explicit `"\n"` instead of `appendLine`, so the "byte-for-byte" determinism contract in the KDoc is self-evident and can't regress to a platform separator. Output is byte-identical to before.
- **`ImpactShareCard`** — bind `data.lastSharedPeriod` to a local `val` and drop the `!!` (a cross-module property can't be smart-cast after a null check; prior incident).

## Tests
Epic mapping test: blank-field fallbacks (key → title, slug → catalogNs, all-blank → null) + CRLF/LF paragraph split. Impact-json test: LF-only invariant.

Closes #1525