### PR TITLE
fix(rss): address #1547/#1549 review — merge N+1, refresh clobber, robustness

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/data/RssConfigImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/RssConfigImpl.kt
@@ -97,12 +97,18 @@ class RssConfigImpl(
         if (trimmed.isEmpty()) return
         store.edit { prefs ->
             val existing = decode(prefs[RssKeys.FEEDS])
-            // No-op if the subscription is gone or the resolved URL is
-            // unchanged / identical to the identity URL (nothing to persist).
             val target = existing.firstOrNull { it.fictionId == fictionId } ?: return@edit
-            if (target.resolvedUrl == trimmed || target.url == trimmed) return@edit
+            // #1549 review — a resolved URL identical to the identity URL is
+            // redundant (encode drops it), so normalize that case to "no
+            // resolution" rather than persisting `url == resolvedUrl`. Compute
+            // the desired value first, then no-op only when it genuinely
+            // matches what's already stored — the old `|| target.url ==
+            // trimmed` guard wrongly left a *stale* resolvedUrl in place when
+            // asked to reset a subscription back to its identity URL.
+            val desired = trimmed.takeIf { it != target.url }
+            if (target.resolvedUrl == desired) return@edit
             val updated = existing.map {
-                if (it.fictionId == fictionId) it.copy(resolvedUrl = trimmed) else it
+                if (it.fictionId == fictionId) it.copy(resolvedUrl = desired) else it
             }
             prefs[RssKeys.FEEDS] = encode(updated)
         }

--- a/app/src/test/kotlin/in/jphe/storyvox/data/RssConfigImplTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/data/RssConfigImplTest.kt
@@ -120,6 +120,19 @@ class RssConfigImplTest {
         assertNull(config.snapshot().single().resolvedUrl)
     }
 
+    @Test fun `setResolvedUrl back to the identity URL clears a stale resolvedUrl`() = runTest {
+        // #1549 review — resetting a subscription to its identity URL must
+        // clear a previously-set resolvedUrl, not leave the stale one in place.
+        config.addFeed("https://tricycle.org")
+        val fid = fictionIdForFeedUrl("https://tricycle.org")
+        config.setResolvedUrl(fid, "https://tricycle.org/feed/atom/")
+        assertEquals("https://tricycle.org/feed/atom/", config.snapshot().single().resolvedUrl)
+
+        config.setResolvedUrl(fid, "https://tricycle.org") // == identity URL
+
+        assertNull("stale resolvedUrl cleared", config.snapshot().single().resolvedUrl)
+    }
+
     @Test fun `removeFeed drops the resolved record too`() = runTest {
         config.addFeed("https://tricycle.org")
         val fid = fictionIdForFeedUrl("https://tricycle.org")

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
@@ -649,14 +649,33 @@ class FictionRepositoryImpl @Inject constructor(
                 audioUrl = prefetched.audioUrl ?: base.audioUrl,
             )
         }
+        // #1547 review — load every existing chapter row for this fiction in
+        // ONE query and index by id, instead of a per-chapter `get()` inside
+        // the merge loop (an N+1 that stung fictions with hundreds/thousands
+        // of chapters). `allChapters` is the same full-row read `get()` did,
+        // batched into a single round-trip.
+        val existingById = chapterDao.allChapters(detail.summary.id).associateBy { it.id }
         val merged = incoming.map { fresh ->
-            val previous = chapterDao.get(fresh.id)
+            val previous = existingById[fresh.id]
             when {
                 previous == null -> fresh
-                // #1497 — the source handed us a fresh body inline this refresh.
-                // Take it (the feed item may have been edited upstream), but
-                // keep the user's read state and in-chapter bookmark so a
-                // re-refresh of a subscribed feed doesn't reset progress.
+                // #1497 — the source handed us a fresh body inline this refresh
+                // (this branch fires exactly when the `incoming` block above
+                // applied a prefetched body). Take that fresh body AND its
+                // notes: `fresh.notesAuthor`/`notesAuthorPosition` were parsed
+                // from THIS body (set from the source's ChapterBody just above),
+                // so they are a matched set. We deliberately do NOT copy
+                // `previous.notesAuthor` here — unlike the else branch (which
+                // *preserves* the old body and so must keep the old body's
+                // notes), copying stale notes onto a fresh body would be a
+                // body/notes mismatch, the inverse of the bug the else-branch
+                // fix addresses. Notes travel with the body; only user-state
+                // (read flags, bookmark) is carried across.
+                //
+                // NB: `bookmarkCharOffset` is an offset into the PREVIOUS
+                // plainBody. Keeping the reader's place (best-effort) beats
+                // dropping it; if an upstream edit changed the body the offset
+                // may drift a little, which the reader tolerates.
                 fresh.downloadState == ChapterDownloadState.DOWNLOADED &&
                     fresh.htmlBody != null -> fresh.copy(
                     userMarkedRead = previous.userMarkedRead,
@@ -674,6 +693,15 @@ class FictionRepositoryImpl @Inject constructor(
                     userMarkedRead = previous.userMarkedRead,
                     firstReadAt = previous.firstReadAt,
                     audioUrl = fresh.audioUrl ?: previous.audioUrl,
+                    // #1547 review — body-associated + user-authored fields a
+                    // metadata refresh must never clobber: the in-chapter
+                    // bookmark (an offset into the preserved plainBody) and the
+                    // author's-note block (parsed from the preserved body). The
+                    // pre-#1497 merge didn't carry these, so a plain refresh
+                    // silently reset a reader's bookmark and dropped notes.
+                    bookmarkCharOffset = previous.bookmarkCharOffset,
+                    notesAuthor = previous.notesAuthor,
+                    notesAuthorPosition = previous.notesAuthorPosition,
                 )
             }
         }
@@ -832,11 +860,12 @@ internal fun inferUrlHost(maybeUrl: String?): String? {
  * [`in`.jphe.storyvox.data.work.ChapterDownloadWorker]'s scheme
  * (hex SHA-256 of the HTML body) so a chapter that later flows through
  * the on-demand download path lands on an identical `bodyChecksum` for
- * identical content.
+ * identical content. Encodes as UTF-8 explicitly (rather than the platform
+ * default) so the checksum is stable across JVMs — #1547 review.
  */
 private fun sha256(s: String): String =
     java.security.MessageDigest.getInstance("SHA-256")
-        .digest(s.toByteArray())
+        .digest(s.toByteArray(Charsets.UTF_8))
         .joinToString("") { "%02x".format(it) }
 
 internal fun ChapterInfo.toEntity(fictionId: String): Chapter = Chapter(

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/work/ChapterDownloadWorker.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/work/ChapterDownloadWorker.kt
@@ -201,7 +201,10 @@ class ChapterDownloadWorker @AssistedInject constructor(
         Data.Builder().putString(KEY_RESULT, tag).build()
 
     private fun sha256(s: String): String {
-        val digest = MessageDigest.getInstance("SHA-256").digest(s.toByteArray())
+        // Encode UTF-8 explicitly (not the platform default) so the checksum
+        // is stable across JVMs and identical to the prefetch-path checksum in
+        // FictionRepositoryImpl — #1547 review.
+        val digest = MessageDigest.getInstance("SHA-256").digest(s.toByteArray(Charsets.UTF_8))
         return digest.joinToString("") { "%02x".format(it) }
     }
 

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/FictionRepositoryImplTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/FictionRepositoryImplTest.kt
@@ -22,6 +22,7 @@ import `in`.jphe.storyvox.data.source.model.FictionResult
 import `in`.jphe.storyvox.data.source.model.FictionStatus
 import `in`.jphe.storyvox.data.source.model.FictionSummary
 import `in`.jphe.storyvox.data.source.model.ListPage
+import `in`.jphe.storyvox.data.source.model.NotePosition
 import `in`.jphe.storyvox.data.source.model.SearchQuery
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -882,12 +883,16 @@ class FictionRepositoryImplTest {
 
     @Test fun `refreshDetail with a prefetched body keeps user read state and bookmark`() = runTest {
         // #1497 — a re-refresh of a subscribed feed may carry an edited item
-        // body. Take the fresh body, but never reset the user's progress.
+        // body. Take the fresh body AND its notes (they're a matched set), but
+        // never reset the user's progress (read flags + bookmark).
         val src = FakeSource(SourceIds.ROYAL_ROAD).apply {
             detailResult = FictionResult.Success(
                 detail("99", chapterCount = 1).copy(
                     prefetchedBodies = mapOf(
-                        "99-c0" to ChapterBody(htmlBody = "<p>new body</p>", plainBody = "new body"),
+                        "99-c0" to ChapterBody(
+                            htmlBody = "<p>new body</p>", plainBody = "new body",
+                            notesAuthor = "fresh note", notesAuthorPosition = NotePosition.BEFORE,
+                        ),
                     ),
                 ),
             )
@@ -899,6 +904,7 @@ class FictionRepositoryImplTest {
             bodyChecksum = "old", bodyFetchedAt = 1L,
             downloadState = ChapterDownloadState.DOWNLOADED,
             userMarkedRead = true, firstReadAt = 5678L, bookmarkCharOffset = 42,
+            notesAuthor = "STALE note", notesAuthorPosition = NotePosition.AFTER,
         )
 
         r.refreshDetail("99")
@@ -909,6 +915,40 @@ class FictionRepositoryImplTest {
         assertEquals("read flag preserved", true, merged.userMarkedRead)
         assertEquals("first-read timestamp preserved", 5678L, merged.firstReadAt)
         assertEquals("bookmark preserved", 42, merged.bookmarkCharOffset)
+        // #1554 review — notes travel WITH the fresh body: the fresh body's
+        // notes win over the stale previous notes (the inverse of the else
+        // branch, which preserves the old body AND its old notes).
+        assertEquals("fresh body's notes win", "fresh note", merged.notesAuthor)
+        assertEquals(NotePosition.BEFORE, merged.notesAuthorPosition)
+    }
+
+    @Test fun `refreshDetail preserves bookmark and notes on a normal (non-prefetched) refresh`() = runTest {
+        // #1547 review — a plain metadata refresh (no prefetched body; the
+        // common non-RSS path) must not clobber user-authored / body-associated
+        // fields. Pre-#1547 the merge dropped bookmarkCharOffset + notesAuthor,
+        // silently resetting a reader's bookmark on every refresh.
+        val src = FakeSource(SourceIds.ROYAL_ROAD).apply {
+            detailResult = FictionResult.Success(detail("99", chapterCount = 1))
+        }
+        val (r, _, chapterDao) = repo(sources = mapOf(SourceIds.ROYAL_ROAD to src))
+        chapterDao.rows["99-c0"] = Chapter(
+            id = "99-c0", fictionId = "99", sourceChapterId = "src-0",
+            index = 0, title = "old", htmlBody = "<p>body</p>", plainBody = "body",
+            bodyChecksum = "abc", bodyFetchedAt = 1L,
+            downloadState = ChapterDownloadState.DOWNLOADED,
+            bookmarkCharOffset = 17,
+            notesAuthor = "Author's note text", notesAuthorPosition = NotePosition.AFTER,
+        )
+
+        r.refreshDetail("99")
+
+        val merged = chapterDao.rows["99-c0"]!!
+        assertEquals("bookmark survives a plain refresh", 17, merged.bookmarkCharOffset)
+        assertEquals("author note survives", "Author's note text", merged.notesAuthor)
+        assertEquals(NotePosition.AFTER, merged.notesAuthorPosition)
+        // Body still preserved (unchanged behaviour).
+        assertEquals("body", merged.plainBody)
+        assertEquals(ChapterDownloadState.DOWNLOADED, merged.downloadState)
     }
 
     @Test fun `refreshDetail prunes chapters dropped from the feed (issues #349, #652, #879)`() = runTest {

--- a/source-rss/src/main/kotlin/in/jphe/storyvox/source/rss/RssSource.kt
+++ b/source-rss/src/main/kotlin/in/jphe/storyvox/source/rss/RssSource.kt
@@ -445,7 +445,11 @@ internal class RssSource @Inject constructor(
                     if (discovered != null && discovered != fetchUrl) {
                         // #1498 — persist across launches, keyed by the stable
                         // fictionId (not the URL) so identity is preserved.
-                        config.setResolvedUrl(fictionId, discovered)
+                        // Best-effort: persistence is an optimization, so a
+                        // DataStore write failure (disk full, IO error) must not
+                        // fail the fetch — we just re-discover next cold start
+                        // (#1549 review).
+                        runCatching { config.setResolvedUrl(fictionId, discovered) }
                         fetchResolveParse(discovered, cacheKey, fictionId, allowDiscovery = false)
                     } else {
                         FictionResult.NetworkError("Couldn't parse feed at $fetchUrl", e)
@@ -485,11 +489,18 @@ private fun RssItem.toChapterInfo(index: Int, fictionId: String): ChapterInfo {
     )
 }
 
+/** #1547 review — hoisted out of [stripHtml] so the patterns compile once
+ *  at class-load instead of on every call. [stripHtml] runs per feed item
+ *  during a detail refresh (#1497), so per-call `Regex(...)` construction
+ *  was needless allocation on the hot path. */
+private val HTML_TAG_REGEX = Regex("<[^>]+>")
+private val WHITESPACE_REGEX = Regex("\\s+")
+
 /** Naive HTML strip for the TTS plaintext. EngineStreamingSource
  *  applies further normalization downstream — this just removes
  *  tags and collapses whitespace so the engine doesn't speak
  *  `<p>...</p>`. */
 private fun String.stripHtml(): String =
-    replace(Regex("<[^>]+>"), " ")
-        .replace(Regex("\\s+"), " ")
+    replace(HTML_TAG_REGEX, " ")
+        .replace(WHITESPACE_REGEX, " ")
         .trim()


### PR DESCRIPTION
## Summary
Follow-up to the now-merged **#1547** (persist chapter bodies, #1497) and **#1549** (decouple identity/fetch URL, #1498), applying their code-review findings from Gemini/Copilot.

## `FictionRepositoryImpl.upsertDetail` (from #1547)
- **N+1 query (Gemini HIGH)** — the per-chapter `chapterDao.get()` inside the merge loop is replaced with a single `allChapters().associateBy { it.id }` batch read. Same rows, one round-trip instead of N; matters for fictions with hundreds/thousands of chapters.
- **Refresh clobber (latent bug the review surfaced)** — a plain (else-branch) refresh now preserves `bookmarkCharOffset`, `notesAuthor`, `notesAuthorPosition`. The pre-#1497 merge dropped them, so a metadata refresh silently **reset a reader's bookmark** and lost author's notes even while preserving the body.
- **Checksum determinism** — `sha256` encodes UTF-8 explicitly; `ChapterDownloadWorker.sha256` matched so the prefetch-path and download-path body checksums stay byte-identical across JVMs.

### Notes preservation — deliberate per-branch asymmetry (documented deviation)
The chapter-merge `when` has three branches; `bookmarkCharOffset` (user-state) is now carried in **all** of them. `notesAuthor`/`notesAuthorPosition` are **content-state that travels with the body**, so they are handled per-branch, NOT copied uniformly:

- **else branch** (body *preserved* from previous): copy `notesAuthor`/`notesAuthorPosition` from `previous` — they match the preserved body. ✅ fixed here.
- **fresh-prefetched-body branch**: `fresh` already carries the notes parsed from **that** body — set from the source's `ChapterBody` in the `incoming` block just above (`notesAuthor = prefetched.notesAuthor`). So the fresh notes win; copying `previous.notesAuthor` here would pair **stale notes with a new body** — the *inverse* of the else-branch bug. Verified by the strengthened test (`fresh body's notes win`).

This is a conscious deviation from "copy the three fields in every branch": the bookmark is user-state (carried everywhere), notes are content-state (follow the body). Rationale + evidence are in an inline comment on that branch. `bookmarkCharOffset` on the fresh-body branch is an offset into the *previous* plainBody — kept best-effort (a stale offset beats losing the reader's place); the possible drift after an upstream body edit is called out in-code.

## `RssSource` / `RssConfigImpl` (from #1549)
- **Fetch robustness (Gemini)** — the discovered-URL `config.setResolvedUrl` write is wrapped in `runCatching`; persistence is a cold-start optimization, so a DataStore IO failure must not fail the feed fetch (we just re-discover next launch).
- **`setResolvedUrl` guard bug (Gemini HIGH)** — now normalizes a resolved-URL-equal-to-identity to `null` and no-ops only on a genuine no-change. The old `|| target.url == trimmed` guard left a **stale** resolvedUrl in place when resetting a subscription back to its identity URL.
- **Perf** — `stripHtml`'s two `Regex` literals hoisted to file-level vals so they compile once instead of per feed item during a detail refresh (#1497 amplified the call rate).

## Tests
- `FictionRepositoryImplTest` — normal (else) refresh preserves bookmark + notes; fresh-prefetched-body refresh takes the fresh body's notes over stale ones while keeping the bookmark.
- `RssConfigImplTest` — `setResolvedUrl` back to identity clears a stale resolvedUrl.

References #1547 / #1549 and the Gemini review findings. No `Closes` — no dedicated issue number. No schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
