### PR TITLE
fix(testkit): fail on mis-routed listPathFragment + di-module docs (#1523, #1522)

### DIFF
--- a/core-source-testkit/src/main/kotlin/in/jphe/storyvox/testkit/source/FictionSourceContractTest.kt
+++ b/core-source-testkit/src/main/kotlin/in/jphe/storyvox/testkit/source/FictionSourceContractTest.kt
@@ -30,6 +30,9 @@ import java.util.Collections
  *  - Cloudflare challenge bodies are detected and surface as
  *    [FictionResult.Cloudflare] or [FictionResult.NetworkError] — never as
  *    content, and never as AuthRequired (a CF 403 is not a login gate)
+ *  - [listPathFragment] actually matches a requested path (#1523) — a wrong
+ *    fragment routes the happy body nowhere and every request 404s, yet the
+ *    IO-pin check above still passes on those 404s (a silent false-green)
  *  - paging & blank-query sanity
  *
  * Search-only sources set [exercisesPopular] = false; the checks then run
@@ -43,6 +46,13 @@ abstract class FictionSourceContractTest {
     // Appended from MockWebServer's dispatcher threads while the JUnit thread
     // reads it — must be synchronized or a concurrent-request source races.
     private val requestThreads: MutableList<String> =
+        Collections.synchronizedList(mutableListOf())
+    // #1523 — every request path the exercised call issued, so the happy-path
+    // check can prove listPathFragment() actually matched a requested path. A
+    // wrong fragment routes the happy body NOWHERE (every request falls through
+    // to the 404 arm), yet the IO-pin check still passes on those 404s — a
+    // silent false-green. Same synchronized-append discipline as requestThreads.
+    private val requestPaths: MutableList<String> =
         Collections.synchronizedList(mutableListOf())
 
     /** Build YOUR source pointed at [baseUrl] with [client]. */
@@ -60,11 +70,13 @@ abstract class FictionSourceContractTest {
 
     @Before fun startServer() {
         requestThreads.clear()
+        requestPaths.clear()
         ClientThreadProbe.clientThreads.clear()
         server = MockWebServer()
         server.dispatcher = object : Dispatcher() {
             override fun dispatch(request: RecordedRequest): MockResponse {
                 requestThreads += Thread.currentThread().name
+                requestPaths += request.path.orEmpty()
                 return route(request)
             }
         }
@@ -120,6 +132,25 @@ abstract class FictionSourceContractTest {
         )
     }
 
+    @Test fun `listPathFragment matches a requested path (happy body is served)`() {
+        runBlocking { exerciseList(source()) }
+        val fragment = listPathFragment()
+        val paths = synchronized(requestPaths) { requestPaths.toList() }
+        // A wrong listPathFragment() sends every request to the default router's
+        // 404 arm, so the happy body is served NOWHERE — but the #585 IO-pin
+        // check above still passes (a request DID execute off the caller thread,
+        // it just 404'd). That silently false-greens a mis-routed fragment (it
+        // bit the first non-id-in-path source, #1523). Asserting the fragment
+        // matched a real requested path makes the mistake fail loudly instead.
+        assertTrue(
+            "listPathFragment(\"$fragment\") matched none of the requested paths " +
+                "$paths — the happy list body was served nowhere (every request fell " +
+                "through to the 404 arm). Point listPathFragment() at a substring your " +
+                "popular()/search() endpoint actually requests (#1523).",
+            paths.any { it.contains(fragment) },
+        )
+    }
+
     @Test fun `401 maps to AuthRequired, not an exception`() {
         server.dispatcher = constant(MockResponse().setResponseCode(401))
         val result = runBlocking { exerciseList(source()) }
@@ -158,6 +189,7 @@ abstract class FictionSourceContractTest {
     private fun constant(r: MockResponse) = object : Dispatcher() {
         override fun dispatch(request: RecordedRequest): MockResponse {
             requestThreads += Thread.currentThread().name
+            requestPaths += request.path.orEmpty()
             return r
         }
     }

--- a/docs/CONTRIBUTING-SOURCES.md
+++ b/docs/CONTRIBUTING-SOURCES.md
@@ -35,8 +35,12 @@ source-<id>/
   build.gradle.kts                       # android-library + hilt + ksp + the test kit
   src/main/.../<Name>Source.kt           # @SourcePlugin, FictionSource stubbed with NotFound
   src/main/.../net/<Name>Api.kt          # IO-pinned request() wrapper, status mapping pre-written
+  src/main/.../di/<Name>Module.kt        # provides this source's qualified OkHttpClient + Api (keep it — see §5)
   src/test/.../<Name>ContractTest.kt     # subclass of the shared contract kit
 ```
+
+(`--local` sources have no `net/` or `di/` — they get a `<Name>Reader` seam and
+a plain `<Name>SourceTest` instead; see **Local-provider sources** below.)
 
 Everything compiles immediately; the contract test **fails honestly** because
 the stub doesn't talk to the network yet. That red test is your to-do list.
@@ -129,7 +133,11 @@ Open `<Name>ContractTest.kt` and set the two fixture hooks:
 - **`happyListBody()`** — a trimmed, real response body from your list endpoint
   (2–3 items is plenty).
 - **`listPathFragment()`** — a substring of the path your `popular()` hits, so
-  the kit routes the happy body to it.
+  the kit routes the happy body to it. The scaffold defaults this to a loud
+  `REPLACE_WITH_YOUR_LIST_PATH` sentinel: the kit asserts the fragment matched a
+  real requested path, so a forgotten edit (or a fragment that isn't actually in
+  your API's path — e.g. the source id, which rarely is) **fails loudly** instead
+  of silently 404-ing the happy body while the IO-pin check still greens (#1523).
 
 Then run it:
 
@@ -164,8 +172,20 @@ implementation(project(":source-<id>"))
 That's it. `@SourcePlugin(id = …)` makes KSP emit **both** Hilt bindings — the
 registry descriptor (Browse chip, Settings auto-section) and the
 `Map<String, FictionSource>` routing entry. You do **not** add a `SourceIds`
-constant (that table is frozen — the annotation `id` is the source of truth) and
-you do **not** hand-write a DI module.
+constant (that table is frozen — the annotation `id` is the source of truth).
+
+Two things sit next to each other here, so keep them straight (#1522):
+
+- **KSP emits the `FictionSource` multibindings** — the descriptor `@IntoSet` and
+  the `Map<String, FictionSource>` `@IntoMap`. You never hand-write *those*.
+- **The scaffold generates `di/<Name>Module.kt`** — the `@Qualifier` + `@Provides`
+  that supply your source's dedicated `OkHttpClient` (with the shared UA
+  interceptor) and its `Api`. There is no global unqualified `OkHttpClient`, so
+  this module is **required**. You don't write it by hand, but do **not** delete
+  it thinking it's redundant: without it the `:app` Hilt graph can't provide
+  `<Name>Api` and the build fails at `:app:hiltJavaCompileRelease` (CI-only —
+  it compiles fine per-module). `--local` sources have no such module: their
+  `<Name>Reader` is a plain `@Inject` class Hilt constructs directly.
 
 ## Local-provider sources (non-HTTP)
 

--- a/scripts/new-source.sh
+++ b/scripts/new-source.sh
@@ -946,8 +946,11 @@ class __PASCAL__ContractTest : FictionSourceContractTest() {
     /** Replace with a trimmed real response body from your list endpoint. */
     override fun happyListBody(): String = "{}"
 
-    /** Replace with a path fragment your popular()/list endpoint hits. */
-    override fun listPathFragment(): String = "__ID__"
+    /** The path fragment your popular()/list endpoint hits. A loud sentinel on
+     *  purpose: the contract test FAILS until you point this at a substring your
+     *  source actually requests — the default id rarely appears in a real API
+     *  path, which used to silently false-green the happy path (#1523). */
+    override fun listPathFragment(): String = "REPLACE_WITH_YOUR_LIST_PATH"
 }
 CTEST
 elif [[ "$MODE" == "xml" ]]; then
@@ -985,8 +988,11 @@ class __PASCAL__ContractTest : FictionSourceContractTest() {
             "<entry><id>1</id><title>Example entry</title></entry>" +
             "</feed>"
 
-    /** Replace with a path fragment your popular()/list endpoint hits. */
-    override fun listPathFragment(): String = "__ID__"
+    /** The path fragment your popular()/list endpoint hits. A loud sentinel on
+     *  purpose: the contract test FAILS until you point this at a substring your
+     *  source actually requests — the default id rarely appears in a real API
+     *  path, which used to silently false-green the happy path (#1523). */
+    override fun listPathFragment(): String = "REPLACE_WITH_YOUR_LIST_PATH"
 }
 CTEST
 elif [[ "$MODE" == "json" ]]; then
@@ -1019,8 +1025,11 @@ class __PASCAL__ContractTest : FictionSourceContractTest() {
     /** Replace with a trimmed real response body from your list endpoint. */
     override fun happyListBody(): String = "{}"
 
-    /** Replace with a path fragment your popular()/list endpoint hits. */
-    override fun listPathFragment(): String = "__ID__"
+    /** The path fragment your popular()/list endpoint hits. A loud sentinel on
+     *  purpose: the contract test FAILS until you point this at a substring your
+     *  source actually requests — the default id rarely appears in a real API
+     *  path, which used to silently false-green the happy path (#1523). */
+    override fun listPathFragment(): String = "REPLACE_WITH_YOUR_LIST_PATH"
 }
 CTEST
 fi


### PR DESCRIPTION
## Kit truthfulness + di-module docs — closes #1523, #1522

**Stacked on #1548** (base = `feat/source-scaffold-modes`). PR 2/3 of the
scaffold/kit/docs series. Review/merge #1548 first.

### #1523 — the kit now fails on a mis-routed `listPathFragment()`
The happy-path check only asserted the #585 IO-pin (*some* request went
off-thread). A wrong `listPathFragment()` routes the happy body **nowhere** —
every request 404s — but a 404 still exercises the network off-thread, so the
check passed and the happy body being served nowhere silently false-greened. It
bit the first non-id-in-path source (Epic's list path is `/freeGamesPromotions`;
the id `epic-free-games` appears nowhere in it).

- **Kit**: record every requested path; assert `listPathFragment()` matched at
  least one. Override-agnostic (works through reddit's custom `route()`) and safe
  for the empty-body fixtures (`gutenberg`, `standard-ebooks`) — chosen over
  asserting `Success`, which those would fail.
- **Scaffold**: default `listPathFragment()` to a loud
  `REPLACE_WITH_YOUR_LIST_PATH` sentinel instead of the id.

> **Audited all 9 existing `FictionSourceContractTest` subclasses** — every
> fragment matches its `popular()` path (ao3 `feed.atom`, epic
> `freeGamesPromotions`, drive `files`, hn `topstories`, notion `search`,
> gutenberg `books`, primegaming `lootscraper`, standard-ebooks `ebooks`, reddit
> `subreddits`). So this only guards against **future** false-greens; no sibling
> goes red.

### #1522 — the generated `di/` module is required, not hand-written
§1's tree omitted the generated `di/<Name>Module.kt`; §5's flat "you do not
hand-write a DI module" conflated KSP's `FictionSource` multibindings (never
hand-written) with the scaffold's OkHttpClient/Api provider module (generated,
**required** — no global unqualified `OkHttpClient`). Deleting it fails at
`:app:hiltJavaCompileRelease` (CI-only). Fixed the §1 tree, split §5, and
documented the §4 sentinel. (The build.gradle scaffold comment was already
clarified in #1548.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
