### PR TITLE
ux(notion): distinct connected-but-empty Browse state on first fetch (#1511)

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.GridView
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.outlined.FilterAlt
 import androidx.compose.material3.AssistChip
@@ -513,6 +514,25 @@ fun BrowseScreen(
                 !state.isLoading &&
                 state.error == null ->
                 RssEmptyState(onAdd = { showRssManageSheet = true })
+            // Issue #1511 — Notion is CONNECTED but the first fetch after
+            // connecting comes back empty: the paginator keys on
+            // source/tab/filter (not the just-saved token), so page 1 was
+            // fetched before the config landed and only a manual refresh
+            // repopulates it. Rather than show the "Connect Notion" CTA
+            // (wrong — they already connected), surface a distinct
+            // "connected, no results yet — pull to refresh" state whose CTA
+            // runs the very refresh that fixes it. This branch precedes the
+            // #1507 connect CTA because it's the more specific case (the
+            // `!notionAnonymousActive` guard = a token IS configured). The
+            // isLoading skeleton branch above still covers the first-fetch
+            // loading affordance.
+            state.sourceId == SourceIds.NOTION_PAT &&
+                state.tab != BrowseTab.Search &&
+                state.items.isEmpty() &&
+                !state.isLoading &&
+                state.error == null &&
+                !state.notionAnonymousActive ->
+                NotionConnectedEmptyState(onRefresh = { viewModel.refresh() })
             // Issue #1507 — Notion chip is visible even when unconfigured
             // (see BrowseViewModel's NOTION_PAT visibility override). An
             // unconnected chip lands on an empty grid; surface a connect-me
@@ -1183,6 +1203,52 @@ private fun NotionConnectEmptyState(onConnect: () -> Unit) {
             BrassButton(
                 label = "Connect Notion",
                 onClick = onConnect,
+                variant = BrassButtonVariant.Primary,
+            )
+        }
+    }
+}
+
+/**
+ * Issue #1511 — Notion is connected but the first fetch returned before the
+ * just-saved token propagated, so the grid is empty until a refresh. Distinct
+ * from [NotionConnectEmptyState] (which is for the *unconnected* chip): this
+ * one acknowledges the connection and offers the one-tap refresh that lands the
+ * content — the same second-fetch users otherwise had to trigger by hand with
+ * pull-to-refresh.
+ */
+@Composable
+private fun NotionConnectedEmptyState(onRefresh: () -> Unit) {
+    val spacing = LocalSpacing.current
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(spacing.sm),
+            modifier = Modifier.padding(horizontal = spacing.xl),
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Refresh,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(48.dp),
+            )
+            Text(
+                "Notion connected",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                textAlign = TextAlign.Center,
+            )
+            Text(
+                "No pages yet — this can take a moment right after connecting. " +
+                    "Pull to refresh, or tap below, and the pages you granted will appear.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(Modifier.height(spacing.md))
+            BrassButton(
+                label = "Refresh",
+                onClick = onRefresh,
                 variant = BrassButtonVariant.Primary,
             )
         }


### PR DESCRIPTION
## Problem
After connecting Notion (token or OAuth), the Browse chip showed an **empty grid** on the first fetch and, worse, rendered the **"Connect Notion"** CTA — even though the user *just* connected. Only a manual pull-to-refresh populated it. Root cause: the paginator keys on `source/tab/filter`, not the just-saved token, so page 1 was fetched before the config propagated (the config-just-saved race, matching the #1489 RSS silent-empty class).

## Change
Split the Notion empty-state branch by connection state:
- **Connected but empty** (`!notionAnonymousActive`, i.e. a token is configured) → new **`NotionConnectedEmptyState`**: "Notion connected — no results yet, pull to refresh", with a **Refresh** CTA that runs `viewModel.refresh()` — the exact second-fetch users previously had to trigger by hand.
- **Not connected** → keeps the #1507 "Connect Notion" CTA.

The existing `isLoading && items.isEmpty()` skeleton branch already covers the first-fetch loading affordance, so this completes the (a) loading / (b) distinct empty-state asks from the issue.

## Deferred (tracked in #1556)
The deeper **auto-refresh-on-connect** race fix (issue point c) is intentionally deferred. Firing the refresh automatically is *not cheap without risk*: a naive `LaunchedEffect(sourceId, notionAnonymousActive)` re-fetches on every entry to a connected Notion chip (resets pagination/scroll) and can double-fetch against the paginator's initial load; doing it right needs transition detection (fire only on unconfigured→configured while visible) or a paginator keyed on the Notion config. Filed as **#1556** so it survives the wave. The one-tap **Refresh** CTA is the pragmatic remedy in the meantime.

## Notes
- **UI-only** — no source-layer change; **no Data-Safety docs touched** (privacy.md / checklist / walkthrough untouched), so no cross-PR serialization needed.

Closes #1511
