### PR TITLE
feat(google-news): base-url seam + contract-kit coverage (#1491)

### DIFF
--- a/source-google-news/build.gradle.kts
+++ b/source-google-news/build.gradle.kts
@@ -56,4 +56,9 @@ dependencies {
     // XmlPullParser path.
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
+    // #1491 — MockWebServer for the direct network-path test, plus the shared
+    // FictionSource contract kit so the source rides FictionSourceContractTest.
+    // Mirrors source-standard-ebooks (both deps, explicit alias not transitive).
+    testImplementation(libs.okhttp.mockwebserver)
+    testImplementation(project(":core-source-testkit"))
 }

--- a/source-google-news/src/main/kotlin/in/jphe/storyvox/source/googlenews/net/GoogleNewsApi.kt
+++ b/source-google-news/src/main/kotlin/in/jphe/storyvox/source/googlenews/net/GoogleNewsApi.kt
@@ -12,7 +12,17 @@ import java.io.IOException
  * URL and returns its raw XML body. Parsing is [GoogleNewsParser]'s job;
  * routing/feed-URL construction is [GoogleNewsSections]'.
  */
-internal class GoogleNewsApi(private val client: OkHttpClient) {
+internal open class GoogleNewsApi(private val client: OkHttpClient) {
+
+    /**
+     * #1491 — base origin for feed fetches. `open` so JVM unit tests can point
+     * the network path at a MockWebServer without restructuring
+     * [GoogleNewsSections]' URL construction (mirrors `StandardEbooksApi.baseUrl`
+     * / `PlosApi.base`). Production keeps Google News; [rebaseFeedUrl] swaps only
+     * the origin so the feed URL's path + query (section / topic / search
+     * routing) is preserved verbatim.
+     */
+    internal open val baseUrl: String get() = DEFAULT_BASE
 
     /**
      * Fetch a feed [url] and return the raw XML on success.
@@ -21,26 +31,71 @@ internal class GoogleNewsApi(private val client: OkHttpClient) {
      * site would otherwise throw `NetworkOnMainThreadException`, which is
      * runtime-only and never caught by a JVM unit test. IO failures come
      * back as [FictionResult.NetworkError] with the cause attached.
+     *
+     * #1491 — status mapping now matches the other HTTP sources (and the
+     * `FictionSourceContractTest` contract): 401/403 -> [FictionResult.AuthRequired]
+     * (unless the body is a Cloudflare challenge, which stays
+     * [FictionResult.Cloudflare]), 429 -> [FictionResult.RateLimited], other
+     * non-2xx -> [FictionResult.NetworkError]. Previously every non-success
+     * collapsed to NetworkError, so an auth gate or a rate-limit was
+     * indistinguishable from a transient network blip.
      */
     suspend fun fetchFeed(url: String): FictionResult<String> = withContext(Dispatchers.IO) {
+        val target = rebaseFeedUrl(url)
         try {
-            client.newCall(Request.Builder().url(url).build()).execute().use { resp ->
-                if (!resp.isSuccessful) {
-                    return@withContext FictionResult.NetworkError("Google News HTTP ${resp.code}")
-                }
-                val body = resp.body?.string()
-                    ?: return@withContext FictionResult.NetworkError("Empty Google News response")
-                if (looksLikeCfChallenge(body)) {
-                    return@withContext FictionResult.Cloudflare(
-                        challengeUrl = url,
-                        message = "Google News returned a Cloudflare challenge",
+            client.newCall(Request.Builder().url(target).build()).execute().use { resp ->
+                when {
+                    // A Cloudflare 403 is not a login gate — peek the body so it
+                    // surfaces as Cloudflare, not AuthRequired (a sign-in prompt
+                    // can't clear a CF challenge).
+                    resp.code == 401 || resp.code == 403 -> {
+                        val body = resp.body?.string().orEmpty()
+                        if (looksLikeCfChallenge(body)) {
+                            FictionResult.Cloudflare(
+                                challengeUrl = target,
+                                message = "Google News returned a Cloudflare challenge",
+                            )
+                        } else {
+                            FictionResult.AuthRequired("Google News HTTP ${resp.code}")
+                        }
+                    }
+                    resp.code == 429 -> FictionResult.RateLimited(
+                        retryAfter = null,
+                        message = "Google News rate limited (HTTP 429)",
                     )
+                    !resp.isSuccessful ->
+                        FictionResult.NetworkError("Google News HTTP ${resp.code}")
+                    else -> {
+                        val body = resp.body?.string()
+                            ?: return@withContext FictionResult.NetworkError("Empty Google News response")
+                        if (looksLikeCfChallenge(body)) {
+                            return@withContext FictionResult.Cloudflare(
+                                challengeUrl = target,
+                                message = "Google News returned a Cloudflare challenge",
+                            )
+                        }
+                        FictionResult.Success(body)
+                    }
                 }
-                FictionResult.Success(body)
             }
         } catch (e: IOException) {
             FictionResult.NetworkError("Google News fetch failed", e)
         }
+    }
+
+    /**
+     * #1491 — swap the production origin for [baseUrl], keeping the path + query
+     * intact. In production [baseUrl] is [DEFAULT_BASE], so this is the identity;
+     * a test overriding [baseUrl] redirects the same feed path at its
+     * MockWebServer. Any URL that doesn't start with [DEFAULT_BASE] is passed
+     * through unchanged (defensive — all feed URLs come from [GoogleNewsSections],
+     * which always builds off Google News).
+     */
+    private fun rebaseFeedUrl(url: String): String {
+        val base = baseUrl.trimEnd('/')
+        if (base == DEFAULT_BASE) return url
+        val path = url.removePrefix(DEFAULT_BASE)
+        return if (path === url) url else base + path
     }
 
     /**
@@ -61,5 +116,10 @@ internal class GoogleNewsApi(private val client: OkHttpClient) {
             body.substringAfter("<title>").substringBefore("</title>")
                 .contains("Just a moment", ignoreCase = true)
         return hasChallengeTitle && body.length < 20_000
+    }
+
+    companion object {
+        /** Production origin all [GoogleNewsSections] feed URLs are built from. */
+        const val DEFAULT_BASE: String = "https://news.google.com"
     }
 }

--- a/source-google-news/src/test/kotlin/in/jphe/storyvox/source/googlenews/GoogleNewsApiMappingTest.kt
+++ b/source-google-news/src/test/kotlin/in/jphe/storyvox/source/googlenews/GoogleNewsApiMappingTest.kt
@@ -1,0 +1,75 @@
+package `in`.jphe.storyvox.source.googlenews
+
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import `in`.jphe.storyvox.source.googlenews.article.ArticleResolver
+import `in`.jphe.storyvox.source.googlenews.net.GoogleNewsApi
+import `in`.jphe.storyvox.source.googlenews.parse.GoogleNewsItem
+import kotlinx.coroutines.runBlocking
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * #1491 — direct MockWebServer coverage of the new [GoogleNewsApi] base-url seam
+ * and status mapping over the real network path (`fictionDetail`). The contract
+ * kit ([GoogleNewsContractTest]) covers 401 / 403-CF / 429 / IO-pin; this pins
+ * the branch the kit doesn't exercise — a plain (non-Cloudflare) 403 -> AuthRequired
+ * — plus the happy parse and that the seam preserves the `/rss` feed path.
+ */
+class GoogleNewsApiMappingTest {
+
+    private lateinit var server: MockWebServer
+
+    @Before fun setUp() { server = MockWebServer(); server.start() }
+    @After fun tearDown() { server.shutdown() }
+
+    private fun source(): GoogleNewsSource {
+        val host = server.url("/").toString().trimEnd('/')
+        val api = object : GoogleNewsApi(OkHttpClient()) {
+            override val baseUrl: String get() = host
+        }
+        return GoogleNewsSource(api, NoOpResolver)
+    }
+
+    @Test
+    fun `plain 403 without a cloudflare body maps to AuthRequired`() {
+        server.enqueue(MockResponse().setResponseCode(403).setBody("<html><body>Forbidden</body></html>"))
+        val r = runBlocking { source().fictionDetail(GoogleNewsSections.TOP_ID) }
+        assertTrue("expected AuthRequired, got $r", r is FictionResult.AuthRequired)
+    }
+
+    @Test
+    fun `429 maps to RateLimited`() {
+        server.enqueue(MockResponse().setResponseCode(429))
+        val r = runBlocking { source().fictionDetail(GoogleNewsSections.TOP_ID) }
+        assertTrue("expected RateLimited, got $r", r is FictionResult.RateLimited)
+    }
+
+    @Test
+    fun `happy feed parses over the base-url seam and keeps the rss path`() {
+        server.enqueue(MockResponse().setResponseCode(200).setBody(FEED_BODY))
+        val r = runBlocking { source().fictionDetail(GoogleNewsSections.TOP_ID) }
+        assertTrue("expected Success, got $r", r is FictionResult.Success)
+        assertEquals(1, (r as FictionResult.Success).value.chapters.size)
+        // The seam swapped only the origin — the /rss feed path must survive so
+        // section/topic/search routing is unchanged in production.
+        assertTrue(server.takeRequest().path!!.startsWith("/rss"))
+    }
+
+    private object NoOpResolver : ArticleResolver {
+        override suspend fun resolve(item: GoogleNewsItem): String? = null
+    }
+
+    companion object {
+        const val FEED_BODY: String =
+            """<?xml version="1.0" encoding="UTF-8"?><rss version="2.0"><channel>""" +
+                """<title>Top stories</title><item><title>Headline</title>""" +
+                """<link>https://news.google.com/articles/CBMiX</link><guid>g1</guid></item>""" +
+                """</channel></rss>"""
+    }
+}

--- a/source-google-news/src/test/kotlin/in/jphe/storyvox/source/googlenews/GoogleNewsContractTest.kt
+++ b/source-google-news/src/test/kotlin/in/jphe/storyvox/source/googlenews/GoogleNewsContractTest.kt
@@ -1,0 +1,64 @@
+package `in`.jphe.storyvox.source.googlenews
+
+import `in`.jphe.storyvox.data.source.FictionSource
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import `in`.jphe.storyvox.data.source.model.FictionSummary
+import `in`.jphe.storyvox.data.source.model.ListPage
+import `in`.jphe.storyvox.source.googlenews.article.ArticleResolver
+import `in`.jphe.storyvox.source.googlenews.net.GoogleNewsApi
+import `in`.jphe.storyvox.source.googlenews.parse.GoogleNewsItem
+import `in`.jphe.storyvox.testkit.source.FictionSourceContractTest
+import okhttp3.OkHttpClient
+
+/**
+ * #1491 — GoogleNews on the shared [FictionSourceContractTest].
+ *
+ * Google News's HTTP lives on the **detail/chapter** path: `popular()` returns a
+ * static catalog (Browse cards) and `search()` a synthetic search fiction, so the
+ * kit's list probe (which exercises `popular()`/`search()`) never touched the
+ * network. Rather than change that deliberate design — or edit the kit — the probe
+ * is bridged to the real network path with a thin **test-only adapter**:
+ * `popular()` delegates to `fictionDetail(TOP_ID)`, which fetches + parses the
+ * live feed. The new [GoogleNewsApi.baseUrl] seam points that fetch at the kit's
+ * MockWebServer.
+ *
+ * The result: the Google News network path now gets the kit's IO-pin (#585),
+ * 401 -> AuthRequired, 403-CF -> Cloudflare, and 429 -> RateLimited coverage that
+ * the other HTTP sources have — with zero production-code behaviour change.
+ */
+class GoogleNewsContractTest : FictionSourceContractTest() {
+
+    override fun createSource(client: OkHttpClient, baseUrl: String): FictionSource {
+        val host = baseUrl.trimEnd('/')
+        val api = object : GoogleNewsApi(client) {
+            override val baseUrl: String get() = host
+        }
+        val real = GoogleNewsSource(api, NoOpArticleResolver)
+        // Route the kit's list-exercise through the real HTTP path (fictionDetail).
+        // Everything else delegates to the real source unchanged.
+        return object : FictionSource by real {
+            override suspend fun popular(page: Int): FictionResult<ListPage<FictionSummary>> =
+                when (val d = real.fictionDetail(GoogleNewsSections.TOP_ID)) {
+                    is FictionResult.Success ->
+                        FictionResult.Success(ListPage(listOf(d.value.summary), page = 1, hasNext = false))
+                    is FictionResult.Failure -> d
+                }
+        }
+    }
+
+    /** A minimal but real Google News RSS 2.0 body with one story — `fetchAndParse`
+     *  treats an empty feed as NetworkError, so the happy path needs an item. */
+    override fun happyListBody(): String =
+        """<?xml version="1.0" encoding="UTF-8"?>""" +
+            """<rss version="2.0"><channel><title>Top stories - Google News</title>""" +
+            """<item><title>Sample headline</title>""" +
+            """<link>https://news.google.com/articles/CBMiSample</link>""" +
+            """<guid>guid-abc-123</guid></item></channel></rss>"""
+
+    /** Every Google News feed path (top / topic / search) lives under `/rss`. */
+    override fun listPathFragment(): String = "/rss"
+
+    private object NoOpArticleResolver : ArticleResolver {
+        override suspend fun resolve(item: GoogleNewsItem): String? = null
+    }
+}


### PR DESCRIPTION
## Problem
`GoogleNewsApi` had **no injectable base-url seam** (feed URLs are built from a `private const` in `GoogleNewsSections`) and mapped **every** non-2xx to `NetworkError` — so a 401 auth gate or a 429 rate-limit was indistinguishable from a transient network blip, and the source couldn't ride `FictionSourceContractTest` (surfaced in the plugin-dx epic #1488; standard-ebooks was retrofitted instead).

## Change
- **Base-url seam** — `GoogleNewsApi.baseUrl` (`open val`, mirrors `StandardEbooksApi.baseUrl` / `PlosApi.base`). `rebaseFeedUrl()` swaps only the **origin**, preserving the feed **path + query** so section/topic/search routing is unchanged; it's the identity in production.
- **Status mapping parity** — `fetchFeed` now maps 401/403 → `AuthRequired` (unless the body is a Cloudflare challenge → `Cloudflare`), 429 → `RateLimited`, other non-2xx → `NetworkError`.
- **Rides the contract kit** — Google News's HTTP lives on the **detail/chapter** path (`popular()`/`search()` are static by design). Rather than change that design *or edit the kit* (consume-only), a thin **test-only adapter** in `createSource` routes the kit's list probe through `fictionDetail(TOP_ID)` over the new seam. Net: the network path gets the kit's IO-pin (#585) / 401 / 403-CF / 429 coverage with **zero production behaviour change**.
- **Direct tests** for the plain-403 → `AuthRequired` branch the kit doesn't exercise, plus the happy parse and `/rss` path preservation.

## Notes
- `core-source-testkit` is **consumed, not edited** (subclassed only).
- Independent of the other quick-fix PRs; touches only `source-google-news`.

Closes #1491

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Google News feed handling so more server responses are correctly recognized, including authentication prompts, rate limits, and other network errors.
  * Preserved feed paths when requests are redirected to different base URLs, helping stories load reliably in test and mirrored environments.

* **New Features**
  * Added broader Google News source coverage for feed fetching, improving confidence in real-world request handling and parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->