### PR TITLE
feat(rss): persist item bodies at refresh so taps never re-fetch (#1497)

### DIFF
--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
@@ -630,21 +630,52 @@ class FictionRepositoryImpl @Inject constructor(
 
         // Upsert chapter rows; preserve body + download state for chapters we
         // already have, drop in fresh metadata for new ones.
-        val incoming = detail.chapters.map { it.toEntity(detail.summary.id) }
+        val incoming = detail.chapters.map { info ->
+            val base = info.toEntity(detail.summary.id)
+            // #1497 — the source parsed this chapter's body while building the
+            // TOC (RSS/Atom feeds carry item content inline). Persist it now
+            // and mark the row DOWNLOADED so a tap reads from Room and never
+            // re-fetches. Reuses the existing offline chapter store — no
+            // parallel entity (#1314).
+            val prefetched = detail.prefetchedBodies[info.id]
+            if (prefetched == null) base else base.copy(
+                htmlBody = prefetched.htmlBody,
+                plainBody = prefetched.plainBody,
+                bodyFetchedAt = now,
+                bodyChecksum = sha256(prefetched.htmlBody),
+                downloadState = ChapterDownloadState.DOWNLOADED,
+                notesAuthor = prefetched.notesAuthor,
+                notesAuthorPosition = prefetched.notesAuthorPosition,
+                audioUrl = prefetched.audioUrl ?: base.audioUrl,
+            )
+        }
         val merged = incoming.map { fresh ->
             val previous = chapterDao.get(fresh.id)
-            if (previous == null) fresh else fresh.copy(
-                htmlBody = previous.htmlBody,
-                plainBody = previous.plainBody,
-                bodyFetchedAt = previous.bodyFetchedAt,
-                bodyChecksum = previous.bodyChecksum,
-                downloadState = previous.downloadState,
-                lastDownloadAttemptAt = previous.lastDownloadAttemptAt,
-                lastDownloadError = previous.lastDownloadError,
-                userMarkedRead = previous.userMarkedRead,
-                firstReadAt = previous.firstReadAt,
-                audioUrl = fresh.audioUrl ?: previous.audioUrl,
-            )
+            when {
+                previous == null -> fresh
+                // #1497 — the source handed us a fresh body inline this refresh.
+                // Take it (the feed item may have been edited upstream), but
+                // keep the user's read state and in-chapter bookmark so a
+                // re-refresh of a subscribed feed doesn't reset progress.
+                fresh.downloadState == ChapterDownloadState.DOWNLOADED &&
+                    fresh.htmlBody != null -> fresh.copy(
+                    userMarkedRead = previous.userMarkedRead,
+                    firstReadAt = previous.firstReadAt,
+                    bookmarkCharOffset = previous.bookmarkCharOffset,
+                )
+                else -> fresh.copy(
+                    htmlBody = previous.htmlBody,
+                    plainBody = previous.plainBody,
+                    bodyFetchedAt = previous.bodyFetchedAt,
+                    bodyChecksum = previous.bodyChecksum,
+                    downloadState = previous.downloadState,
+                    lastDownloadAttemptAt = previous.lastDownloadAttemptAt,
+                    lastDownloadError = previous.lastDownloadError,
+                    userMarkedRead = previous.userMarkedRead,
+                    firstReadAt = previous.firstReadAt,
+                    audioUrl = fresh.audioUrl ?: previous.audioUrl,
+                )
+            }
         }
         chapterDao.upsertChaptersForFiction(detail.summary.id, merged)
     }
@@ -795,6 +826,18 @@ internal fun inferUrlHost(maybeUrl: String?): String? {
         java.net.URI(maybeUrl).host?.removePrefix("www.")
     }.getOrNull()
 }
+
+/**
+ * Issue #1497 — checksum for a prefetched body. Matches
+ * [`in`.jphe.storyvox.data.work.ChapterDownloadWorker]'s scheme
+ * (hex SHA-256 of the HTML body) so a chapter that later flows through
+ * the on-demand download path lands on an identical `bodyChecksum` for
+ * identical content.
+ */
+private fun sha256(s: String): String =
+    java.security.MessageDigest.getInstance("SHA-256")
+        .digest(s.toByteArray())
+        .joinToString("") { "%02x".format(it) }
 
 internal fun ChapterInfo.toEntity(fictionId: String): Chapter = Chapter(
     id = id,

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/source/model/ChapterContent.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/source/model/ChapterContent.kt
@@ -36,6 +36,30 @@ data class ChapterContent(
     val audioUrl: String? = null,
 )
 
+/**
+ * Issue #1497 — a chapter body a source already has in hand at
+ * detail-fetch time. Some backends (RSS/Atom feeds) parse every item's
+ * full content while building the table-of-contents, so there's no
+ * reason to re-fetch it on tap. A source surfaces these via
+ * [FictionDetail.prefetchedBodies] (keyed by [ChapterInfo.id]); the
+ * repository persists them into the existing offline chapter store
+ * during refresh and marks the row DOWNLOADED, so a chapter tap reads
+ * from Room instead of round-tripping the network.
+ *
+ * Distinct from [ChapterContent] (which pairs a body with its
+ * [ChapterInfo] for the on-demand fetch path): this carries only the
+ * body bytes, correlated to a chapter by the map key, and coordinates
+ * with the existing download pipeline rather than adding a parallel
+ * store (see #1314).
+ */
+data class ChapterBody(
+    val htmlBody: String,
+    val plainBody: String,
+    val notesAuthor: String? = null,
+    val notesAuthorPosition: NotePosition? = null,
+    val audioUrl: String? = null,
+)
+
 /** Whether an author's-note block sits before or after the main body. */
 enum class NotePosition { BEFORE, AFTER }
 

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/source/model/FictionDetail.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/source/model/FictionDetail.kt
@@ -6,6 +6,10 @@ package `in`.jphe.storyvox.data.source.model
  * `chapters` is the full table-of-contents at fetch time — bodies are NOT included,
  * the caller must fetch each chapter separately (typically through a repository
  * which schedules `ChapterDownloadWorker`).
+ *
+ * Exception: [prefetchedBodies]. Issue #1497 — sources that parse every item's
+ * body while building the TOC (RSS/Atom feeds) can hand those bodies back here
+ * so the repository persists them at refresh time and taps never re-fetch.
  */
 data class FictionDetail(
     val summary: FictionSummary,
@@ -16,4 +20,15 @@ data class FictionDetail(
     val followers: Int? = null,
     val lastUpdatedAt: Long? = null,
     val authorId: String? = null,
+    /**
+     * Issue #1497 — chapter bodies the source already parsed at
+     * detail-fetch time, keyed by [ChapterInfo.id]. Empty for the common
+     * case (sources that fetch bodies lazily on tap). When a chapter's id
+     * appears here, [FictionRepository.refreshDetail] writes the body into
+     * the chapter row and marks it DOWNLOADED, so the reader/playback layer
+     * reads from Room without a network round-trip. Only meaningful on the
+     * source→repository ingestion path — the DB-backed read path
+     * (`observeFiction`) leaves it empty.
+     */
+    val prefetchedBodies: Map<String, ChapterBody> = emptyMap(),
 )

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/FictionRepositoryImplTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/FictionRepositoryImplTest.kt
@@ -14,6 +14,7 @@ import `in`.jphe.storyvox.data.db.entity.Fiction
 import `in`.jphe.storyvox.data.source.FictionSource
 import `in`.jphe.storyvox.data.source.FictionSourceEvent
 import `in`.jphe.storyvox.data.source.SourceIds
+import `in`.jphe.storyvox.data.source.model.ChapterBody
 import `in`.jphe.storyvox.data.source.model.ChapterContent
 import `in`.jphe.storyvox.data.source.model.ChapterInfo
 import `in`.jphe.storyvox.data.source.model.FictionDetail
@@ -844,6 +845,70 @@ class FictionRepositoryImplTest {
         assertEquals("first-read timestamp preserved", 5678L, merged.firstReadAt)
         // Title from the fresh detail page wins (mutable upstream metadata).
         assertEquals("chapter 0", merged.title)
+    }
+
+    // -- #1497 prefetched-body persistence ---------------------------------------
+
+    @Test fun `refreshDetail persists prefetched bodies and marks chapters DOWNLOADED`() = runTest {
+        // #1497 — RSS/Atom feeds parse every item body while building the TOC.
+        // When the source hands those back in FictionDetail.prefetchedBodies,
+        // the repository writes them into the chapter row and marks it
+        // DOWNLOADED so a tap reads from Room and never re-fetches the feed.
+        val src = FakeSource(SourceIds.ROYAL_ROAD).apply {
+            detailResult = FictionResult.Success(
+                detail("99", chapterCount = 2).copy(
+                    prefetchedBodies = mapOf(
+                        "99-c0" to ChapterBody(htmlBody = "<p>hello</p>", plainBody = "hello"),
+                        // c1 intentionally absent — mixed feed (blank-body item).
+                    ),
+                ),
+            )
+        }
+        val (r, _, chapterDao) = repo(sources = mapOf(SourceIds.ROYAL_ROAD to src))
+
+        r.refreshDetail("99")
+
+        val c0 = chapterDao.rows["99-c0"]!!
+        assertEquals("<p>hello</p>", c0.htmlBody)
+        assertEquals("hello", c0.plainBody)
+        assertEquals(ChapterDownloadState.DOWNLOADED, c0.downloadState)
+        assertNotNull("checksum stamped for the prefetched body", c0.bodyChecksum)
+        assertNotNull("body-fetched timestamp stamped", c0.bodyFetchedAt)
+        // A chapter with no prefetched body stays on the lazy on-tap path.
+        val c1 = chapterDao.rows["99-c1"]!!
+        assertNull(c1.htmlBody)
+        assertEquals(ChapterDownloadState.NOT_DOWNLOADED, c1.downloadState)
+    }
+
+    @Test fun `refreshDetail with a prefetched body keeps user read state and bookmark`() = runTest {
+        // #1497 — a re-refresh of a subscribed feed may carry an edited item
+        // body. Take the fresh body, but never reset the user's progress.
+        val src = FakeSource(SourceIds.ROYAL_ROAD).apply {
+            detailResult = FictionResult.Success(
+                detail("99", chapterCount = 1).copy(
+                    prefetchedBodies = mapOf(
+                        "99-c0" to ChapterBody(htmlBody = "<p>new body</p>", plainBody = "new body"),
+                    ),
+                ),
+            )
+        }
+        val (r, _, chapterDao) = repo(sources = mapOf(SourceIds.ROYAL_ROAD to src))
+        chapterDao.rows["99-c0"] = Chapter(
+            id = "99-c0", fictionId = "99", sourceChapterId = "src-0",
+            index = 0, title = "old", htmlBody = "<p>old body</p>", plainBody = "old body",
+            bodyChecksum = "old", bodyFetchedAt = 1L,
+            downloadState = ChapterDownloadState.DOWNLOADED,
+            userMarkedRead = true, firstReadAt = 5678L, bookmarkCharOffset = 42,
+        )
+
+        r.refreshDetail("99")
+
+        val merged = chapterDao.rows["99-c0"]!!
+        assertEquals("fresh body wins", "new body", merged.plainBody)
+        assertEquals(ChapterDownloadState.DOWNLOADED, merged.downloadState)
+        assertEquals("read flag preserved", true, merged.userMarkedRead)
+        assertEquals("first-read timestamp preserved", 5678L, merged.firstReadAt)
+        assertEquals("bookmark preserved", 42, merged.bookmarkCharOffset)
     }
 
     @Test fun `refreshDetail prunes chapters dropped from the feed (issues #349, #652, #879)`() = runTest {

--- a/source-rss/src/main/kotlin/in/jphe/storyvox/source/rss/RssSource.kt
+++ b/source-rss/src/main/kotlin/in/jphe/storyvox/source/rss/RssSource.kt
@@ -6,6 +6,7 @@ import `in`.jphe.storyvox.data.source.filter.FilterDimension
 import `in`.jphe.storyvox.data.source.filter.FilterState
 import `in`.jphe.storyvox.data.source.plugin.SourceCategory
 import `in`.jphe.storyvox.data.source.plugin.SourcePlugin
+import `in`.jphe.storyvox.data.source.model.ChapterBody
 import `in`.jphe.storyvox.data.source.model.ChapterContent
 import `in`.jphe.storyvox.data.source.model.ChapterInfo
 import `in`.jphe.storyvox.data.source.model.FictionDetail
@@ -282,6 +283,23 @@ internal class RssSource @Inject constructor(
 
         val chapters = feed.items.mapIndexed { idx, item -> item.toChapterInfo(idx, fictionId) }
 
+        // #1497 — the feed we just parsed already carries every item's body
+        // inline (RssItem.htmlBody). Hand them to the repository keyed by
+        // chapter id so it persists them into the offline chapter store at
+        // refresh time: a chapter tap then reads from Room and never
+        // re-downloads the feed. This matters most for hard-throttled feeds
+        // (reddit answers the app's UA with HTTP 429 on the first .rss), where
+        // a cold-session tap otherwise couldn't load the chapter at all.
+        // Items with a blank body fall through to the normal on-tap fetch path.
+        val prefetchedBodies = feed.items.mapNotNull { item ->
+            val html = item.htmlBody
+            if (html.isBlank()) null
+            else item.toChapterId(fictionId) to ChapterBody(
+                htmlBody = html,
+                plainBody = html.stripHtml(),
+            )
+        }.toMap()
+
         // Authors-of-feed = first item's author or feed-level author.
         // Falls back to URL host so the field isn't blank.
         val author = feed.author
@@ -299,7 +317,12 @@ internal class RssSource @Inject constructor(
         )
         val lastUpdatedAt = feed.items.mapNotNull { it.publishedAtEpochMs }.maxOrNull()
         return FictionResult.Success(
-            FictionDetail(summary = summary, chapters = chapters, lastUpdatedAt = lastUpdatedAt),
+            FictionDetail(
+                summary = summary,
+                chapters = chapters,
+                lastUpdatedAt = lastUpdatedAt,
+                prefetchedBodies = prefetchedBodies,
+            ),
         )
     }
 


### PR DESCRIPTION
## Summary
Follow-up to #1489 / #1490. RSS/Atom feeds parse every item's body while building the TOC, but `RssSource.fictionDetail` discarded those bodies and the reader re-fetched the whole feed on each chapter tap. A **cold session** (or an expired in-memory feed cache) therefore needed the network to open a chapter — and on a hard-throttled feed (reddit answers the app's UA with HTTP 429 on the first `.rss` request) a cold tap couldn't load at all.

This persists the bodies into the **existing** offline chapter store at refresh time — no parallel entity (per #1314).

## Changes
- **New `ChapterBody` model + `FictionDetail.prefetchedBodies`** map (keyed by chapter id). Empty for the common lazy-fetch case; only the source→repository ingestion path populates it. The DB-backed read path (`observeFiction`) leaves it empty.
- **`FictionRepositoryImpl.upsertDetail`** writes a prefetched body into the chapter row, stamps `bodyFetchedAt` / `bodyChecksum` (same SHA-256 scheme as `ChapterDownloadWorker`) and marks it `DOWNLOADED`. A re-refresh takes the fresh body (feeds edit items upstream) but **preserves the user's read state, first-read timestamp, and in-chapter bookmark**.
- **`RssSource.fictionDetail`** hands back the bodies it already parsed; blank-body items fall through to the existing on-tap fetch path.

A chapter tap now reads from Room via `observeChapter`/`getChapter` and never round-trips the network.

## No schema change
Reuses the existing `chapter` body columns (`htmlBody`/`plainBody`/`bodyFetchedAt`/`bodyChecksum`/`downloadState`). No DB version bump / migration.

## Storage note
Opening an RSS feed's detail now persists all item bodies (bounded by feed size), even for a feed not yet in the library — that's the point of the issue (taps never re-fetch). Existing `removeFromLibrary`/`deleteIfTransient` + body-trim paths handle cleanup; the debug storage screen reflects usage.

## Tests
`FictionRepositoryImplTest`:
- persists prefetched bodies + marks `DOWNLOADED` (and leaves a blank-body chapter on the lazy path);
- re-refresh keeps user read state + bookmark while taking the fresh body.

## Note for reviewers
Shares `source-rss/.../RssSource.kt` with the sibling PR for #1498 (discovered-feed-URL persistence). The two edits touch different regions of `fictionDetail`; whichever merges second may need a trivial rebase.

Closes #1497

🤖 Generated with [Claude Code](https://claude.com/claude-code)