### PR TITLE
feat(rss): decouple subscription identity from fetch URL (#1498)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/data/RssConfigImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/RssConfigImpl.kt
@@ -20,11 +20,21 @@ import kotlinx.coroutines.flow.map
 private val Context.rssDataStore: DataStore<Preferences> by preferencesDataStore(name = "storyvox_rss")
 
 private object RssKeys {
-    /** Pipe-separated list of feed URLs the user has added. Pipe is a
-     *  safe delimiter — URL spec excludes `|` from any URL component
+    /** Pipe-separated list of feed records the user has added. Pipe is a
+     *  safe record delimiter — URL spec excludes `|` from any URL component
      *  without percent-encoding, so we never collide with a real URL.
-     *  Empty / missing key = no subscriptions. */
+     *  Empty / missing key = no subscriptions.
+     *
+     *  Issue #1498 — each record is `url` or, once autodiscovery has
+     *  resolved a distinct feed URL, `url<space>resolvedUrl`. Space is a
+     *  safe field delimiter for the same reason as pipe: a valid URL never
+     *  carries a literal space (it must be percent-encoded). Legacy records
+     *  (bare `url`, no space) decode with `resolvedUrl = null`. */
     val FEEDS = stringPreferencesKey("pref_rss_feeds")
+
+    /** #1498 — separator between a subscription's identity URL and its
+     *  autodiscovered fetch URL within one pipe-delimited record. */
+    const val RESOLVED_SEP: Char = ' '
 }
 
 /**
@@ -34,10 +44,12 @@ private object RssKeys {
  * churning that file's preference schema (same pattern as
  * [PalaceConfigImpl]).
  *
- * Storage format: pipe-separated URLs. Round-trip is just
- * `split('|').filter { it.isNotBlank() }`. Adding/removing rewrites
- * the whole field — it's a small list (typically <50 feeds) so a
- * full rewrite is cheaper than maintaining structured storage.
+ * Storage format: pipe-separated records, each `url` or (issue #1498)
+ * `url<space>resolvedUrl` once autodiscovery has resolved a distinct
+ * feed URL. Adding/removing/resolving rewrites the whole field — it's a
+ * small list (typically <50 feeds) so a full rewrite is cheaper than
+ * maintaining structured storage. Legacy pipe-only-URL data decodes with
+ * `resolvedUrl = null`, so upgrades re-discover once.
  */
 @Singleton
 class RssConfigImpl(
@@ -80,14 +92,48 @@ class RssConfigImpl(
         }
     }
 
+    override suspend fun setResolvedUrl(fictionId: String, resolvedUrl: String) {
+        val trimmed = resolvedUrl.trim()
+        if (trimmed.isEmpty()) return
+        store.edit { prefs ->
+            val existing = decode(prefs[RssKeys.FEEDS])
+            // No-op if the subscription is gone or the resolved URL is
+            // unchanged / identical to the identity URL (nothing to persist).
+            val target = existing.firstOrNull { it.fictionId == fictionId } ?: return@edit
+            if (target.resolvedUrl == trimmed || target.url == trimmed) return@edit
+            val updated = existing.map {
+                if (it.fictionId == fictionId) it.copy(resolvedUrl = trimmed) else it
+            }
+            prefs[RssKeys.FEEDS] = encode(updated)
+        }
+    }
+
     private fun encode(subs: List<RssSubscription>): String =
-        subs.joinToString("|") { it.url }
+        subs.joinToString("|") { sub ->
+            // #1498 — append the resolved fetch URL only when it differs from
+            // the identity URL; a bare `url` keeps the legacy record shape.
+            val resolved = sub.resolvedUrl
+            if (resolved.isNullOrBlank() || resolved == sub.url) sub.url
+            else "${sub.url}${RssKeys.RESOLVED_SEP}$resolved"
+        }
 
     private fun decode(raw: String?): List<RssSubscription> {
         if (raw.isNullOrBlank()) return emptyList()
         return raw.split('|')
             .map { it.trim() }
             .filter { it.isNotEmpty() }
-            .map { url -> RssSubscription(fictionId = fictionIdForFeedUrl(url), url = url) }
+            .map { record ->
+                // #1498 — `url` (legacy) or `url<space>resolvedUrl`. Split on
+                // the FIRST separator only; neither field can contain a space.
+                val url = record.substringBefore(RssKeys.RESOLVED_SEP)
+                val resolved = record.substringAfter(RssKeys.RESOLVED_SEP, "")
+                    .trim()
+                    .takeIf { it.isNotEmpty() }
+                RssSubscription(
+                    fictionId = fictionIdForFeedUrl(url),
+                    url = url,
+                    resolvedUrl = resolved,
+                )
+            }
     }
 }

--- a/app/src/test/kotlin/in/jphe/storyvox/data/RssConfigImplTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/RssConfigImplTest.kt
@@ -1,0 +1,155 @@
+package `in`.jphe.storyvox.data
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import `in`.jphe.storyvox.source.rss.config.fictionIdForFeedUrl
+import java.io.File
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Issue #1498 — [RssConfigImpl] persistence of the autodiscovered feed URL
+ * (`resolvedUrl`) as a field distinct from the identity-bearing
+ * subscription URL. Real temp-file DataStore so serialization is identical
+ * to production — same shape as the [SettingsRepositoryUiImpl] tests.
+ *
+ * Guarantees under test:
+ *  - `resolvedUrl` round-trips through the pipe/space record format;
+ *  - the `fictionId` stays derived from the original `url` (never the
+ *    resolved URL) so no Room rows are orphaned;
+ *  - legacy pipe-only-URL data decodes with `resolvedUrl = null`;
+ *  - `removeFeed` drops the resolved record with the subscription.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class RssConfigImplTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private lateinit var scope: CoroutineScope
+    private lateinit var store: DataStore<Preferences>
+    private lateinit var config: RssConfigImpl
+
+    private val feedsKey = stringPreferencesKey("pref_rss_feeds")
+
+    @Before
+    fun setUp() {
+        scope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher())
+        val file = File(tempFolder.newFolder(), "storyvox_rss.preferences_pb")
+        store = PreferenceDataStoreFactory.create(scope = scope, produceFile = { file })
+        config = RssConfigImpl(store)
+    }
+
+    @After
+    fun tearDown() {
+        scope.cancel()
+    }
+
+    @Test fun `a freshly added feed has a null resolvedUrl`() = runTest {
+        config.addFeed("https://tricycle.org/feed")
+        val sub = config.snapshot().single()
+        assertEquals("https://tricycle.org/feed", sub.url)
+        assertNull("no discovery has run yet", sub.resolvedUrl)
+        assertEquals(fictionIdForFeedUrl("https://tricycle.org/feed"), sub.fictionId)
+    }
+
+    @Test fun `setResolvedUrl persists the discovered feed without changing identity`() = runTest {
+        config.addFeed("https://tricycle.org")
+        val fid = fictionIdForFeedUrl("https://tricycle.org")
+
+        config.setResolvedUrl(fid, "https://tricycle.org/feed/atom/")
+
+        val sub = config.snapshot().single()
+        assertEquals("identity URL unchanged", "https://tricycle.org", sub.url)
+        assertEquals("fetch URL persisted", "https://tricycle.org/feed/atom/", sub.resolvedUrl)
+        // The critical invariant: fictionId still derives from the original URL.
+        assertEquals(fid, sub.fictionId)
+        assertEquals(fictionIdForFeedUrl("https://tricycle.org"), sub.fictionId)
+    }
+
+    @Test fun `resolvedUrl survives a fresh config instance (persistence)`() = runTest {
+        config.addFeed("https://tricycle.org")
+        val fid = fictionIdForFeedUrl("https://tricycle.org")
+        config.setResolvedUrl(fid, "https://tricycle.org/feed/atom/")
+
+        // A new RssConfigImpl over the SAME store models a process relaunch.
+        val reopened = RssConfigImpl(store)
+        val sub = reopened.snapshot().single()
+        assertEquals("https://tricycle.org/feed/atom/", sub.resolvedUrl)
+        assertEquals("https://tricycle.org", sub.url)
+    }
+
+    @Test fun `legacy pipe-only URL data decodes with null resolvedUrl`() = runTest {
+        // Pre-#1498 on-disk format: bare pipe-separated URLs, no resolved URL.
+        store.edit { it[feedsKey] = "https://a.example.com/feed|https://b.example.com/feed" }
+
+        val subs = config.snapshot()
+        assertEquals(2, subs.size)
+        subs.forEach { assertNull("upgrade re-discovers once", it.resolvedUrl) }
+        assertEquals("https://a.example.com/feed", subs[0].url)
+        assertEquals("https://b.example.com/feed", subs[1].url)
+        assertEquals(fictionIdForFeedUrl("https://b.example.com/feed"), subs[1].fictionId)
+    }
+
+    @Test fun `setResolvedUrl is a no-op for an unknown fictionId`() = runTest {
+        config.addFeed("https://a.example.com/feed")
+        config.setResolvedUrl("rss:deadbeef", "https://evil.example.com/feed")
+        assertNull(config.snapshot().single().resolvedUrl)
+    }
+
+    @Test fun `setResolvedUrl does not persist when resolved equals the identity URL`() = runTest {
+        config.addFeed("https://a.example.com/feed")
+        val fid = fictionIdForFeedUrl("https://a.example.com/feed")
+        config.setResolvedUrl(fid, "https://a.example.com/feed")
+        // Nothing to resolve — record stays legacy-shaped, resolvedUrl null.
+        assertNull(config.snapshot().single().resolvedUrl)
+    }
+
+    @Test fun `removeFeed drops the resolved record too`() = runTest {
+        config.addFeed("https://tricycle.org")
+        val fid = fictionIdForFeedUrl("https://tricycle.org")
+        config.setResolvedUrl(fid, "https://tricycle.org/feed/atom/")
+
+        config.removeFeed(fid)
+
+        assertEquals(emptyList<Any>(), config.snapshot())
+    }
+
+    @Test fun `resolvedUrl round-trips alongside a plain sibling subscription`() = runTest {
+        config.addFeed("https://tricycle.org")   // will get a resolvedUrl
+        config.addFeed("https://plain.example.com/feed") // stays plain
+        val fid = fictionIdForFeedUrl("https://tricycle.org")
+        config.setResolvedUrl(fid, "https://tricycle.org/feed/atom/")
+
+        val subs = config.snapshot()
+        assertEquals(2, subs.size)
+        val resolvedSub = subs.first { it.fictionId == fid }
+        val plainSub = subs.first { it.url == "https://plain.example.com/feed" }
+        assertEquals("https://tricycle.org/feed/atom/", resolvedSub.resolvedUrl)
+        assertNull(plainSub.resolvedUrl)
+    }
+
+    @Test fun `flow emits the persisted resolvedUrl`() = runTest {
+        config.addFeed("https://tricycle.org")
+        val fid = fictionIdForFeedUrl("https://tricycle.org")
+        config.setResolvedUrl(fid, "https://tricycle.org/feed/atom/")
+
+        val subs = config.subscriptions.first()
+        assertEquals("https://tricycle.org/feed/atom/", subs.single().resolvedUrl)
+    }
+}

--- a/source-rss/src/main/kotlin/in/jphe/storyvox/source/rss/RssSource.kt
+++ b/source-rss/src/main/kotlin/in/jphe/storyvox/source/rss/RssSource.kt
@@ -26,7 +26,6 @@ import `in`.jphe.storyvox.source.rss.parse.RssParser
 import `in`.jphe.storyvox.source.rss.parse.discoverFeedUrl
 import `in`.jphe.storyvox.source.rss.cache.TtlCache
 import `in`.jphe.storyvox.source.rss.templates.CraigslistTemplates
-import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -79,15 +78,6 @@ internal class RssSource @Inject constructor(
      *  read through it (see [fetchAndParse]); the caching decision lives in
      *  the pure, plain-JUnit-tested [TtlCache]. */
     private val feedCache = TtlCache<RssFeed>(FEED_CACHE_TTL_MS, System::currentTimeMillis)
-
-    /** #1489 — subscription URL → autodiscovered feed URL. When a user pastes
-     *  a bare homepage, the first fetch parses the HTML for its `<link
-     *  rel=alternate>` feed; we remember it here so an expired-cache re-fetch
-     *  goes straight to the real feed instead of re-scanning the HTML. Kept in
-     *  memory only — persisting it would mean rewriting the subscription URL,
-     *  which changes the URL-hash-derived fictionId and orphans the Room rows
-     *  (see PR notes; a model-level fix is a follow-up). */
-    private val resolvedFeedUrls = ConcurrentHashMap<String, String>()
 
     /** Issue #472 — RSS / Atom feed URLs. Matched by path/extension
      *  heuristics: `.rss`, `.atom`, `.xml`, or paths containing
@@ -266,7 +256,7 @@ internal class RssSource @Inject constructor(
         val sub = config.snapshot().firstOrNull { it.fictionId == fictionId }
             ?: return FictionResult.NotFound("Feed not subscribed: $fictionId")
 
-        val feed = when (val r = fetchAndParse(sub.url)) {
+        val feed = when (val r = fetchAndParse(sub)) {
             is FictionResult.Success -> r.value
             // #1489 — propagate RateLimited / Cloudflare / NetworkError so the
             // UI can surface the real reason instead of a generic failure.
@@ -310,7 +300,7 @@ internal class RssSource @Inject constructor(
         val sub = config.snapshot().firstOrNull { it.fictionId == fictionId }
             ?: return FictionResult.NotFound("Feed not subscribed: $fictionId")
 
-        val feed = when (val r = fetchAndParse(sub.url)) {
+        val feed = when (val r = fetchAndParse(sub)) {
             is FictionResult.Success -> r.value
             // #1489 — propagate RateLimited / Cloudflare / NetworkError so the
             // UI can surface the real reason instead of a generic failure.
@@ -381,14 +371,21 @@ internal class RssSource @Inject constructor(
      * outage). Propagating the fetcher's [FictionResult.Failure] lets the UI
      * surface rate-limiting / Cloudflare honestly.
      */
-    private suspend fun fetchAndParse(url: String): FictionResult<RssFeed> {
+    private suspend fun fetchAndParse(sub: RssSubscription): FictionResult<RssFeed> {
         // Serve a recently-parsed feed from memory so a chapter tap after the
         // detail list has loaded is instant (no re-download, no re-parse).
-        feedCache.get(url)?.let { return FictionResult.Success(it) }
-        // If we've already autodiscovered the real feed for this subscription,
-        // fetch it directly — skip the HTML round-trip and the re-scan.
-        val target = resolvedFeedUrls[url] ?: url
-        return fetchResolveParse(fetchUrl = target, cacheKey = url, allowDiscovery = target == url)
+        feedCache.get(sub.url)?.let { return FictionResult.Success(it) }
+        // #1498 — if autodiscovery already resolved the real feed for this
+        // subscription (persisted in RssConfig, distinct from the identity
+        // URL), fetch it directly and skip the HTML round-trip + re-scan. Only
+        // attempt discovery when we haven't resolved one yet.
+        val target = sub.resolvedUrl ?: sub.url
+        return fetchResolveParse(
+            fetchUrl = target,
+            cacheKey = sub.url,
+            fictionId = sub.fictionId,
+            allowDiscovery = sub.resolvedUrl == null,
+        )
     }
 
     /**
@@ -397,10 +394,17 @@ internal class RssSource @Inject constructor(
      * treated as an HTML page and run through RSS/Atom autodiscovery —
      * following exactly ONE hop to the advertised feed (the recursion passes
      * `allowDiscovery = false`, so a non-feed discovered URL can't loop).
+     *
+     * #1498 — a discovered feed URL is persisted via [RssConfig.setResolvedUrl]
+     * (keyed by [fictionId]) so a later cold-start fetch goes straight to the
+     * real feed. The identity-bearing subscription URL is never rewritten, so
+     * the URL-hash-derived fictionId — and every Room row keyed to it — stays
+     * put.
      */
     private suspend fun fetchResolveParse(
         fetchUrl: String,
         cacheKey: String,
+        fictionId: String,
         allowDiscovery: Boolean,
     ): FictionResult<RssFeed> {
         return when (val result = fetcher.fetch(fetchUrl)) {
@@ -416,8 +420,10 @@ internal class RssSource @Inject constructor(
                     // homepage; the HTML may advertise its feed. Try once.
                     val discovered = if (allowDiscovery) discoverFeedUrl(body.xml, fetchUrl) else null
                     if (discovered != null && discovered != fetchUrl) {
-                        resolvedFeedUrls[cacheKey] = discovered
-                        fetchResolveParse(discovered, cacheKey, allowDiscovery = false)
+                        // #1498 — persist across launches, keyed by the stable
+                        // fictionId (not the URL) so identity is preserved.
+                        config.setResolvedUrl(fictionId, discovered)
+                        fetchResolveParse(discovered, cacheKey, fictionId, allowDiscovery = false)
                     } else {
                         FictionResult.NetworkError("Couldn't parse feed at $fetchUrl", e)
                     }

--- a/source-rss/src/main/kotlin/in/jphe/storyvox/source/rss/config/RssConfig.kt
+++ b/source-rss/src/main/kotlin/in/jphe/storyvox/source/rss/config/RssConfig.kt
@@ -26,16 +26,37 @@ interface RssConfig {
 
     /** Remove a feed by its derived [RssSubscription.fictionId]. */
     suspend fun removeFeed(fictionId: String)
+
+    /**
+     * Issue #1498 — persist the feed URL autodiscovery resolved for a
+     * subscription (e.g. the user pasted a bare homepage and the source
+     * followed its `<link rel="alternate">` hint to the real feed). Stored
+     * separately from the identity-bearing [RssSubscription.url] so the
+     * URL-hash-derived [fictionId] never changes — rewriting `url` would
+     * orphan every Room row keyed to the old id. Fetches then use
+     * [RssSubscription.resolvedUrl] `?: url`. No-op if [fictionId] isn't
+     * subscribed.
+     *
+     * Default is a no-op so hand-rolled test fakes need no change; the
+     * production [RssConfigImpl] overrides it.
+     */
+    suspend fun setResolvedUrl(fictionId: String, resolvedUrl: String) {}
 }
 
 /**
  * One persisted feed subscription. [fictionId] is what storyvox uses
- * everywhere — it's a stable hash of the URL, so the same feed has
- * the same id across re-launches.
+ * everywhere — it's a stable hash of [url], so the same feed has the same
+ * id across re-launches.
+ *
+ * [resolvedUrl] (issue #1498) is the feed URL autodiscovery resolved from
+ * [url] when they differ (bare-homepage paste → advertised feed). Null
+ * until discovery runs; when set, fetches use it while [fictionId] stays
+ * derived from the original [url] so no Room rows are orphaned.
  */
 data class RssSubscription(
     val fictionId: String,
     val url: String,
+    val resolvedUrl: String? = null,
 )
 
 /**


### PR DESCRIPTION
## Summary
Follow-up to #1489 / #1490. Feed autodiscovery — paste a bare homepage (`tricycle.org`) and the source follows its `<link rel="alternate" type="application/rss+xml">` hint one hop to the real feed — kept the resolved URL **in memory only**.

It couldn't be persisted because the RSS `fictionId` is a hash of the subscription URL (`fictionIdForFeedUrl`). Rewriting the stored URL to the discovered feed URL would **change the fictionId and orphan every Room row** keyed to the old id (chapters, library membership, played/downloaded state, bookmarks). So every cold start re-scanned the homepage HTML.

This persists the discovered URL as a field **distinct from identity**.

## Changes
- **`RssSubscription.resolvedUrl: String?`** (null until discovery). `fictionId` stays derived from the original `url`; fetches use `resolvedUrl ?: url`.
- **`RssConfig.setResolvedUrl(fictionId, resolvedUrl)`** — persists it. Added with a **default no-op** so the hand-rolled test fakes need no change (per the interface-fakes rule); `RssConfigImpl` overrides it.
- **`RssConfigImpl`** stores it in the existing `storyvox_rss` DataStore as `url<space>resolvedUrl` within each pipe-delimited record. Space is a URL-safe field delimiter (a valid URL never carries a literal space — the same assumption the existing `|` record delimiter already relies on). **Legacy pipe-only-URL data decodes with `resolvedUrl = null`**, so existing installs just re-discover once (the migration the issue calls for).
- **`RssSource`** drops the in-memory `resolvedFeedUrls` map; `fetchAndParse(sub)` reads `sub.resolvedUrl` and persists a newly-discovered URL via the config. Autodiscovery now survives relaunch with **no network re-scan on cold start**.

## No schema change
DataStore-only (`storyvox_rss` prefs). No Room migration.

## Tests
`RssConfigImplTest` (new) — resolvedUrl round-trip + persistence across a fresh instance (relaunch), **identity/fictionId invariance**, legacy decode, `removeFeed` cleanup, sibling plain subscription, and no-op guards (unknown id / resolved == identity).

## Note for reviewers
Shares `source-rss/.../RssSource.kt` with the sibling PR for #1497 (persist chapter bodies). The two edits touch different regions of `fictionDetail`; whichever merges second may need a trivial rebase. Branched independently off `origin/main` per the wave plan.

Closes #1498

🤖 Generated with [Claude Code](https://claude.com/claude-code)