### PR TITLE
feat(scaffold): new-source.sh --local/--auth/--xml modes (#1526, #1529, #1533)

### DIFF
--- a/docs/CONTRIBUTING-SOURCES.md
+++ b/docs/CONTRIBUTING-SOURCES.md
@@ -41,6 +41,23 @@ source-<id>/
 Everything compiles immediately; the contract test **fails honestly** because
 the stub doesn't talk to the network yet. That red test is your to-do list.
 
+### Scaffold modes
+
+`new-source.sh` scaffolds an **anonymous JSON HTTP** source by default. Pass one
+mode flag (mutually exclusive) when your backend has a different shape:
+
+| Flag               | Backend shape                                       | What changes vs. the default                                                                                          |
+|--------------------|-----------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
+| *(none)*           | Anonymous JSON HTTP — `source-hackernews`           | —                                                                                                                   |
+| `--auth`/`--oauth` | OAuth / BYOK token HTTP — `source-reddit`, `source-google-drive` | `request()` threads a Bearer token via an `accessToken()` seam; the contract test wires a non-blank fake token (#1529) |
+| `--xml`/`--feed`   | XML / Atom / RSS HTTP — `source-arxiv`, `source-rss`, `source-primegaming` | XML `Accept` header, no kotlinx-serialization, Atom-bodied contract fixture (#1533)                                  |
+| `--local`          | Non-HTTP local provider — `source-ocr`, `source-epub`, `source-calendar` | a `<Name>Reader` device-read seam, no OkHttp/serialization, a plain fake-backed test — no HTTP contract kit (#1526)  |
+
+An authed **XML** feed is the one combination the flags don't cover directly:
+start from `--auth` and swap the `Accept` header (and drop the JSON parse-error
+catch), or start from `--xml` and add the `accessToken()` seam. See
+**Local-provider sources** below for the `--local` path in full.
+
 ## 2. Implement `net/<Name>Api.kt`
 
 The scaffold ships a `request()` wrapper that already does the two things every
@@ -52,6 +69,21 @@ exception to the source layer.
 Point your endpoints at the real service and add typed request functions
 (`popular`, `search`, a detail fetch, a chapter fetch). The `baseUrl` seam is
 already `open` so the contract test can retarget it at a MockWebServer.
+
+> **Authenticated source (`--auth`)?** The scaffolded `request()` reads the
+> bearer token from an `open suspend fun accessToken()` seam and short-circuits
+> to `AuthRequired` when it's blank — wire `accessToken()` to your token store.
+> The `--auth` contract test overrides `accessToken()` with a **non-blank fake**
+> so `popular()` actually reaches the wire; without it a blank-token
+> short-circuit issues zero requests and the IO-pin check fails confusingly with
+> "no request reached the probe" (#1529).
+
+> **Feed / XML source (`--xml`)?** The scaffolded `request()` sends an XML
+> `Accept` header and has **no** kotlinx-serialization parse-error catch (regex
+> and `XmlPullParser` don't throw `SerializationException`). Parse in your
+> `parse` lambda; feed sources usually add conditional-GET headers
+> (`If-None-Match` / `If-Modified-Since`) here. `source-arxiv` and `source-rss`
+> are two real XML precedents (#1533).
 
 ### `FictionResult` decision table
 
@@ -114,7 +146,8 @@ The kit enforces the tribal gotchas as executable checks:
 
 If your source is search-only (no meaningful `popular()`), set
 `override val exercisesPopular = false` and the popular-based checks skip.
-Purely local (non-HTTP) sources don't use this kit at all.
+Purely local (non-HTTP) sources don't use this kit at all — scaffold them with
+`--local` and see **Local-provider sources** below.
 
 ## 5. The two edits that finish the module
 
@@ -133,6 +166,36 @@ registry descriptor (Browse chip, Settings auto-section) and the
 `Map<String, FictionSource>` routing entry. You do **not** add a `SourceIds`
 constant (that table is frozen — the annotation `id` is the source of truth) and
 you do **not** hand-write a DI module.
+
+## Local-provider sources (non-HTTP)
+
+Some sources read the **device**, not a network service — `source-ocr` (scanned
+text), `source-epub` (SAF-picked books), `source-calendar` (`CalendarContract`).
+They have no HTTP surface, so the OkHttp `request()` wrapper, the qualified-client
+DI module, and the HTTP contract kit don't apply. Scaffold them with `--local`:
+
+```bash
+scripts/new-source.sh --local <id> "<Display Name>"
+```
+
+That emits a leaner module:
+
+- **no** OkHttp / kotlinx-serialization and **no** `core-source-testkit` dep;
+- a `<Name>Reader` seam — a concrete `@Inject`-constructor class (so Hilt builds
+  it with no hand-written DI module) whose IO-pinned `items()` / `item()` methods
+  you point at your device read (SAF, `ContentResolver`, or a DataStore the
+  `:app` / `:feature` layer persists);
+- a plain `<Name>SourceTest` with a hand-rolled `FakeReader` (the `source-ocr`
+  `OcrSourceTest` pattern) instead of a contract-kit subclass;
+- an `AndroidManifest.xml` placeholder for a permission you may need to declare
+  (e.g. `READ_CALENDAR`) — delete it if your source needs none.
+
+The IO pin the HTTP kit enforces automatically is **your** responsibility in a
+local source: keep every blocking device read inside
+`withContext(Dispatchers.IO)` in the reader. `source-ocr` is the reference
+implementation. If you ran the default scaffold before realizing your source is
+local, re-run with `--local` on a fresh id rather than gutting the HTTP scaffold
+by hand.
 
 ## PR checklist
 

--- a/scripts/new-source.sh
+++ b/scripts/new-source.sh
@@ -2,24 +2,65 @@
 #
 # new-source.sh — scaffold a new Candela FictionSource plugin module.
 #
-#   scripts/new-source.sh <id> "<Display Name>"
+#   scripts/new-source.sh [MODE] <id> "<Display Name>"
 #   e.g. scripts/new-source.sh demofeed "Demo Feed"
 #
+# MODE (optional, mutually exclusive — pick the one that matches your backend):
+#   (none)          Anonymous JSON HTTP source (the default; source-hackernews).
+#   --auth|--oauth  Token-authed HTTP source (OAuth/BYOK): request() threads a
+#                   Bearer token via an accessToken() seam, and the contract test
+#                   wires a non-blank fake token so the IO-pin probe sees traffic
+#                   (#1529). For Reddit-BYOK / Google-Drive-OAuth class sources.
+#   --xml|--feed    XML/Atom/RSS HTTP source: request() sends an XML Accept header
+#                   and drops the JSON (kotlinx-serialization) parse path (#1533).
+#                   For arxiv / rss / primegaming (Atom) class sources.
+#   --local         Non-HTTP local-provider source: no OkHttp, no serialization,
+#                   no HTTP contract kit — injects a small <Name>Reader seam and a
+#                   plain fake-backed unit test instead (#1526). For ocr / epub /
+#                   calendar (CalendarContract) class sources.
+#
 # Generates source-<id>/ with a build file, a @SourcePlugin-annotated
-# FictionSource stub, an IO-pinned net/<Name>Api.kt request wrapper, and a
-# contract-test subclass wired to :core-source-testkit. The generated stubs
-# COMPILE and the contract test FAILS honestly until you wire popular()/etc. to
-# the Api — that red→green loop is your starting point. See
-# docs/CONTRIBUTING-SOURCES.md.
+# FictionSource stub, the mode-appropriate net/<Name>Api.kt (or, for --local, a
+# <Name>Reader seam), and a matching test. The generated stubs COMPILE and the
+# test FAILS honestly until you wire popular()/etc. to the Api/Reader — that
+# red->green loop is your starting point. See docs/CONTRIBUTING-SOURCES.md.
 #
 # Zero central edits are baked in: @SourcePlugin makes KSP emit both Hilt
 # bindings (the registry descriptor AND the Map<String, FictionSource> entry),
 # so finishing the module is two one-line edits, printed at the end.
 set -euo pipefail
 
+usage() {
+    echo "usage: scripts/new-source.sh [--auth|--xml|--feed|--local] <id> \"<Display Name>\"" >&2
+    echo "  e.g. scripts/new-source.sh demofeed \"Demo Feed\"           # anonymous JSON HTTP" >&2
+    echo "       scripts/new-source.sh --auth gdrive \"Google Drive\"    # token-authed HTTP" >&2
+    echo "       scripts/new-source.sh --xml myfeed \"My Feed\"          # XML/Atom HTTP" >&2
+    echo "       scripts/new-source.sh --local scans \"Scanned text\"    # non-HTTP local" >&2
+}
+
+# ── Mode flag (optional, mutually exclusive) ─────────────────────────────────
+MODE="json" # json | auth | xml | local
+set_mode() {
+    if [[ "$MODE" != "json" ]]; then
+        echo "error: --auth, --xml/--feed, and --local are mutually exclusive (an authed XML feed: pick --auth or --xml and swap the Accept header — see docs/CONTRIBUTING-SOURCES.md)" >&2
+        exit 2
+    fi
+    MODE="$1"
+}
+while [[ $# -gt 0 && "$1" == -* ]]; do
+    case "$1" in
+        --auth|--oauth) set_mode auth ;;
+        --xml|--feed)   set_mode xml ;;
+        --local)        set_mode local ;;
+        -h|--help)      usage; exit 0 ;;
+        --)             shift; break ;;
+        *)              echo "error: unknown flag: $1" >&2; usage; exit 2 ;;
+    esac
+    shift
+done
+
 if [[ $# -ne 2 ]]; then
-    echo "usage: scripts/new-source.sh <id> \"<Display Name>\"" >&2
-    echo "  e.g. scripts/new-source.sh demofeed \"Demo Feed\"" >&2
+    usage
     exit 2
 fi
 
@@ -67,10 +108,117 @@ if [[ -e "$MODDIR" ]]; then
     exit 1
 fi
 
-mkdir -p "$MAIN/net" "$MAIN/di" "$TEST"
+if [[ "$MODE" == "local" ]]; then
+    mkdir -p "$MAIN" "$TEST"
+else
+    mkdir -p "$MAIN/net" "$MAIN/di" "$TEST"
+fi
 
 # ── build.gradle.kts ─────────────────────────────────────────────────────────
-cat > "$MODDIR/build.gradle.kts" <<'GRADLE'
+if [[ "$MODE" == "local" ]]; then
+    # Local providers read the device, not the network: no OkHttp, no
+    # kotlinx-serialization, and no HTTP contract kit. Mirrors source-ocr.
+    cat > "$MODDIR/build.gradle.kts" <<'GRADLE'
+plugins {
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.hilt)
+}
+
+android {
+    namespace = "in.jphe.storyvox.source.__PKG__"
+    compileSdk = 37
+
+    defaultConfig {
+        minSdk = 26
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+    }
+}
+
+dependencies {
+    implementation(project(":core-data"))
+
+    implementation(libs.kotlinx.coroutines.android)
+
+    implementation(libs.hilt.android)
+    ksp(libs.hilt.compiler)
+
+    // @SourcePlugin -> KSP emits the SourcePluginDescriptor @IntoSet binding
+    // AND the Map<String, FictionSource> @IntoMap binding (#1371). The
+    // <Name>Reader seam is an @Inject class, so Hilt constructs it with no
+    // hand-written di/ module.
+    ksp(project(":core-plugin-ksp"))
+
+    // Local sources do NOT use the HTTP contract kit — a plain fake-backed
+    // unit test (see <Name>SourceTest) verifies the read path instead.
+    testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
+}
+GRADLE
+elif [[ "$MODE" == "xml" ]]; then
+    # XML/Atom/RSS feed source: OkHttp for the fetch, but parse with an
+    # XmlPullParser or regex — NOT kotlinx-serialization (#1533).
+    cat > "$MODDIR/build.gradle.kts" <<'GRADLE'
+plugins {
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.hilt)
+}
+
+android {
+    namespace = "in.jphe.storyvox.source.__PKG__"
+    compileSdk = 37
+
+    defaultConfig {
+        minSdk = 26
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+    }
+}
+
+dependencies {
+    implementation(project(":core-data"))
+
+    implementation(libs.kotlinx.coroutines.android)
+    // XML/Atom feed: parse with android.util.Xml / XmlPullParser or a regex
+    // pass — no kotlinx-serialization dependency (#1533). See source-arxiv
+    // and source-rss for two real XML precedents.
+    implementation(libs.okhttp)
+
+    implementation(libs.hilt.android)
+    ksp(libs.hilt.compiler)
+
+    // @SourcePlugin -> KSP emits the SourcePluginDescriptor @IntoSet binding
+    // AND the Map<String, FictionSource> @IntoMap binding (#1371).
+    ksp(project(":core-plugin-ksp"))
+
+    testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(project(":core-source-testkit"))
+}
+GRADLE
+else
+    # json / auth: anonymous or token-authed JSON HTTP source.
+    cat > "$MODDIR/build.gradle.kts" <<'GRADLE'
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.ksp)
@@ -109,8 +257,9 @@ dependencies {
     ksp(libs.hilt.compiler)
 
     // @SourcePlugin -> KSP emits the SourcePluginDescriptor @IntoSet binding
-    // AND the Map<String, FictionSource> @IntoMap binding (#1371). No hand
-    // di/ module needed.
+    // AND the Map<String, FictionSource> @IntoMap binding (#1371). The
+    // scaffold also generates di/<Name>Module.kt, which provides this source's
+    // dedicated OkHttpClient + Api — that one you keep (don't delete it; #1522).
     ksp(project(":core-plugin-ksp"))
 
     testImplementation(libs.junit)
@@ -118,9 +267,85 @@ dependencies {
     testImplementation(project(":core-source-testkit"))
 }
 GRADLE
+fi
 
 # ── <Pascal>Source.kt ────────────────────────────────────────────────────────
-cat > "$MAIN/${PASCAL}Source.kt" <<'SRC'
+if [[ "$MODE" == "local" ]]; then
+    cat > "$MAIN/${PASCAL}Source.kt" <<'SRC'
+package `in`.jphe.storyvox.source.__PKG__
+
+import `in`.jphe.storyvox.data.source.FictionSource
+import `in`.jphe.storyvox.data.source.model.ChapterContent
+import `in`.jphe.storyvox.data.source.model.FictionDetail
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import `in`.jphe.storyvox.data.source.model.FictionSummary
+import `in`.jphe.storyvox.data.source.model.ListPage
+import `in`.jphe.storyvox.data.source.model.SearchQuery
+import `in`.jphe.storyvox.data.source.plugin.SourceCategory
+import `in`.jphe.storyvox.data.source.plugin.SourcePlugin
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * __DISPLAY__ source — a LOCAL provider (scaffolded by new-source.sh --local).
+ *
+ * Reads from the device (files, ContentResolver, a DataStore the :app/:feature
+ * layer persists) via [__PASCAL__Reader] — there is NO network and no HTTP
+ * contract kit. Wire each stubbed member to the reader and map the result into
+ * the core-data models; the plain unit test in src/test fails until popular()
+ * surfaces the reader's items. See docs/CONTRIBUTING-SOURCES.md ("Local-provider
+ * sources") and :source-ocr for the reference implementation.
+ *
+ * The @SourcePlugin id below is the SINGLE source of truth for this backend's
+ * identity — do NOT add a SourceIds constant (that table is frozen).
+ */
+@SourcePlugin(
+    id = "__ID__",
+    displayName = "__DISPLAY__",
+    defaultEnabled = false,
+    category = SourceCategory.Text,
+    supportsSearch = true,
+    description = "One-line subtitle — local surface, zero-network (fill me in)",
+    sourceUrl = "",
+)
+@Singleton
+internal class __PASCAL__Source @Inject constructor(
+    @Suppress("unused") private val reader: __PASCAL__Reader,
+) : FictionSource {
+
+    override val id: String = "__ID__"
+    override val displayName: String = "__DISPLAY__"
+
+    override suspend fun popular(page: Int): FictionResult<ListPage<FictionSummary>> =
+        FictionResult.NotFound("not implemented")
+
+    override suspend fun latestUpdates(page: Int): FictionResult<ListPage<FictionSummary>> =
+        FictionResult.NotFound("not implemented")
+
+    override suspend fun byGenre(genre: String, page: Int): FictionResult<ListPage<FictionSummary>> =
+        FictionResult.NotFound("not implemented")
+
+    override suspend fun search(query: SearchQuery): FictionResult<ListPage<FictionSummary>> =
+        FictionResult.NotFound("not implemented")
+
+    override suspend fun fictionDetail(fictionId: String): FictionResult<FictionDetail> =
+        FictionResult.NotFound("not implemented")
+
+    override suspend fun chapter(fictionId: String, chapterId: String): FictionResult<ChapterContent> =
+        FictionResult.NotFound("not implemented")
+
+    override suspend fun followsList(page: Int): FictionResult<ListPage<FictionSummary>> =
+        FictionResult.AuthRequired("not implemented")
+
+    override suspend fun setFollowed(fictionId: String, followed: Boolean): FictionResult<Unit> =
+        FictionResult.AuthRequired("not implemented")
+
+    override suspend fun genres(): FictionResult<List<String>> =
+        FictionResult.Success(emptyList())
+}
+SRC
+else
+    cat > "$MAIN/${PASCAL}Source.kt" <<'SRC'
 package `in`.jphe.storyvox.source.__PKG__
 
 import `in`.jphe.storyvox.data.source.FictionSource
@@ -193,9 +418,234 @@ internal class __PASCAL__Source @Inject constructor(
         FictionResult.Success(emptyList())
 }
 SRC
+fi
 
-# ── net/<Pascal>Api.kt ───────────────────────────────────────────────────────
-cat > "$MAIN/net/${PASCAL}Api.kt" <<'API'
+# ── net/<Pascal>Api.kt  (HTTP modes only) ────────────────────────────────────
+if [[ "$MODE" == "auth" ]]; then
+    cat > "$MAIN/net/${PASCAL}Api.kt" <<'API'
+package `in`.jphe.storyvox.source.__PKG__.net
+
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.IOException
+import javax.inject.Inject
+
+/**
+ * HTTP client for __DISPLAY__ (OAuth/BYOK authed). The [request] wrapper is
+ * pre-written to satisfy the FictionSourceContractTest: it pins the blocking
+ * OkHttp call to Dispatchers.IO (#585), threads the bearer token from
+ * [accessToken], and maps status codes to typed failures. Copy its shape for
+ * every endpoint you add — do NOT surface raw HTTP codes or exceptions.
+ */
+internal open class __PASCAL__Api @Inject constructor(
+    private val client: OkHttpClient,
+) {
+    /** Test seam — `open` so unit tests point this at a MockWebServer without
+     *  restructuring call sites (mirrors StandardEbooksApi.baseUrl). */
+    internal open val baseUrl: String get() = BASE_URL
+
+    /**
+     * Current OAuth/BYOK bearer token, or null/blank when the user has not
+     * linked an account. Wire this to your token store: inject it into this Api
+     * and return the persisted token. The contract test overrides this with a
+     * non-blank fake so popular() actually reaches the wire (#1529) — a source
+     * that short-circuits to AuthRequired on a blank token records zero network
+     * calls, which fails the IO-pin probe with a confusing "no request reached
+     * the probe" message.
+     */
+    internal open suspend fun accessToken(): String? = null
+
+    /**
+     * IO-pinned authed GET. `parse` turns the response body into your typed
+     * model. Returns [FictionResult.AuthRequired] when there is no token, and a
+     * typed failure for every non-2xx status — never throws for an HTTP error.
+     */
+    suspend fun <T> request(path: String, parse: (String) -> T): FictionResult<T> =
+        withContext(Dispatchers.IO) {
+            val url = baseUrl + path
+            val token = accessToken()
+            if (token.isNullOrBlank()) {
+                return@withContext FictionResult.AuthRequired("__DISPLAY__: link your account in Settings")
+            }
+            try {
+                val req = Request.Builder()
+                    .url(url)
+                    .header("Accept", "application/json")
+                    .header("Authorization", "Bearer $token")
+                    .get()
+                    .build()
+                client.newCall(req).execute().use { resp ->
+                    when {
+                        resp.code == 404 -> FictionResult.NotFound("__DISPLAY__: $path not found")
+                        resp.code == 401 -> FictionResult.AuthRequired("HTTP 401 from $url")
+                        resp.code == 403 -> {
+                            // Cloudflare interstitials arrive as HTTP 403 with challenge
+                            // HTML — the CF sniff MUST precede the auth mapping, or a
+                            // CF-gated 403 misreports as "sign in required" (see
+                            // docs/CONTRIBUTING-SOURCES.md decision table).
+                            val body = resp.body?.string().orEmpty()
+                            if (looksLikeCfChallenge(body)) {
+                                FictionResult.NetworkError(
+                                    "__DISPLAY__ returned a Cloudflare challenge page — try again later",
+                                    IOException("Cloudflare challenge"),
+                                )
+                            } else {
+                                FictionResult.AuthRequired("HTTP 403 from $url")
+                            }
+                        }
+                        resp.code == 429 -> FictionResult.RateLimited(
+                            retryAfter = null,
+                            message = "__DISPLAY__ rate limited (HTTP 429)",
+                        )
+                        !resp.isSuccessful -> FictionResult.NetworkError(
+                            "HTTP ${resp.code} from $url",
+                            IOException("HTTP ${resp.code}"),
+                        )
+                        else -> {
+                            val text = resp.body?.string()
+                                ?: return@withContext FictionResult.NetworkError(
+                                    "empty body",
+                                    IOException("empty body"),
+                                )
+                            FictionResult.Success(parse(text))
+                        }
+                    }
+                }
+            } catch (e: IOException) {
+                FictionResult.NetworkError(e.message ?: "fetch failed", e)
+            } catch (e: kotlinx.serialization.SerializationException) {
+                // A throwing parse lambda must stay inside the typed-error
+                // contract — never escape as a raw exception.
+                FictionResult.NetworkError("__DISPLAY__ returned an unexpected response shape", e)
+            }
+        }
+
+    /**
+     * #1443-family heuristic: does a body look like a Cloudflare challenge
+     * interstitial rather than your API's payload? Keep this arm ahead of
+     * the 401/403 auth mapping (see the request() template above).
+     */
+    private fun looksLikeCfChallenge(body: String): Boolean =
+        body.contains("/cdn-cgi/challenge-platform/") ||
+            body.contains("Just a moment...") ||
+            body.contains("cf-mitigated")
+
+    companion object {
+        const val BASE_URL = "https://example.com"
+    }
+}
+API
+elif [[ "$MODE" == "xml" ]]; then
+    cat > "$MAIN/net/${PASCAL}Api.kt" <<'API'
+package `in`.jphe.storyvox.source.__PKG__.net
+
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.IOException
+import javax.inject.Inject
+
+/**
+ * HTTP client for __DISPLAY__ (XML/Atom/RSS feed). The [request] wrapper is
+ * pre-written to satisfy the FictionSourceContractTest: it pins the blocking
+ * OkHttp call to Dispatchers.IO (#585), sends an XML Accept header, and maps
+ * status codes to typed failures. `parse` is where you run an XmlPullParser or
+ * a regex pass (there is no kotlinx-serialization here, #1533) — see
+ * source-arxiv and source-rss for two real XML precedents. Copy this shape for
+ * every endpoint you add — do NOT surface raw HTTP codes or exceptions.
+ */
+internal open class __PASCAL__Api @Inject constructor(
+    private val client: OkHttpClient,
+) {
+    /** Test seam — `open` so unit tests point this at a MockWebServer without
+     *  restructuring call sites (mirrors StandardEbooksApi.baseUrl). */
+    internal open val baseUrl: String get() = BASE_URL
+
+    /**
+     * IO-pinned GET for an XML/Atom body. `parse` turns the response text into
+     * your typed model (XmlPullParser / regex). Returns a typed
+     * [FictionResult] failure for every non-2xx status — never throws for an
+     * HTTP error. A feed source usually adds conditional-GET headers
+     * (If-None-Match / If-Modified-Since) here — see source-primegaming.
+     */
+    suspend fun <T> request(path: String, parse: (String) -> T): FictionResult<T> =
+        withContext(Dispatchers.IO) {
+            val url = baseUrl + path
+            try {
+                val req = Request.Builder()
+                    .url(url)
+                    .header("Accept", "application/atom+xml, application/xml;q=0.9, */*;q=0.8")
+                    .get()
+                    .build()
+                client.newCall(req).execute().use { resp ->
+                    when {
+                        resp.code == 404 -> FictionResult.NotFound("__DISPLAY__: $path not found")
+                        resp.code == 401 -> FictionResult.AuthRequired("HTTP 401 from $url")
+                        resp.code == 403 -> {
+                            // Cloudflare interstitials arrive as HTTP 403 with challenge
+                            // HTML — the CF sniff MUST precede the auth mapping, or a
+                            // CF-gated 403 misreports as "sign in required" (see
+                            // docs/CONTRIBUTING-SOURCES.md decision table).
+                            val body = resp.body?.string().orEmpty()
+                            if (looksLikeCfChallenge(body)) {
+                                FictionResult.NetworkError(
+                                    "__DISPLAY__ returned a Cloudflare challenge page — try again later",
+                                    IOException("Cloudflare challenge"),
+                                )
+                            } else {
+                                FictionResult.AuthRequired("HTTP 403 from $url")
+                            }
+                        }
+                        resp.code == 429 -> FictionResult.RateLimited(
+                            retryAfter = null,
+                            message = "__DISPLAY__ rate limited (HTTP 429)",
+                        )
+                        !resp.isSuccessful -> FictionResult.NetworkError(
+                            "HTTP ${resp.code} from $url",
+                            IOException("HTTP ${resp.code}"),
+                        )
+                        else -> {
+                            val text = resp.body?.string()
+                                ?: return@withContext FictionResult.NetworkError(
+                                    "empty body",
+                                    IOException("empty body"),
+                                )
+                            // XML/regex parsing does not throw SerializationException,
+                            // so there is no JSON parse-error catch here (#1533). If
+                            // your parser can throw (XmlPullParserException is an
+                            // IOException, caught below), keep failures inside the
+                            // typed contract — never let one escape as a raw throw.
+                            FictionResult.Success(parse(text))
+                        }
+                    }
+                }
+            } catch (e: IOException) {
+                FictionResult.NetworkError(e.message ?: "fetch failed", e)
+            }
+        }
+
+    /**
+     * #1443-family heuristic: does a body look like a Cloudflare challenge
+     * interstitial rather than your feed payload? Keep this arm ahead of
+     * the 401/403 auth mapping (see the request() template above).
+     */
+    private fun looksLikeCfChallenge(body: String): Boolean =
+        body.contains("/cdn-cgi/challenge-platform/") ||
+            body.contains("Just a moment...") ||
+            body.contains("cf-mitigated")
+
+    companion object {
+        const val BASE_URL = "https://example.com"
+    }
+}
+API
+elif [[ "$MODE" == "json" ]]; then
+    cat > "$MAIN/net/${PASCAL}Api.kt" <<'API'
 package `in`.jphe.storyvox.source.__PKG__.net
 
 import `in`.jphe.storyvox.data.source.model.FictionResult
@@ -294,13 +744,63 @@ internal open class __PASCAL__Api @Inject constructor(
     }
 }
 API
+fi
 
-# ── di/<Pascal>Module.kt ─────────────────────────────────────────────────────
+# ── <Pascal>Reader.kt  (--local only) ────────────────────────────────────────
+if [[ "$MODE" == "local" ]]; then
+    cat > "$MAIN/${PASCAL}Reader.kt" <<'READER'
+package `in`.jphe.storyvox.source.__PKG__
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Local read seam for __DISPLAY__ (scaffolded by new-source.sh --local).
+ *
+ * A local-provider source reads from the device — files via SAF, a
+ * ContentResolver query (e.g. CalendarContract), or a DataStore the
+ * :app/:feature capture flow persists — NOT the network. Keep every blocking
+ * read pinned to Dispatchers.IO here so the source layer stays main-safe: the
+ * HTTP contract kit's #585 IO-pin check does NOT run for local sources, so
+ * this is your responsibility.
+ *
+ * This is a concrete `open class` with an `@Inject` constructor on purpose:
+ * Hilt constructs it with zero DI wiring (no hand-written di/ module), and unit
+ * tests subclass it with a fake — see __PASCAL__SourceTest. Mirrors
+ * :source-ocr's `OcrConfig` seam.
+ */
+@Singleton
+internal open class __PASCAL__Reader @Inject constructor() {
+
+    /** Every item this local source exposes, newest first. Stub — replace with
+     *  a real device read (SAF / ContentResolver / DataStore), IO-pinned. */
+    internal open suspend fun items(): List<__PASCAL__Item> =
+        withContext(Dispatchers.IO) { emptyList() }
+
+    /** One item's full body by id, or null if it is gone. Stub. */
+    internal open suspend fun item(id: String): __PASCAL__Item? =
+        withContext(Dispatchers.IO) { null }
+}
+
+/** Minimal local record — rename/extend to match your device data. */
+internal data class __PASCAL__Item(
+    val id: String,
+    val title: String,
+    val body: String,
+)
+READER
+fi
+
+# ── di/<Pascal>Module.kt  (JSON / auth / XML HTTP modes only) ─────────────────
 # @SourcePlugin makes KSP emit the FictionSource multibindings, but the source's
 # OkHttpClient + Api still need a provider (there is no global unqualified
 # OkHttpClient — each source owns a qualified client with the shared UA
-# interceptor). Mirrors source-hackernews/di/HackerNewsHttpModule.kt.
-cat > "$MAIN/di/${PASCAL}Module.kt" <<'DIMOD'
+# interceptor). Mirrors source-hackernews/di/HackerNewsHttpModule.kt. --local
+# sources skip this: the <Name>Reader is an @Inject class Hilt builds directly.
+if [[ "$MODE" != "local" ]]; then
+    cat > "$MAIN/di/${PASCAL}Module.kt" <<'DIMOD'
 package `in`.jphe.storyvox.source.__PKG__.di
 
 import dagger.Module
@@ -347,9 +847,135 @@ internal object __PASCAL__HttpModule {
     ): __PASCAL__Api = __PASCAL__Api(client)
 }
 DIMOD
+fi
 
-# ── src/test/<Pascal>ContractTest.kt ─────────────────────────────────────────
-cat > "$TEST/${PASCAL}ContractTest.kt" <<'CTEST'
+# ── src/test/<Pascal>(Contract)Test.kt ───────────────────────────────────────
+if [[ "$MODE" == "local" ]]; then
+    cat > "$TEST/${PASCAL}SourceTest.kt" <<'CTEST'
+package `in`.jphe.storyvox.source.__PKG__
+
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * __DISPLAY__ read-path test over a fake [__PASCAL__Reader] — the :source-ocr
+ * OcrSourceTest pattern. No Robolectric, no device: the fake stands in for the
+ * real device read so the source's mapping (item -> fiction, page -> chapter)
+ * is verified in pure JVM.
+ *
+ * This FAILS until you map [__PASCAL__Reader.items] into a
+ * ListPage<FictionSummary> in [__PASCAL__Source.popular] — that mapping is your
+ * to-do list. See docs/CONTRIBUTING-SOURCES.md ("Local-provider sources").
+ */
+class __PASCAL__SourceTest {
+
+    private class FakeReader(private val seed: List<__PASCAL__Item>) : __PASCAL__Reader() {
+        override suspend fun items(): List<__PASCAL__Item> = seed
+        override suspend fun item(id: String): __PASCAL__Item? = seed.firstOrNull { it.id == id }
+    }
+
+    @Test
+    fun `popular surfaces every local item as a fiction`() = runTest {
+        val source = __PASCAL__Source(
+            FakeReader(
+                listOf(
+                    __PASCAL__Item(id = "1", title = "First", body = "Body one"),
+                    __PASCAL__Item(id = "2", title = "Second", body = "Body two"),
+                ),
+            ),
+        )
+
+        val result = source.popular(1)
+
+        assertTrue(
+            "wire popular() to reader.items() and map to ListPage<FictionSummary>",
+            result is FictionResult.Success<*>,
+        )
+    }
+}
+CTEST
+elif [[ "$MODE" == "auth" ]]; then
+    cat > "$TEST/${PASCAL}ContractTest.kt" <<'CTEST'
+package `in`.jphe.storyvox.source.__PKG__
+
+import `in`.jphe.storyvox.data.source.FictionSource
+import `in`.jphe.storyvox.source.__PKG__.net.__PASCAL__Api
+import `in`.jphe.storyvox.testkit.source.FictionSourceContractTest
+import okhttp3.OkHttpClient
+
+/**
+ * __DISPLAY__ (authed) against the shared contract kit. This FAILS until you
+ * wire [__PASCAL__Source.popular] (and friends) through [__PASCAL__Api.request]:
+ * the stub never hits the network, so the "network work leaves the caller
+ * thread" and auth/rate-limit checks fail honestly. Replace [happyListBody] /
+ * [listPathFragment] with your real list endpoint, make the source talk to the
+ * Api, and turn this green. See docs/CONTRIBUTING-SOURCES.md.
+ */
+class __PASCAL__ContractTest : FictionSourceContractTest() {
+    override fun createSource(client: OkHttpClient, baseUrl: String): FictionSource {
+        val host = baseUrl.trimEnd('/')
+        return __PASCAL__Source(
+            object : __PASCAL__Api(client) {
+                override val baseUrl: String get() = host
+                // #1529 — a non-blank fake token so request() adds the Bearer
+                // header and actually reaches the wire. Without it every call
+                // short-circuits to AuthRequired and the IO-pin probe records
+                // zero traffic ("no request reached the probe").
+                override suspend fun accessToken(): String = "contract-fake-token"
+            },
+        )
+    }
+
+    /** Replace with a trimmed real response body from your list endpoint. */
+    override fun happyListBody(): String = "{}"
+
+    /** Replace with a path fragment your popular()/list endpoint hits. */
+    override fun listPathFragment(): String = "__ID__"
+}
+CTEST
+elif [[ "$MODE" == "xml" ]]; then
+    cat > "$TEST/${PASCAL}ContractTest.kt" <<'CTEST'
+package `in`.jphe.storyvox.source.__PKG__
+
+import `in`.jphe.storyvox.data.source.FictionSource
+import `in`.jphe.storyvox.source.__PKG__.net.__PASCAL__Api
+import `in`.jphe.storyvox.testkit.source.FictionSourceContractTest
+import okhttp3.OkHttpClient
+
+/**
+ * __DISPLAY__ (XML/Atom feed) against the shared contract kit. This FAILS until
+ * you wire [__PASCAL__Source.popular] (and friends) through
+ * [__PASCAL__Api.request]: the stub never hits the network, so the "network
+ * work leaves the caller thread" and auth/rate-limit checks fail honestly.
+ * Replace [happyListBody] with a trimmed real feed body and [listPathFragment]
+ * with your real list path, make the source parse the feed, and turn this
+ * green. See docs/CONTRIBUTING-SOURCES.md and source-arxiv / source-rss.
+ */
+class __PASCAL__ContractTest : FictionSourceContractTest() {
+    override fun createSource(client: OkHttpClient, baseUrl: String): FictionSource {
+        val host = baseUrl.trimEnd('/')
+        return __PASCAL__Source(
+            object : __PASCAL__Api(client) {
+                override val baseUrl: String get() = host
+            },
+        )
+    }
+
+    /** Replace with a trimmed real Atom/RSS body from your feed (2–3 entries). */
+    override fun happyListBody(): String =
+        "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
+            "<feed xmlns=\"http://www.w3.org/2005/Atom\">" +
+            "<entry><id>1</id><title>Example entry</title></entry>" +
+            "</feed>"
+
+    /** Replace with a path fragment your popular()/list endpoint hits. */
+    override fun listPathFragment(): String = "__ID__"
+}
+CTEST
+elif [[ "$MODE" == "json" ]]; then
+    cat > "$TEST/${PASCAL}ContractTest.kt" <<'CTEST'
 package `in`.jphe.storyvox.source.__PKG__
 
 import `in`.jphe.storyvox.data.source.FictionSource
@@ -382,6 +1008,23 @@ class __PASCAL__ContractTest : FictionSourceContractTest() {
     override fun listPathFragment(): String = "__ID__"
 }
 CTEST
+fi
+
+# ── AndroidManifest.xml  (--local only, for a declared permission) ────────────
+if [[ "$MODE" == "local" ]]; then
+    cat > "$MODDIR/src/main/AndroidManifest.xml" <<'MANIFEST'
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Local-provider manifest placeholder. If your source reads a permission-gated
+  provider (e.g. CalendarContract needs READ_CALENDAR), declare it here and
+  request it at runtime from the :feature/:app layer. Delete this file if your
+  source needs no permission (an empty manifest is synthesized from `namespace`).
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- <uses-permission android:name="android.permission.READ_CALENDAR" /> -->
+</manifest>
+MANIFEST
+fi
 
 # Substitute placeholders (| delimiter so display names with '/' are safe).
 # The display name is user text: escape sed replacement metacharacters
@@ -397,8 +1040,17 @@ find "$MODDIR" -type f -print0 | while IFS= read -r -d '' f; do
         "$f"
 done
 
+# ── Done ─────────────────────────────────────────────────────────────────────
+case "$MODE" in
+    local) MODE_LABEL="local provider (non-HTTP; <Name>Reader seam)" ;;
+    auth)  MODE_LABEL="authed HTTP (OAuth/BYOK; Bearer-token request wrapper)" ;;
+    xml)   MODE_LABEL="XML/Atom feed HTTP (XML Accept, no serialization)" ;;
+    *)     MODE_LABEL="anonymous JSON HTTP" ;;
+esac
+
 cat <<DONE
-Scaffolded $MODULE ($PASCAL) at $MODDIR
+Scaffolded $MODULE ($PASCAL) — mode: $MODE_LABEL
+  at $MODDIR
 
 Done. Two edits remain:
   1. settings.gradle.kts       → include(":source-$ID")

--- a/scripts/new-source.sh
+++ b/scripts/new-source.sh
@@ -572,6 +572,11 @@ internal open class __PASCAL__Api @Inject constructor(
      * [FictionResult] failure for every non-2xx status — never throws for an
      * HTTP error. A feed source usually adds conditional-GET headers
      * (If-None-Match / If-Modified-Since) here — see source-primegaming.
+     *
+     * Parser failures stay inside the contract: a throwing XmlPullParser maps to
+     * [FictionResult.NetworkError] via the dedicated catch below. Your `parse`
+     * MUST NOT let a parse exception escape as a raw throw — if you parse with a
+     * type other than XmlPullParser, add a matching narrow catch arm.
      */
     suspend fun <T> request(path: String, parse: (String) -> T): FictionResult<T> =
         withContext(Dispatchers.IO) {
@@ -616,16 +621,26 @@ internal open class __PASCAL__Api @Inject constructor(
                                     IOException("empty body"),
                                 )
                             // XML/regex parsing does not throw SerializationException,
-                            // so there is no JSON parse-error catch here (#1533). If
-                            // your parser can throw (XmlPullParserException is an
-                            // IOException, caught below), keep failures inside the
-                            // typed contract — never let one escape as a raw throw.
+                            // so there is no JSON parse-error catch here (#1533). A
+                            // throwing XmlPullParser surfaces as XmlPullParserException,
+                            // which has its OWN catch arm below (it extends Exception,
+                            // NOT IOException) — keep parse()'s failures inside the
+                            // typed contract, never let one escape as a raw throw.
                             FictionResult.Success(parse(text))
                         }
                     }
                 }
             } catch (e: IOException) {
                 FictionResult.NetworkError(e.message ?: "fetch failed", e)
+            } catch (e: org.xmlpull.v1.XmlPullParserException) {
+                // XmlPullParserException extends java.lang.Exception, NOT
+                // IOException (verified against android.jar), so a malformed feed
+                // thrown by an XmlPullParser is NOT caught by the IOException arm
+                // above and needs this one. Do NOT fold it into that arm or drop
+                // it: without it a bad feed escapes the typed contract as a raw
+                // crash (#1533 review). Any parser you swap in must likewise keep
+                // its failures inside FictionResult — add a narrow arm per type.
+                FictionResult.NetworkError("__DISPLAY__ returned a malformed XML feed", e)
             }
         }
 


### PR DESCRIPTION
## Scaffold modes for `new-source.sh` — closes #1526, #1529, #1533

`scripts/new-source.sh` only scaffolded an **anonymous JSON HTTP** source, so
whole classes of sources had to gut the generated HTTP template before writing
real code. This adds three mutually-exclusive mode flags; the default
(anonymous JSON) path is byte-for-byte unchanged.

| Flag | Backend | What it emits differently |
|------|---------|---------------------------|
| *(none)* | Anonymous JSON HTTP | — (unchanged) |
| `--auth`/`--oauth` | OAuth / BYOK token HTTP | `request()` threads a Bearer token via an `open suspend fun accessToken()` seam + short-circuits to `AuthRequired` when blank; contract test overrides `accessToken()` with a **non-blank fake** so `popular()` reaches the wire |
| `--xml`/`--feed` | XML / Atom / RSS HTTP | XML `Accept` header, **no** kotlinx-serialization dep/plugin/parse-catch, Atom-bodied contract fixture |
| `--local` | Non-HTTP local provider | `<Name>Reader` device-read seam (concrete `@Inject` class → no hand DI module), plain fake-backed `<Name>SourceTest` (the `source-ocr` pattern), `AndroidManifest.xml` permission placeholder; no OkHttp/serialization/contract-kit |

### Why these three (the dogfood evidence)
- **#1526** — building `source-calendar` (#1495) meant deleting `net/`, the DI
  module, the contract test, and the okhttp/serialization deps right after
  scaffolding. `--local` emits the lean shape directly.
- **#1529** — `source-google-drive` (OAuth) and `source-reddit` (BYOK) both had
  to hand-add a Bearer seam **and** discover that a blank-token short-circuit
  makes the IO-pin probe see zero traffic ("no request reached the probe").
  `--auth` bakes both in.
- **#1533** — `source-primegaming` (Atom) had to rewrite the JSON `request()`
  wrapper wholesale. `--xml` emits the XML-shaped wrapper and cites the
  arxiv/rss precedents.

### Notes
- An authed **XML** feed is the one combo the flags don't cover directly —
  documented workaround: start from `--auth` and swap the `Accept` header (or
  `--xml` + add the `accessToken()` seam). Kept flags mutually exclusive rather
  than multiplying template variants (no gold-plating).
- Dogfooded: generated all four modes, verified trees + placeholder
  substitution + mode-specific content, cleaned up. No local gradle (CI is the
  compile gate).

### Series (stacked, sequential)
1. **PR 1/3 — this PR**: scaffold modes (`new-source.sh` + docs).
2. PR 2/3 — kit truthfulness (#1523) + docs di-module truth (#1522).
3. PR 3/3 — Browse glyph `@SourcePlugin(iconName)` consumption (#1527).

`#1504` (testkit split) is gated on this whole series merging. `#1544`
(source handbook) is gated on this PR (#1526).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
