### PR TITLE
fix(ksp): disambiguate generated Hilt module names by package hash

### DIFF
--- a/core-plugin-ksp/build.gradle.kts
+++ b/core-plugin-ksp/build.gradle.kts
@@ -19,4 +19,9 @@ kotlin {
 
 dependencies {
     implementation(libs.ksp.symbol.processing.api)
+
+    // Plain-JVM unit tests for the pure processor helpers (e.g. generated
+    // module naming, #1506). Full KSP compile-testing is intentionally out
+    // of scope — the collision logic is extracted into a pure function.
+    testImplementation(libs.junit)
 }

--- a/core-plugin-ksp/src/main/kotlin/in/jphe/storyvox/plugin/ksp/GeneratedNaming.kt
+++ b/core-plugin-ksp/src/main/kotlin/in/jphe/storyvox/plugin/ksp/GeneratedNaming.kt
@@ -1,0 +1,38 @@
+package `in`.jphe.storyvox.plugin.ksp
+
+/**
+ * Collision-free base name for a generated Hilt module (#1506).
+ *
+ * Both [SourcePluginProcessor] and [VoicePluginProcessor] emit their
+ * `@Module` classes into the single flat package
+ * `in.jphe.storyvox.plugin.generated`, and Hilt aggregates `@Module`
+ * classes by their fully-qualified name when it builds the
+ * `@HiltAndroidApp` graph. Keying the generated name on the plugin's
+ * *simple* name alone (`FooSource` → `FooSource_SourcePluginModule`) means
+ * two same-named plugin classes in different packages — `a.FooSource` and
+ * `b.FooSource` — would generate the same file **and** the same class FQN
+ * and collide at compile time. Before this fix that hazard was latent:
+ * every shipped source/voice plugin happens to have a unique simple name.
+ *
+ * Disambiguate by suffixing the simple name with a short, deterministic
+ * hash of the declaring package: `FooSource_<pkgHash>`. Two classes in the
+ * same package cannot share a simple name, so `(simpleName, packageHash)`
+ * is unique per class. The hash is derived from [String.hashCode], whose
+ * formula is fixed by the Java Language Specification, so the generated
+ * names are stable across compiler runs and machines — an incremental KSP
+ * re-run produces byte-identical output.
+ *
+ * Callers append the module-role suffix, e.g.
+ * `"${generatedModuleBaseName(fqn)}_SourcePluginModule"`.
+ *
+ * @param qualifiedName the plugin class's raw (un-escaped) fully-qualified
+ *   name, e.g. `in.jphe.storyvox.source.kvmr.KvmrSource`.
+ */
+internal fun generatedModuleBaseName(qualifiedName: String): String {
+    val simpleName = qualifiedName.substringAfterLast('.')
+    val packageName = qualifiedName.substringBeforeLast('.', missingDelimiterValue = "")
+    // Unsigned hex → 1..8 chars, [0-9a-f] only. Never negative, so no '-'
+    // that would break the identifier; safe to embed mid-name.
+    val packageHash = Integer.toHexString(packageName.hashCode())
+    return "${simpleName}_$packageHash"
+}

--- a/core-plugin-ksp/src/main/kotlin/in/jphe/storyvox/plugin/ksp/SourcePluginProcessor.kt
+++ b/core-plugin-ksp/src/main/kotlin/in/jphe/storyvox/plugin/ksp/SourcePluginProcessor.kt
@@ -21,9 +21,9 @@ import java.nio.charset.StandardCharsets
  * needs, from the single annotation.
  *
  * For each annotated `FictionSource` implementation, the processor
- * generates ONE Kotlin file in
- * `in.jphe.storyvox.plugin.generated.<module-mangled-id>` containing
- * TWO `@Module`s installed in `SingletonComponent`:
+ * generates ONE Kotlin file in the flat package
+ * `in.jphe.storyvox.plugin.generated` containing TWO `@Module`s
+ * installed in `SingletonComponent`:
  *
  *  1. `<Source>_SourcePluginModule` (`object`) — a
  *     `@Provides @IntoSet SourcePluginDescriptor` factory that
@@ -46,11 +46,14 @@ import java.nio.charset.StandardCharsets
  * machinery then merges every module's `@IntoSet` contributions at
  * the app's `@HiltAndroidApp` graph-build step.
  *
- * That's also why the generated module name is mangled per source
- * class: `KvmrSource` → `KvmrSource_SourcePluginModule`. Two modules
- * declaring the same name would collide at compile time even when
- * they're in different packages, because Hilt aggregates by FQN at
- * the bytecode level.
+ * Because every file lands in the flat `in.jphe.storyvox.plugin.generated`
+ * package and Hilt aggregates `@Module` classes by fully-qualified name,
+ * the generated name must be unique across *all* source modules. Two
+ * same-named `FictionSource` classes in different packages (`a.FooSource`
+ * / `b.FooSource`) would otherwise emit the same file and class FQN and
+ * collide at compile time — so [generatedModuleBaseName] disambiguates by
+ * suffixing the simple name with a hash of the declaring package (#1506):
+ * `KvmrSource` → `KvmrSource_<pkgHash>_SourcePluginModule`.
  *
  * ## Generated shape (illustrative)
  *
@@ -127,9 +130,12 @@ class SourcePluginProcessor(
     }
 
     private fun emitModule(target: KSClassDeclaration, annotation: KSAnnotation) {
-        val targetFqn = target.qualifiedName?.asString()?.let(::escapeKotlinFqn)
+        val rawFqn = target.qualifiedName?.asString()
             ?: error("@SourcePlugin target ${target.simpleName.asString()} has no qualified name")
-        val targetSimple = target.simpleName.asString()
+        val targetFqn = escapeKotlinFqn(rawFqn)
+        // #1506 — package-hash suffix so two same-named source classes in
+        // different packages don't collide in the flat generated package.
+        val baseName = generatedModuleBaseName(rawFqn)
 
         val args: Map<String, Any?> = annotation.arguments.associate { it.name?.asString().orEmpty() to it.value }
         val id = args["id"] as? String
@@ -162,11 +168,11 @@ class SourcePluginProcessor(
             }
         }
 
-        val moduleSimpleName = "${targetSimple}_SourcePluginModule"
+        val moduleSimpleName = "${baseName}_SourcePluginModule"
         // #1371 — second @Module emitted into the same file: the @Binds
         // @IntoMap routing contribution. Distinct name so Hilt's
         // by-FQN aggregation doesn't collide with the descriptor module.
-        val routingModuleSimpleName = "${targetSimple}_SourceRoutingModule"
+        val routingModuleSimpleName = "${baseName}_SourceRoutingModule"
         val generatedFqn = "$GENERATED_PACKAGE_RAW.$moduleSimpleName"
 
         val containingFile = target.containingFile

--- a/core-plugin-ksp/src/main/kotlin/in/jphe/storyvox/plugin/ksp/VoicePluginProcessor.kt
+++ b/core-plugin-ksp/src/main/kotlin/in/jphe/storyvox/plugin/ksp/VoicePluginProcessor.kt
@@ -79,11 +79,13 @@ class VoicePluginProcessor(
     }
 
     private fun emitModule(target: KSClassDeclaration, engineId: String) {
-        val targetFqn = target.qualifiedName?.asString()?.let(::escapeKotlinFqn)
+        val rawFqn = target.qualifiedName?.asString()
             ?: error("@VoicePlugin target ${target.simpleName.asString()} has no qualified name")
-        val targetSimple = target.simpleName.asString()
+        val targetFqn = escapeKotlinFqn(rawFqn)
 
-        val moduleSimpleName = "${targetSimple}_VoicePluginModule"
+        // #1506 — package-hash suffix so two same-named plugin classes in
+        // different packages don't collide in the flat generated package.
+        val moduleSimpleName = "${generatedModuleBaseName(rawFqn)}_VoicePluginModule"
 
         val containingFile = target.containingFile
         val dependencies = if (containingFile != null) {

--- a/core-plugin-ksp/src/test/kotlin/in/jphe/storyvox/plugin/ksp/GeneratedNamingTest.kt
+++ b/core-plugin-ksp/src/test/kotlin/in/jphe/storyvox/plugin/ksp/GeneratedNamingTest.kt
@@ -1,0 +1,56 @@
+package `in`.jphe.storyvox.plugin.ksp
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure unit tests for [generatedModuleBaseName] — the collision-free
+ * naming introduced for issue 1506. Property-based (no hardcoded hash
+ * literals) so they stay valid if the underlying hash ever changes, while
+ * still pinning the invariant the fix exists to guarantee.
+ */
+class GeneratedNamingTest {
+
+    @Test
+    fun `is deterministic for the same qualified name`() {
+        val fqn = "in.jphe.storyvox.source.kvmr.KvmrSource"
+        assertEquals(generatedModuleBaseName(fqn), generatedModuleBaseName(fqn))
+    }
+
+    @Test
+    fun `same simple name in different packages does not collide`() {
+        // The actual bug (issue 1506): flat generated package keyed only on
+        // the simple name would emit identical file + class FQN for both.
+        val a = generatedModuleBaseName("in.jphe.storyvox.a.FooSource")
+        val b = generatedModuleBaseName("in.jphe.storyvox.b.FooSource")
+        assertNotEquals("same-named classes in different packages must differ", a, b)
+    }
+
+    @Test
+    fun `different simple names in the same package stay distinct`() {
+        val a = generatedModuleBaseName("in.jphe.storyvox.pkg.FooSource")
+        val b = generatedModuleBaseName("in.jphe.storyvox.pkg.BarSource")
+        assertNotEquals(a, b)
+    }
+
+    @Test
+    fun `base name is prefixed with the simple class name`() {
+        val name = generatedModuleBaseName("in.jphe.storyvox.source.kvmr.KvmrSource")
+        assertTrue(name, name.startsWith("KvmrSource_"))
+    }
+
+    @Test
+    fun `base name is a legal kotlin identifier`() {
+        val name = generatedModuleBaseName("in.jphe.storyvox.a.FooSource")
+        assertTrue(name, name.matches(Regex("[A-Za-z_][A-Za-z0-9_]*")))
+    }
+
+    @Test
+    fun `handles a class in the default package`() {
+        val name = generatedModuleBaseName("FooSource")
+        assertTrue(name, name.startsWith("FooSource_"))
+        assertTrue(name, name.matches(Regex("[A-Za-z_][A-Za-z0-9_]*")))
+    }
+}


### PR DESCRIPTION
From the #1488 ultrareview: `VoicePluginProcessor` names its generated `@Module` `${targetSimple}_VoicePluginModule` and drops it into the single flat package `in.jphe.storyvox.plugin.generated`, keyed only on the **simple** class name. Hilt aggregates `@Module` classes by fully-qualified name at the `@HiltAndroidApp` graph-build step, so two same-named `@VoicePlugin` classes in different packages (`a.Foo` / `b.Foo`) would emit the same file **and** the same class FQN → compile-time collision.

`SourcePluginProcessor` has the **identical latent bug** (both `_SourcePluginModule` and `_SourceRoutingModule` were keyed on the simple name) — and, ironically, its KDoc *claimed* the name was already "mangled per source class ... even when they're in different packages." It wasn't. The issue explicitly permits fixing both, so this does.

## Fix
- **`GeneratedNaming.kt`** — new pure `internal fun generatedModuleBaseName(qualifiedName)`: suffixes the simple name with an unsigned-hex hash of the declaring **package** → `FooSource_<pkgHash>`. Within a package two classes can't share a simple name, so `(simpleName, packageHash)` is unique per class. The hash comes from `String.hashCode` (formula fixed by the JLS), so generated names are stable across compiler runs/machines — incremental KSP re-runs produce byte-identical output.
- Both processors route their module names through it (`SourcePluginProcessor`: descriptor + routing; `VoicePluginProcessor`: the binding module).
- Corrected the `SourcePluginProcessor` KDoc to describe the real mechanism (and fixed a stale reference to a non-existent `.generated.<mangled-id>` sub-package — the package is flat).

## Tests
- `GeneratedNamingTest` — plain-JVM JUnit4 (adds `testImplementation(libs.junit)` to the module). Property-based, no hardcoded hash literals: determinism, same-simple-name-different-package ⇒ distinct (the bug), legal-identifier shape, default-package handling. Full KSP compile-testing is intentionally out of scope — the collision logic is extracted into a pure function, matching the project's "pure decision fn" test style.

## Notes
- No `core-playback` edits (the `@VoicePlugin` annotation is only referenced by FQN string — untouched).

Closes #1506