### PR TITLE
feat(settings): generic per-source config-field seam + Prime feed-URL UI (#1531, #1535)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
@@ -70,8 +70,14 @@ import `in`.jphe.storyvox.source.azure.AzureSpeechClient
 import `in`.jphe.storyvox.source.azure.AzureVoiceRoster
 import `in`.jphe.storyvox.feature.api.CacheQuotaOptions
 import `in`.jphe.storyvox.feature.api.HighlightMode
+import `in`.jphe.storyvox.data.source.plugin.SourceConfigContributor
+import `in`.jphe.storyvox.data.source.plugin.SourceConfigField
+import `in`.jphe.storyvox.data.source.plugin.SourceConfigValue
+import `in`.jphe.storyvox.feature.api.SourceConfigFieldType
 import `in`.jphe.storyvox.feature.api.UiSettings
 import `in`.jphe.storyvox.feature.api.UiSigil
+import `in`.jphe.storyvox.feature.api.UiSourceConfigField
+import `in`.jphe.storyvox.feature.api.UiSourceConfigSection
 import `in`.jphe.storyvox.ui.theme.ReaderTheme
 import `in`.jphe.storyvox.ui.theme.ReaderFontFamily
 import `in`.jphe.storyvox.ui.theme.ReaderTypography
@@ -1101,12 +1107,15 @@ class SettingsRepositoryUiImpl(
      *  at [cacheStats]) need no update; production's @Inject constructor
      *  below always supplies the real impl. */
     private val bookshareConfig: BookshareConfigImpl? = null,
-    /** Issue #1492 — Reddit installed-app config (client id + comment
-     *  epilogue toggle). Nullable + null-default so the primary-ctor test
-     *  harnesses (named args ending at [cacheStats]) need no update, exactly
-     *  like [bookshareConfig]; production's @Inject constructor supplies the
-     *  real impl. When null, Reddit settings project as unconfigured. */
-    private val redditConfig: RedditConfigImpl? = null,
+    /** Issue #1531 — source config-field contributors (Reddit client id +
+     *  comment epilogue, Notion database id + token, Prime Gaming feed-URL
+     *  override, plus any future credentialed source). Default empty so the
+     *  primary-ctor test harnesses (named args ending at [cacheStats]) need
+     *  no update, exactly like [bookshareConfig]; production's @Inject
+     *  constructor supplies the `@IntoSet` multibinding. Drives
+     *  [UiSettings.sourceConfigSections] and [setSourceConfigValue]. */
+    private val sourceConfigContributors: Set<@JvmSuppressWildcards SourceConfigContributor> =
+        emptySet(),
     /** Issue #977 — push-on-write seam. The action [scheduleSettingsPush]
      *  fires after the debounce so every synced preference change reaches
      *  InstantDB without a cold-start/manual sync (and can't be clobbered
@@ -1180,7 +1189,8 @@ class SettingsRepositoryUiImpl(
         pcmCacheConfig: PcmCacheConfig,
         cacheStats: CacheStatsRepository,
         bookshareConfig: BookshareConfigImpl,
-        redditConfig: RedditConfigImpl,
+        // Issue #1531 — the @IntoSet config-field contributors.
+        sourceConfigContributors: Set<@JvmSuppressWildcards SourceConfigContributor>,
         // Issue #977 — ⚠️ [dagger.Lazy] is load-bearing: the DI graph has
         // a cycle — SyncCoordinator → Set<Syncer> → SettingsSyncer →
         // SettingsSnapshotSource (this class) → SyncCoordinator. Lazy
@@ -1199,7 +1209,7 @@ class SettingsRepositoryUiImpl(
         googleTokenSource,
         pcmCache, pcmCacheConfig, cacheStats,
         bookshareConfig = bookshareConfig,
-        redditConfig = redditConfig,
+        sourceConfigContributors = sourceConfigContributors,
         pushSettings = { coordinator.get().requestPush(SETTINGS_PUSH_DOMAIN) },
     )
 
@@ -1276,11 +1286,27 @@ class SettingsRepositoryUiImpl(
         val discord: `in`.jphe.storyvox.source.discord.config.DiscordConfigState,
         val telegram: `in`.jphe.storyvox.source.telegram.config.TelegramConfigState,
         val cacheStats: CacheStatsRepository.CacheStats,
-        // Issue #1492 — Reddit config folded in as the outer combine's third
-        // arm (the inner 5-way combine is at the typed-arity limit; the outer
-        // had room, per the NonPrefsConfigs bundle rationale above).
-        val reddit: `in`.jphe.storyvox.source.reddit.config.RedditConfigState,
+        // Issue #1531 — generic per-source config sections, folded in as the
+        // outer combine's third arm (replacing the old bespoke Reddit arm;
+        // Reddit now rides this seam like every other credentialed source).
+        val sourceConfigSections: List<UiSourceConfigSection>,
     )
+
+    /** Issue #1531 — live per-source config sections built from the injected
+     *  [sourceConfigContributors]. Each contributor's declared fields + live
+     *  values map to one [UiSourceConfigSection]; sorted by display name so
+     *  the Settings order is stable across builds. Emits an empty list when
+     *  no source contributes fields (e.g. primary-ctor test harnesses).
+     *  Defined before [nonPrefsConfigs] so its member reference resolves. */
+    private val sourceConfigSectionsFlow: Flow<List<UiSourceConfigSection>> = run {
+        val perSource = sourceConfigContributors
+            .sortedBy { it.displayName.lowercase() }
+            .map { contributor ->
+                contributor.values.map { values -> contributor.toUiSection(values) }
+            }
+        if (perSource.isEmpty()) flowOf(emptyList())
+        else combine(perSource) { sections -> sections.toList() }
+    }
 
     private val nonPrefsConfigs: Flow<NonPrefsConfigs> =
         combine(
@@ -1294,9 +1320,8 @@ class SettingsRepositoryUiImpl(
                 arrayOf(palace, wiki, notion, discord, telegram)
             },
             cacheStats.observe(),
-            // Null redditConfig (primary-ctor test harnesses) → default state.
-            redditConfig?.state ?: flowOf(`in`.jphe.storyvox.source.reddit.config.RedditConfigState()),
-        ) { sourceStates, stats, reddit ->
+            sourceConfigSectionsFlow,
+        ) { sourceStates, stats, sections ->
             NonPrefsConfigs(
                 palace = sourceStates[0] as `in`.jphe.storyvox.source.mempalace.config.PalaceConfigState,
                 wikipedia = sourceStates[1] as `in`.jphe.storyvox.source.wikipedia.config.WikipediaConfigState,
@@ -1304,7 +1329,7 @@ class SettingsRepositoryUiImpl(
                 discord = sourceStates[3] as `in`.jphe.storyvox.source.discord.config.DiscordConfigState,
                 telegram = sourceStates[4] as `in`.jphe.storyvox.source.telegram.config.TelegramConfigState,
                 cacheStats = stats,
-                reddit = reddit,
+                sourceConfigSections = sections,
             )
         }
 
@@ -1320,7 +1345,6 @@ class SettingsRepositoryUiImpl(
         val notion = configs.notion
         val discord = configs.discord
         val telegram = configs.telegram
-        val reddit = configs.reddit
         UiSettings(
             ttsEngine = "VoxSherpa",
             defaultVoiceId = prefs[Keys.DEFAULT_VOICE_ID],
@@ -1384,9 +1408,9 @@ class SettingsRepositoryUiImpl(
             discordServerName = discord.serverName,
             discordCoalesceMinutes = discord.coalesceMinutes,
             telegramTokenConfigured = telegram.apiToken.isNotBlank(),
-            // Issue #1492 — Reddit installed-app config projection.
-            redditClientIdConfigured = reddit.clientId.isNotBlank(),
-            redditAppendTopComments = reddit.appendTopComments,
+            // Issue #1531 — generic per-source config sections (Reddit,
+            // Notion, Prime Gaming, …) built from the injected contributors.
+            sourceConfigSections = configs.sourceConfigSections,
             // Plugin-seam Phase 1 (#384) — derive the per-plugin map
             // from the JSON blob seeded by SourcePluginsMapMigration.
             // Empty map (parse error / missing key in a race) falls
@@ -2509,13 +2533,18 @@ class SettingsRepositoryUiImpl(
         notionConfig.setApiToken(token)
     }
 
-    // Issue #1492 — Reddit installed-app client id + comment-epilogue toggle.
-    // No-op when redditConfig is absent (primary-ctor test harnesses).
-    override suspend fun setRedditClientId(clientId: String?) {
-        redditConfig?.setClientId(clientId)
+    /** Issue #1531 — contributors keyed by source id, for [setSourceConfigValue]
+     *  routing. Empty in primary-ctor test harnesses (no contributors passed). */
+    private val contributorsById: Map<String, SourceConfigContributor> by lazy {
+        sourceConfigContributors.associateBy { it.sourceId }
     }
-    override suspend fun setRedditAppendTopComments(enabled: Boolean) {
-        redditConfig?.setAppendTopComments(enabled)
+
+    // Issue #1531 — generic per-source config write path. Routes to the
+    // owning source's contributor (which writes through its existing
+    // *ConfigImpl backing store). Unknown source/key = no-op. These configs
+    // live in their own DataStores, so no settings-sync stamp is needed.
+    override suspend fun setSourceConfigValue(sourceId: String, key: String, raw: String) {
+        contributorsById[sourceId]?.set(key, raw)
     }
 
     /**
@@ -3793,3 +3822,57 @@ private fun GitHubSession.toUi(): UiGitHubAuthState = when (this) {
     )
     is GitHubSession.Expired -> UiGitHubAuthState.Expired
 }
+
+/**
+ * Issue #1531 — project a [SourceConfigContributor]'s declared fields +
+ * current [values] into the UI-facing [UiSourceConfigSection]. Maps the
+ * `core-data` `SourceConfigField` sealed hierarchy onto the feature layer's
+ * flattened [SourceConfigFieldType] enum, so `:feature` stays free of the
+ * source-plugin types. A field missing from [values] renders with a
+ * type-appropriate empty default.
+ */
+private fun SourceConfigContributor.toUiSection(
+    values: Map<String, SourceConfigValue>,
+): UiSourceConfigSection = UiSourceConfigSection(
+    sourceId = sourceId,
+    displayName = displayName,
+    help = sectionHelp,
+    fields = fields().map { field ->
+        val value = values[field.key]
+        when (field) {
+            is SourceConfigField.PlainText -> UiSourceConfigField(
+                key = field.key,
+                type = SourceConfigFieldType.PLAIN,
+                label = field.label,
+                help = field.help,
+                placeholder = field.placeholder,
+                value = (value as? SourceConfigValue.Text)?.value.orEmpty(),
+                configured = (value as? SourceConfigValue.Text)?.value?.isNotBlank() ?: false,
+            )
+            is SourceConfigField.SecretText -> UiSourceConfigField(
+                key = field.key,
+                type = SourceConfigFieldType.SECRET,
+                label = field.label,
+                help = field.help,
+                placeholder = field.placeholder,
+                configured = (value as? SourceConfigValue.Secret)?.configured ?: false,
+            )
+            is SourceConfigField.UrlText -> UiSourceConfigField(
+                key = field.key,
+                type = SourceConfigFieldType.URL,
+                label = field.label,
+                help = field.help,
+                placeholder = field.placeholder,
+                value = (value as? SourceConfigValue.Text)?.value.orEmpty(),
+                configured = (value as? SourceConfigValue.Text)?.value?.isNotBlank() ?: false,
+            )
+            is SourceConfigField.Toggle -> UiSourceConfigField(
+                key = field.key,
+                type = SourceConfigFieldType.TOGGLE,
+                label = field.label,
+                help = field.help,
+                toggled = (value as? SourceConfigValue.Bool)?.on ?: false,
+            )
+        }
+    },
+)

--- a/app/src/main/kotlin/in/jphe/storyvox/data/SourceConfigContributors.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SourceConfigContributors.kt
@@ -1,0 +1,159 @@
+package `in`.jphe.storyvox.data
+
+import `in`.jphe.storyvox.data.source.SourceIds
+import `in`.jphe.storyvox.data.source.plugin.SourceConfigContributor
+import `in`.jphe.storyvox.data.source.plugin.SourceConfigField
+import `in`.jphe.storyvox.data.source.plugin.SourceConfigValue
+import `in`.jphe.storyvox.source.primegaming.config.PrimeGamingConfig
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+/**
+ * Issue #1531 — the three worked examples that prove the generic
+ * config-field seam. Each wraps an existing `*ConfigImpl` (the DataStore /
+ * EncryptedSharedPreferences backing store stays exactly where it was) and
+ * exposes it through the [SourceConfigContributor] contract, so Settings
+ * renders the fields with no bespoke row.
+ *
+ * These live in `:app` (not the leaf source modules) because that is where
+ * the Android-backed `*ConfigImpl`s already live — the same split the
+ * config impls themselves use to keep source modules free of Preferences
+ * plumbing. A new credentialed source adds one contributor here (or an
+ * out-of-tree equivalent) plus one `@IntoSet` binding in `AppBindings` —
+ * and touches none of the three Settings monoliths.
+ */
+
+/**
+ * Reddit installed-app BYOK (#1492): the client id (masked, write-only) plus
+ * the top-comment epilogue toggle. Replaces the bespoke `RedditConfigRow` +
+ * the `setRedditClientId` / `setRedditAppendTopComments` mutators.
+ */
+@Singleton
+class RedditConfigContributor @Inject constructor(
+    private val config: RedditConfigImpl,
+) : SourceConfigContributor {
+    override val sourceId: String = "reddit"
+    override val displayName: String = "Reddit"
+    override val sectionHelp: String =
+        "Bring your own Reddit installed-app credential — full post bodies via " +
+            "Reddit's API (~100 requests/min)."
+
+    override fun fields(): List<SourceConfigField> = listOf(
+        SourceConfigField.SecretText(
+            key = "clientId",
+            label = "Client id",
+            help = "Create a free \"installed app\" at reddit.com/prefs/apps " +
+                "(type: installed app — no secret) and paste its client id. " +
+                "See docs/reddit-setup.md.",
+            placeholder = "e.g. AbC1dEf2GhI3jK",
+        ),
+        SourceConfigField.Toggle(
+            key = "appendTopComments",
+            label = "Append top comments",
+            help = "Narrate each post's top comments after its body.",
+        ),
+    )
+
+    override val values: Flow<Map<String, SourceConfigValue>> = config.state.map { s ->
+        mapOf(
+            "clientId" to SourceConfigValue.Secret(s.clientId.isNotBlank()),
+            "appendTopComments" to SourceConfigValue.Bool(s.appendTopComments),
+        )
+    }
+
+    override suspend fun set(key: String, raw: String) {
+        when (key) {
+            "clientId" -> config.setClientId(raw.ifBlank { null })
+            "appendTopComments" -> config.setAppendTopComments(raw.toBoolean())
+        }
+    }
+}
+
+/**
+ * Notion (#233/#393): the database id (plain, shown) plus the Internal
+ * Integration Token (masked, write-only). Replaces the bespoke
+ * `NotionConfigRow` in Settings. The Browse "Manage Notion" sheet keeps its
+ * own OAuth-aware surface via the repository's `setNotionApiToken` /
+ * `setNotionDatabaseId` — both write through the same [NotionConfigImpl], so
+ * there's a single source of truth in storage.
+ */
+@Singleton
+class NotionConfigContributor @Inject constructor(
+    private val config: NotionConfigImpl,
+) : SourceConfigContributor {
+    override val sourceId: String = SourceIds.NOTION
+    override val displayName: String = "Notion"
+    override val sectionHelp: String =
+        "Reads TechEmpower's public Notion content by default. Paste an " +
+            "Internal Integration Token (notion.so/my-integrations) to read " +
+            "your own workspace database."
+
+    override fun fields(): List<SourceConfigField> = listOf(
+        SourceConfigField.PlainText(
+            key = "databaseId",
+            label = "Database ID",
+            help = "The Notion database the source reads in token mode. " +
+                "Defaults to TechEmpower's public database.",
+            placeholder = "32-hex or hyphenated UUID",
+        ),
+        SourceConfigField.SecretText(
+            key = "token",
+            label = "Integration token",
+            help = "Create one at notion.so/my-integrations, then share your " +
+                "database with the integration.",
+            placeholder = "ntn_…",
+        ),
+    )
+
+    override val values: Flow<Map<String, SourceConfigValue>> = config.state.map { s ->
+        mapOf(
+            "databaseId" to SourceConfigValue.Text(s.databaseId),
+            "token" to SourceConfigValue.Secret(s.apiToken.isNotBlank()),
+        )
+    }
+
+    override suspend fun set(key: String, raw: String) {
+        when (key) {
+            "databaseId" -> config.setDatabaseId(raw)
+            "token" -> config.setApiToken(raw.ifBlank { null })
+        }
+    }
+}
+
+/**
+ * Prime Gaming feed-URL override (#1494/#1535): the single tunable, an
+ * http(s) URL that defaults to the bundled LootScraper feed. This is the
+ * first user-facing surface for the override — it was previously reachable
+ * only in code, deferred to this seam. Blank reverts to the default.
+ */
+@Singleton
+class PrimeGamingConfigContributor @Inject constructor(
+    private val config: PrimeGamingConfigImpl,
+) : SourceConfigContributor {
+    override val sourceId: String = "primegaming"
+    override val displayName: String = "Prime Gaming"
+    override val sectionHelp: String =
+        "The Amazon-Prime claims feed (community LootScraper Atom feed). " +
+            "Override if the feed moves hosts or you self-host it."
+
+    override fun fields(): List<SourceConfigField> = listOf(
+        SourceConfigField.UrlText(
+            key = "feedUrl",
+            label = "Feed URL override",
+            help = "Leave blank to use the bundled default feed.",
+            placeholder = PrimeGamingConfig.DEFAULT_FEED_URL,
+        ),
+    )
+
+    override val values: Flow<Map<String, SourceConfigValue>> = config.feedUrlFlow.map { url ->
+        mapOf("feedUrl" to SourceConfigValue.Text(url))
+    }
+
+    override suspend fun set(key: String, raw: String) {
+        when (key) {
+            "feedUrl" -> config.setFeedUrl(raw.ifBlank { null })
+        }
+    }
+}

--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -6,6 +6,7 @@ import android.os.SystemClock
 import androidx.core.content.ContextCompat
 import dagger.Module
 import dagger.Provides
+import dagger.multibindings.IntoSet
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
@@ -95,6 +96,26 @@ object AppBindings {
         repo: FictionRepository,
         chapters: ChapterRepository,
     ): FictionRepositoryUi = RealFictionRepositoryUi(repo, chapters)
+
+    // Issue #1531 — generic config-field seam contributors. Each is added to
+    // the `Set<SourceConfigContributor>` that SettingsRepositoryUiImpl
+    // consumes to render one registry-driven config section per source. A new
+    // credentialed source adds ONE binding here + one contributor class, and
+    // touches none of the three Settings monoliths.
+    @Provides @Singleton @IntoSet
+    fun provideRedditConfigContributor(
+        impl: `in`.jphe.storyvox.data.RedditConfigContributor,
+    ): `in`.jphe.storyvox.data.source.plugin.SourceConfigContributor = impl
+
+    @Provides @Singleton @IntoSet
+    fun provideNotionConfigContributor(
+        impl: `in`.jphe.storyvox.data.NotionConfigContributor,
+    ): `in`.jphe.storyvox.data.source.plugin.SourceConfigContributor = impl
+
+    @Provides @Singleton @IntoSet
+    fun providePrimeGamingConfigContributor(
+        impl: `in`.jphe.storyvox.data.PrimeGamingConfigContributor,
+    ): `in`.jphe.storyvox.data.source.plugin.SourceConfigContributor = impl
 
     /** Issue #1228 — bridges the `:feature` [DocumentImporterUi] seam to
      *  the app-side single-file import path (the same one MainActivity's

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/source/plugin/SourceConfig.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/source/plugin/SourceConfig.kt
@@ -1,0 +1,153 @@
+package `in`.jphe.storyvox.data.source.plugin
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Issue #1531 — generic per-source **config-field seam**.
+ *
+ * ## The problem this solves
+ *
+ * `@SourcePlugin` (#384/#1371) gave a new backend a zero-central-edit
+ * *Settings auto-section* (the Plugin Manager toggle + chip). But there
+ * was **no generic way for a source to declare a config *field*** — a
+ * credential entry, a URL override, a behaviour toggle. The only
+ * mechanism was a hand-written composable plus a four-file monolith edit
+ * (`SettingsScreen.kt` + `UiContracts.kt` + `SettingsViewModel.kt` +
+ * `SettingsRepositoryUiImpl.kt`), repeated once per credentialed source —
+ * and those are the highest-churn files in the repo, so N sibling source
+ * PRs each adding a config row collided and broke auto-merge.
+ *
+ * ## The seam
+ *
+ * A source contributes a [SourceConfigContributor] (bound `@IntoSet` in
+ * `:app`, next to where its `*ConfigImpl` already lives). Each contributor
+ * declares a list of typed [SourceConfigField]s and exposes a live value
+ * stream + a generic setter. The Settings layer renders **every**
+ * contributor's fields through one registry-driven section — so adding a
+ * credentialed source is now **zero** edits to the three Settings
+ * monoliths. That restores auto-merge for source waves and closes the
+ * last big touchpoint for the most valuable class of new sources (authed
+ * ones).
+ *
+ * Mirrors how `chipLabel` / `searchHint` / `iconName` are already carried
+ * off the [SourcePluginDescriptor] rather than hand-wired per source.
+ */
+sealed interface SourceConfigField {
+    /** Stable per-source field key, e.g. `"clientId"`. Persisted by the
+     *  contributor and echoed back on writes; unique within a source. */
+    val key: String
+
+    /** Human-readable field label for the Settings row. */
+    val label: String
+
+    /** Optional one-line explanatory text rendered under the field.
+     *  Empty string hides it. */
+    val help: String
+
+    /**
+     * Validate a proposed raw value before it is persisted. Returns null
+     * when the value is acceptable, or a short human-readable error
+     * message to surface in the UI. The default accepts everything; a
+     * blank value is always treated as "clear / reset to default" by the
+     * contributor, so validators should return null for blank input.
+     */
+    fun validate(value: String): String? = null
+
+    /** A plain, non-secret text field whose current value is shown and
+     *  editable (e.g. a Notion database id). */
+    data class PlainText(
+        override val key: String,
+        override val label: String,
+        override val help: String = "",
+        val placeholder: String = "",
+    ) : SourceConfigField
+
+    /** A write-only credential field. The stored value is never surfaced
+     *  back to the UI (only a "configured" boolean is), and input is
+     *  masked. Blank clears the stored credential. */
+    data class SecretText(
+        override val key: String,
+        override val label: String,
+        override val help: String = "",
+        val placeholder: String = "",
+    ) : SourceConfigField
+
+    /** A URL field. Its current value is shown and editable; a non-blank
+     *  value must be an `http(s)` URL. Blank resets to the source's baked
+     *  default (e.g. the Prime Gaming feed URL). */
+    data class UrlText(
+        override val key: String,
+        override val label: String,
+        override val help: String = "",
+        val placeholder: String = "",
+    ) : SourceConfigField {
+        override fun validate(value: String): String? {
+            if (value.isBlank()) return null
+            val ok = value.startsWith("http://") || value.startsWith("https://")
+            return if (ok) null else "Enter an http(s) URL"
+        }
+    }
+
+    /** A boolean behaviour toggle (e.g. "append top comments"). */
+    data class Toggle(
+        override val key: String,
+        override val label: String,
+        override val help: String = "",
+    ) : SourceConfigField
+}
+
+/**
+ * Current display value of a [SourceConfigField], streamed by the
+ * contributor. The variant matches the field type:
+ *  - [Text] — for [SourceConfigField.PlainText] / [SourceConfigField.UrlText]
+ *    (carries the current value).
+ *  - [Secret] — for [SourceConfigField.SecretText] (carries only whether a
+ *    value is stored; never the value itself).
+ *  - [Bool] — for [SourceConfigField.Toggle].
+ */
+sealed interface SourceConfigValue {
+    data class Text(val value: String) : SourceConfigValue
+    data class Secret(val configured: Boolean) : SourceConfigValue
+    data class Bool(val on: Boolean) : SourceConfigValue
+}
+
+/**
+ * Issue #1531 — a source's contribution of user-configurable fields to
+ * the generic Settings config section.
+ *
+ * Bound `@IntoSet Set<SourceConfigContributor>` in `:app` (where the
+ * `*ConfigImpl` backing stores already live, so a contributor can wrap
+ * the existing DataStore / EncryptedSharedPreferences implementation
+ * without leaking Android plumbing into the leaf source module). The
+ * Settings layer consumes the whole set generically — no per-source UI
+ * edit — the same way [SourcePluginRegistry] consumes descriptors.
+ */
+interface SourceConfigContributor {
+    /** The owning source's stable id (matches its `@SourcePlugin` id).
+     *  Used to route [set] calls back to this contributor. */
+    val sourceId: String
+
+    /** UI label for the section header, e.g. `"Reddit"`. */
+    val displayName: String
+
+    /** Optional one-line section-level explanation shown above the fields.
+     *  Empty string hides it. */
+    val sectionHelp: String get() = ""
+
+    /** The typed fields this source declares, in render order. */
+    fun fields(): List<SourceConfigField>
+
+    /** Live map of `fieldKey → current value` for the declared [fields].
+     *  Re-emits whenever any backing store changes. A field absent from
+     *  the map renders with a type-appropriate empty default. */
+    val values: Flow<Map<String, SourceConfigValue>>
+
+    /**
+     * Persist [raw] for [key]. Semantics are field-type dependent:
+     *  - text / url / secret: a blank [raw] clears the value (reverting to
+     *    the field's default where one exists);
+     *  - toggle: [raw] is `"true"` / `"false"`.
+     * Unknown keys are ignored.
+     */
+    suspend fun set(key: String, raw: String)
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -852,6 +852,61 @@ data class UiChatGrounding(
     val includeEntireBookSoFar: Boolean = false,
 )
 
+/**
+ * Issue #1531 — UI-facing kind of a per-source config field. Mirrors the
+ * `core-data` `SourceConfigField` sealed hierarchy, flattened to an enum
+ * so `:feature` stays independent of the source-plugin types (the same
+ * posture as `notionMode` being carried as a plain String). The
+ * `:app` repository maps `SourceConfigField` → this enum.
+ */
+enum class SourceConfigFieldType {
+    /** Plain, non-secret text; current [UiSourceConfigField.value] shown. */
+    PLAIN,
+
+    /** Write-only credential; input masked, value never surfaced. */
+    SECRET,
+
+    /** URL override; current value shown, validated as http(s). */
+    URL,
+
+    /** Boolean behaviour toggle. */
+    TOGGLE,
+}
+
+/**
+ * Issue #1531 — one config field projected for the generic Settings
+ * section. The `:app` repository builds these from each source's
+ * `SourceConfigContributor` (declared fields + live values).
+ */
+data class UiSourceConfigField(
+    /** Stable per-source field key, echoed back on writes. */
+    val key: String,
+    val type: SourceConfigFieldType,
+    val label: String,
+    val help: String = "",
+    val placeholder: String = "",
+    /** Current value for [SourceConfigFieldType.PLAIN] / [SourceConfigFieldType.URL];
+     *  always empty for [SourceConfigFieldType.SECRET] (never surfaced). */
+    val value: String = "",
+    /** True when a value is stored (secret present, or plain/url non-blank). */
+    val configured: Boolean = false,
+    /** Current state for [SourceConfigFieldType.TOGGLE]. */
+    val toggled: Boolean = false,
+)
+
+/**
+ * Issue #1531 — one source's config section for the registry-driven
+ * Settings UI. Rendered generically by `SourceConfigSection`; adding a
+ * credentialed source contributes one of these with zero Settings-monolith
+ * edits.
+ */
+data class UiSourceConfigSection(
+    val sourceId: String,
+    val displayName: String,
+    val help: String = "",
+    val fields: List<UiSourceConfigField> = emptyList(),
+)
+
 data class UiSettings(
     val ttsEngine: String,
     val defaultVoiceId: String?,
@@ -1024,14 +1079,16 @@ data class UiSettings(
      *  token" branch. v1 has no separate server/channel picker — the
      *  channel list is derived from observed `getUpdates` activity. */
     val telegramTokenConfigured: Boolean = false,
-    /** Issue #1492 — true when a Reddit installed-app client id has been
-     *  stored. The client id itself is never surfaced to the UI; only this
-     *  boolean drives the Settings card's "Configured / paste a client id"
-     *  branch. */
-    val redditClientIdConfigured: Boolean = false,
-    /** Issue #1492 — when true, each Reddit chapter appends its top
-     *  comments as a narrated epilogue. Default off. */
-    val redditAppendTopComments: Boolean = false,
+    /** Issue #1531 — generic per-source config sections, rendered by the
+     *  registry-driven [SourceConfigSection] composable in Settings. Each
+     *  entry is one source's declared config fields (credentials, URL
+     *  overrides, toggles) plus their current values. Populated by
+     *  `SettingsRepositoryUiImpl` from the injected
+     *  `Set<SourceConfigContributor>`; empty until at least one source
+     *  contributes fields. Reddit (client id + comment epilogue), Notion
+     *  (database id + token), and Prime Gaming (feed-URL override, #1535)
+     *  ride this seam — no bespoke Settings row per source. */
+    val sourceConfigSections: List<UiSourceConfigSection> = emptyList(),
     /**
      * Plugin-seam Phase 3 (#384) — per-plugin on/off keyed by stable
      * plugin id ("kvmr", "royalroad", "notion-techempower", ...). Single source of
@@ -2311,15 +2368,13 @@ interface SettingsRepositoryUi {
      *  `pref_source_telegram_token` in `storyvox.secrets`. */
     suspend fun setTelegramApiToken(token: String?)
 
-    /** Issue #1492 — persist or clear the Reddit installed-app client id.
-     *  Pass null/blank to clear. Stored encrypted under
-     *  `pref_source_reddit_client_id` in `storyvox.secrets`. Default body
-     *  (no-op) so hand-rolled test fakes needn't implement it. */
-    suspend fun setRedditClientId(clientId: String?) {}
-
-    /** Issue #1492 — toggle appending top comments to each Reddit chapter.
-     *  Default body (no-op) so hand-rolled test fakes needn't implement it. */
-    suspend fun setRedditAppendTopComments(enabled: Boolean) {}
+    /** Issue #1531 — generic write path for the per-source config-field
+     *  seam. Routes [raw] to the [sourceId] source's contributor for the
+     *  field [key]. A blank [raw] clears/resets the field; a toggle passes
+     *  `"true"`/`"false"`. Replaces the per-source `setRedditClientId` /
+     *  `setRedditAppendTopComments`-style mutators. Default body (no-op) so
+     *  hand-rolled test fakes needn't implement it. */
+    suspend fun setSourceConfigValue(sourceId: String, key: String, raw: String) {}
 
     /**
      * Issue #462 — verify the bot token by hitting Telegram's

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
@@ -90,6 +90,9 @@ import `in`.jphe.storyvox.feature.api.PUNCTUATION_PAUSE_OFF_MULTIPLIER
 import `in`.jphe.storyvox.feature.api.AzureProbeResult
 import `in`.jphe.storyvox.feature.api.PalaceProbeResult
 import `in`.jphe.storyvox.feature.api.ThemeOverride
+import `in`.jphe.storyvox.feature.api.SourceConfigFieldType
+import `in`.jphe.storyvox.feature.api.UiSourceConfigField
+import `in`.jphe.storyvox.feature.api.UiSourceConfigSection
 import `in`.jphe.storyvox.feature.api.UiAiSettings
 import `in`.jphe.storyvox.feature.api.UiAzureConfig
 import `in`.jphe.storyvox.feature.api.UiChatGrounding
@@ -613,12 +616,6 @@ fun SettingsScreen(
                 languageCode = s.wikipediaLanguageCode,
                 onLanguageCodeChange = viewModel::setWikipediaLanguageCode,
             )
-            NotionConfigRow(
-                databaseId = s.notionDatabaseId,
-                tokenConfigured = s.notionTokenConfigured,
-                onDatabaseIdChange = viewModel::setNotionDatabaseId,
-                onApiTokenChange = viewModel::setNotionApiToken,
-            )
             val discordGuilds by viewModel.discordGuilds.collectAsStateWithLifecycle()
             DiscordConfigRow(
                 tokenConfigured = s.discordTokenConfigured,
@@ -640,12 +637,17 @@ fun SettingsScreen(
                 onApiTokenChange = viewModel::setTelegramApiToken,
                 onRefreshProbe = viewModel::refreshTelegramProbe,
             )
-            // #1492 — Reddit installed-app client id (BYOK) + comment epilogue.
-            RedditConfigRow(
-                clientIdConfigured = s.redditClientIdConfigured,
-                appendTopComments = s.redditAppendTopComments,
-                onClientIdChange = viewModel::setRedditClientId,
-                onAppendTopCommentsChange = viewModel::setRedditAppendTopComments,
+            // #1531 — generic per-source config-field seam. Renders every
+            // source's declared config fields (Reddit client id + comment
+            // epilogue, Notion database id + token, Prime Gaming feed-URL
+            // override #1535, and any future credentialed source) from the
+            // registry with ZERO bespoke rows here. This is the whole point
+            // of the seam: a new authed source contributes a
+            // SourceConfigContributor and appears below with no edit to this
+            // monolith.
+            SourceConfigSection(
+                sections = s.sourceConfigSections,
+                onValueChange = viewModel::setSourceConfigValue,
             )
             // #1295 — Google News full-article text (opt-in, default OFF).
             SettingsSwitchRow(
@@ -3472,223 +3474,141 @@ private fun WikipediaLanguageRow(
 }
 
 /**
- * Issue #233 — Notion source config row. Two fields:
+ * Issue #1531 — generic, registry-driven per-source config section.
  *
- *  - **Database ID** — the Notion database the source queries. Defaults
- *    to the techempower.org placeholder from `NotionDefaults`; the user
- *    can override to point at their own Notion DB. Both hyphenated UUID
- *    and 32-hex compact forms accepted by the API.
- *  - **Integration token** — Notion "Internal Integration Token" from
- *    notion.so/my-integrations. Stored encrypted; never re-displayed.
- *    A configured token shows as "Token configured" rather than
- *    surfacing the value.
+ * Replaces the bespoke `NotionConfigRow` / `RedditConfigRow`-per-source
+ * composables. Renders every [UiSourceConfigSection] the repository built
+ * from the injected `Set<SourceConfigContributor>`, so a new credentialed
+ * source appears here with ZERO edit to this file — that is the whole point
+ * of the seam (#1531): source waves stop colliding on this monolith.
  *
- * Inline under the Notion toggle in Library & Sync, mirroring the
- * OutlineConfigRow shape. The "Save" button writes both fields at
- * once; the user can change one without retyping the other.
+ * Each field renders by type: a masked write-only credential (SECRET), a
+ * plain editable value (PLAIN), an http(s)-validated URL override (URL, e.g.
+ * the Prime Gaming feed override #1535), or a behaviour toggle (TOGGLE).
  */
 @Composable
-private fun NotionConfigRow(
-    databaseId: String,
-    tokenConfigured: Boolean,
-    onDatabaseIdChange: (String) -> Unit,
-    onApiTokenChange: (String?) -> Unit,
+private fun SourceConfigSection(
+    sections: List<UiSourceConfigSection>,
+    onValueChange: (sourceId: String, key: String, raw: String) -> Unit,
 ) {
     val spacing = LocalSpacing.current
-    val context = LocalContext.current
-    var dbDraft by remember(databaseId) { mutableStateOf(databaseId) }
-    var tokenDraft by remember { mutableStateOf("") }
-
-    // Issue #447 — the prefilled Database ID ("2a3d70…") read as
-    // either a leaked infrastructure id or a confusing placeholder.
-    // Detect when the field is still at the TechEmpower default and
-    // surface a clear label so the user knows it's a public DB they
-    // can replace with their own.
-    val techempowerDefaultId = "2a3d706803c649409e74e9ce5ccd4c4b"
-    val isDefaultDatabaseId = databaseId == techempowerDefaultId
-    Column(modifier = Modifier.padding(horizontal = spacing.md, vertical = spacing.sm)) {
-        Text(
-            "Notion integration",
-            style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(bottom = spacing.xs),
-        )
-        Text(
-            text = when {
-                tokenConfigured ->
-                    "Token configured. Paste a new token to replace it, " +
-                        "or clear it to switch back to the anonymous TechEmpower demo content."
-                isDefaultDatabaseId ->
-                    "No token configured — Browse → Notion shows TechEmpower's public " +
-                        "Notion content as a demo. Paste a Notion Internal Integration " +
-                        "Token from notion.so/my-integrations to read your own database; " +
-                        "replace the Database ID below with your own."
-                else ->
-                    "Paste a Notion Internal Integration Token. " +
-                        "Create one at notion.so/my-integrations, then share " +
-                        "your database with the integration."
-            },
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(bottom = spacing.sm),
-        )
-        androidx.compose.material3.OutlinedTextField(
-            value = dbDraft,
-            onValueChange = { dbDraft = it.trim().take(64) },
-            label = {
-                Text(
-                    if (dbDraft == techempowerDefaultId)
-                        "Database ID (TechEmpower demo)"
-                    else
-                        "Database ID",
-                )
-            },
-            placeholder = { Text("32-hex or hyphenated UUID") },
-            singleLine = true,
-            supportingText = {
-                if (dbDraft == techempowerDefaultId) {
-                    Text(
-                        "Default points at TechEmpower's public Resources DB. " +
-                            "Replace with your own DB id to read a personal database.",
-                        style = MaterialTheme.typography.labelSmall,
-                    )
-                }
-            },
-            modifier = Modifier.fillMaxWidth(),
-        )
-        androidx.compose.material3.OutlinedTextField(
-            value = tokenDraft,
-            onValueChange = { tokenDraft = it },
-            label = { Text("Integration token") },
-            placeholder = { Text("ntn_…") },
-            singleLine = true,
-            visualTransformation = androidx.compose.ui.text.input.PasswordVisualTransformation(),
-            modifier = Modifier.fillMaxWidth().padding(top = spacing.xs),
-        )
-        Row(
-            modifier = Modifier.fillMaxWidth().padding(top = spacing.sm),
-            horizontalArrangement = Arrangement.spacedBy(spacing.sm),
-        ) {
-            BrassButton(
-                label = "Save",
-                onClick = {
-                    // Issue #455 — empty required fields produce a toast
-                    // so the user sees that something was missing.
-                    // Database ID has a baked-in default (TechEmpower),
-                    // so an "empty Database ID at save time" already
-                    // applies that default silently — the toast still
-                    // names it so the user knows the demo content will
-                    // be what they see in Browse → Notion.
-                    val skipped = buildList {
-                        if (dbDraft.isBlank()) add("Database ID")
-                        if (tokenDraft.isBlank() && !tokenConfigured) add("Integration token")
-                    }
-                    if (dbDraft != databaseId) onDatabaseIdChange(dbDraft)
-                    if (tokenDraft.isNotBlank()) {
-                        onApiTokenChange(tokenDraft)
-                        tokenDraft = ""
-                    }
-                    if (skipped.isNotEmpty()) {
-                        Toast.makeText(
-                            context,
-                            "Saved. Skipped (defaults applied): ${skipped.joinToString(", ")}",
-                            Toast.LENGTH_SHORT,
-                        ).show()
-                    }
-                },
-                variant = BrassButtonVariant.Primary,
+    sections.forEach { section ->
+        Column(modifier = Modifier.padding(horizontal = spacing.md, vertical = spacing.sm)) {
+            Text(
+                section.displayName,
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(bottom = spacing.xs),
             )
-            if (tokenConfigured) {
-                androidx.compose.material3.TextButton(
-                    onClick = {
-                        onApiTokenChange(null)
-                        tokenDraft = ""
-                    },
-                ) { Text("Clear token") }
+            if (section.help.isNotBlank()) {
+                Text(
+                    section.help,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(bottom = spacing.sm),
+                )
+            }
+            section.fields.forEach { field ->
+                when (field.type) {
+                    SourceConfigFieldType.TOGGLE ->
+                        SettingsSwitchRow(
+                            title = field.label,
+                            subtitle = field.help,
+                            checked = field.toggled,
+                            onCheckedChange = { on ->
+                                onValueChange(section.sourceId, field.key, on.toString())
+                            },
+                        )
+                    else ->
+                        SourceConfigTextField(
+                            sourceId = section.sourceId,
+                            field = field,
+                            onValueChange = onValueChange,
+                        )
+                }
             }
         }
     }
 }
 
 /**
- * Issue #1492 — Reddit backend config card. Renders inside the
- * Library & Sync section.
+ * Issue #1531 — one editable text-like config field (PLAIN / SECRET / URL)
+ * for [SourceConfigSection].
  *
- * Reddit is BYOK: the user creates their own free "installed app" at
- * reddit.com/prefs/apps and pastes its **client id** (installed apps have
- * no secret — see docs/reddit-setup.md). Parallel shape to
- * [NotionConfigRow]: header + explanatory text + client-id field +
- * save/clear + a comment-epilogue toggle. The client id is not masked —
- * unlike a token it's a public identifier, and showing it lets the user
- * verify the paste.
+ *  - SECRET: input is masked and write-only — the stored value is never
+ *    prefilled; a "Configured" hint + Clear action appear once set.
+ *  - PLAIN / URL: the current value is prefilled and editable; Clear reverts
+ *    to the source's baked default (a blank write).
+ *  - URL: a non-blank value must be http(s) — Save is blocked with an inline
+ *    error otherwise.
  */
 @OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
 @Composable
-private fun RedditConfigRow(
-    clientIdConfigured: Boolean,
-    appendTopComments: Boolean,
-    onClientIdChange: (String?) -> Unit,
-    onAppendTopCommentsChange: (Boolean) -> Unit,
+private fun SourceConfigTextField(
+    sourceId: String,
+    field: UiSourceConfigField,
+    onValueChange: (sourceId: String, key: String, raw: String) -> Unit,
 ) {
     val spacing = LocalSpacing.current
-    var clientIdDraft by remember { mutableStateOf("") }
-    Column(modifier = Modifier.padding(horizontal = spacing.md, vertical = spacing.sm)) {
-        Text(
-            "Reddit (installed-app OAuth)",
-            style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(bottom = spacing.xs),
-        )
-        Text(
-            text = if (clientIdConfigured) {
-                "Client id configured — Reddit browsing is active. Paste a new " +
-                    "client id to replace it, or clear it to disable Reddit."
-            } else {
-                "Create a free \"installed app\" at reddit.com/prefs/apps (type: " +
-                    "installed app — no secret) and paste its client id. Full post " +
-                    "bodies via Reddit's API, ~100 requests/min. See docs/reddit-setup.md."
-            },
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(bottom = spacing.sm),
-        )
-        androidx.compose.material3.OutlinedTextField(
-            value = clientIdDraft,
-            onValueChange = { clientIdDraft = it.trim().take(64) },
-            label = { Text(if (clientIdConfigured) "Replace client id" else "Client id") },
-            placeholder = { Text("e.g. AbC1dEf2GhI3jK") },
-            singleLine = true,
-            modifier = Modifier.fillMaxWidth(),
-        )
-        Row(
-            modifier = Modifier.fillMaxWidth().padding(top = spacing.sm),
-            horizontalArrangement = Arrangement.spacedBy(spacing.sm),
-        ) {
-            BrassButton(
-                label = "Save",
-                onClick = {
-                    if (clientIdDraft.isNotBlank()) {
-                        onClientIdChange(clientIdDraft)
-                        clientIdDraft = ""
-                    }
-                },
-                variant = BrassButtonVariant.Primary,
+    val isSecret = field.type == SourceConfigFieldType.SECRET
+    // Secrets are write-only: start blank so the masked field never echoes
+    // the stored credential. Plain/URL fields prefill the current value so
+    // the user edits in place. Re-key on value/configured so an external
+    // change (e.g. Clear) resets the draft.
+    var draft by remember(field.value, field.configured) {
+        mutableStateOf(if (isSecret) "" else field.value)
+    }
+    val urlError = field.type == SourceConfigFieldType.URL && draft.isNotBlank() &&
+        !(draft.startsWith("http://") || draft.startsWith("https://"))
+    androidx.compose.material3.OutlinedTextField(
+        value = draft,
+        onValueChange = { draft = if (isSecret) it.take(256) else it.trim().take(512) },
+        label = {
+            Text(
+                if (isSecret && field.configured) "Replace ${field.label.lowercase()}"
+                else field.label,
             )
-            if (clientIdConfigured) {
-                androidx.compose.material3.TextButton(
-                    onClick = {
-                        onClientIdChange(null)
-                        clientIdDraft = ""
-                    },
-                ) { Text("Clear") }
+        },
+        placeholder = { if (field.placeholder.isNotBlank()) Text(field.placeholder) },
+        singleLine = true,
+        isError = urlError,
+        visualTransformation = if (isSecret)
+            androidx.compose.ui.text.input.PasswordVisualTransformation()
+        else
+            androidx.compose.ui.text.input.VisualTransformation.None,
+        supportingText = {
+            when {
+                urlError -> Text("Enter an http(s) URL")
+                isSecret && field.configured -> Text("Configured")
+                field.help.isNotBlank() -> Text(field.help)
             }
-        }
-        SettingsSwitchRow(
-            title = "Append top comments",
-            subtitle = "Narrate each post's top comments after its body.",
-            checked = appendTopComments,
-            onCheckedChange = onAppendTopCommentsChange,
+        },
+        modifier = Modifier.fillMaxWidth(),
+    )
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(top = spacing.sm),
+        horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+    ) {
+        BrassButton(
+            label = "Save",
+            onClick = {
+                // Secret: a blank draft is a no-op (nothing to store).
+                // Plain/URL: Save always persists the current draft.
+                if (!urlError && (!isSecret || draft.isNotBlank())) {
+                    onValueChange(sourceId, field.key, draft)
+                    if (isSecret) draft = ""
+                }
+            },
+            variant = BrassButtonVariant.Primary,
         )
+        if (field.configured) {
+            androidx.compose.material3.TextButton(
+                onClick = {
+                    onValueChange(sourceId, field.key, "")
+                    draft = ""
+                },
+            ) { Text("Clear") }
+        }
     }
 }
 
@@ -3706,7 +3626,7 @@ private fun RedditConfigRow(
  *  - **Coalesce minutes slider** — 1-30 min, default 5. Tunes the
  *    same-author message coalesce window.
  *
- * Parallel shape to [NotionConfigRow]: header + explanatory text +
+ * Parallel shape to the other credential rows: header + explanatory text +
  * masked token field + extra config + save/clear actions. The
  * Discord-specific piece is the guilds dropdown, which only renders
  * once a token is configured (no point listing servers when the bot

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
@@ -235,21 +235,18 @@ class SettingsViewModel @Inject constructor(
 
     fun setWikipediaLanguageCode(code: String) =
         viewModelScope.launch { repo.setWikipediaLanguageCode(code) }
-    fun setNotionDatabaseId(id: String) =
-        viewModelScope.launch { repo.setNotionDatabaseId(id) }
-    fun setNotionApiToken(token: String?) =
-        viewModelScope.launch { repo.setNotionApiToken(token) }
     fun setDiscordApiToken(token: String?) =
         viewModelScope.launch { repo.setDiscordApiToken(token) }
     fun setDiscordServer(serverId: String, serverName: String) =
         viewModelScope.launch { repo.setDiscordServer(serverId, serverName) }
     fun setDiscordCoalesceMinutes(minutes: Int) =
         viewModelScope.launch { repo.setDiscordCoalesceMinutes(minutes) }
-    // Issue #1492 — Reddit installed-app client id + comment-epilogue toggle.
-    fun setRedditClientId(clientId: String?) =
-        viewModelScope.launch { repo.setRedditClientId(clientId) }
-    fun setRedditAppendTopComments(enabled: Boolean) =
-        viewModelScope.launch { repo.setRedditAppendTopComments(enabled) }
+    // Issue #1531 — generic per-source config-field write path. Reddit
+    // (client id + comment epilogue), Notion (database id + token), and
+    // Prime Gaming (feed URL) all route through this one seam instead of a
+    // bespoke `setXxx` mutator per source.
+    fun setSourceConfigValue(sourceId: String, key: String, raw: String) =
+        viewModelScope.launch { repo.setSourceConfigValue(sourceId, key, raw) }
 
     /** Hot stream of guilds the configured bot has been invited to.
      *  Refreshed manually via [refreshDiscordGuilds]; the UI calls


### PR DESCRIPTION
## Generic per-source config-field seam (#1531), + Prime Gaming feed-URL UI (#1535)

Closes #1531
Closes #1535

### The problem
`@SourcePlugin` gave a new backend a zero-central-edit *Settings auto-section* (the Plugin Manager toggle/chip). But there was **no generic way for a source to declare a config *field*** — a credential, a URL override, a toggle. The only mechanism was a hand-written composable **plus a four-file monolith edit** (`SettingsScreen.kt` + `UiContracts.kt` + `SettingsViewModel.kt` + `SettingsRepositoryUiImpl.kt`), repeated per credentialed source. Those are the highest-churn files in the repo, so N sibling source PRs each adding a config row **collided and broke auto-merge**.

### The seam
- **`SourceConfigField`** (core-data) — sealed: `PlainText` / `SecretText` / `UrlText` / `Toggle`, each with `label` / `help` / `validate()`.
- **`SourceConfigContributor`** (core-data) — a source declares `fields()` + a live `values` stream + a generic `set(key, raw)`. Bound `@IntoSet` in `:app` (where the `*ConfigImpl` backing stores already live).
- **`SourceConfigSection`** (feature/settings) — one generic composable iterates `UiSettings.sourceConfigSections` and renders every contributor's fields. **Adding a credentialed source is now zero edits to the three Settings monoliths.**
- **`setSourceConfigValue(sourceId, key, raw)`** — one generic write path replaces the per-source `setXxx` mutators. Default body so hand-rolled fakes are unaffected.

### Three consumers migrated onto the seam (proof)
| Source | Field(s) | Type |
|---|---|---|
| Reddit | client id, append-top-comments | Secret, Toggle |
| Notion | database id, integration token | Plain, Secret |
| Prime Gaming | feed-URL override (**#1535** — first user-facing control) | Url |

Reddit migrates fully (bespoke row, mutators, `UiSettings` fields, and repo ctor arm all removed). Notion's Settings row is replaced by the seam; its repo mutators (`setNotionApiToken`/`setNotionDatabaseId`) stay because the **Browse "Manage Notion" sheet** still uses them — both write through the same `NotionConfigImpl`, so storage stays single-source-of-truth. Prime is greenfield.

### Notes for review
- Contributors wrap the **existing** `*ConfigImpl`s — no source client rewrites, no new storage, no Hilt cycle (contributor → leaf `*ConfigImpl`, no back-edge).
- `SecretText` is masked + write-only (stored value never surfaced); `UrlText` validates http(s) with blank = reset-to-default.
- New interface method has a default body; verified no hand-rolled `SettingsRepositoryUi`/`UiSettings` fake references the removed Reddit symbols.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
