### PR TITLE
ux(settings): 'Replay the welcome tour' row in About — no restart (#1558)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -1473,6 +1473,16 @@ private fun StoryvoxNavHostContent(
                     onOpenLicenses = { navController.navigate(StoryvoxRoutes.SETTINGS_LICENSES) },
                     // Issue #1463 — route into the impact-sharing explainer.
                     onOpenImpactSharing = { navController.navigate(StoryvoxRoutes.SETTINGS_IMPACT_SHARING) },
+                    // Issue #1558 — clear the whole settings back stack down to
+                    // the start destination and land on LIBRARY, so the reactive
+                    // root-level OnboardingHost re-shows the welcome over a clean
+                    // base (the wizard's own CTAs navigate from there).
+                    onReplayTour = {
+                        navController.navigate(StoryvoxRoutes.LIBRARY) {
+                            popUpTo(navController.graph.findStartDestination().id) { inclusive = true }
+                            launchSingleTop = true
+                        }
+                    },
                 )
             }
             composable(

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/AboutSettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/AboutSettingsScreen.kt
@@ -149,17 +149,16 @@ fun AboutSettingsScreen(
                 )
             }
             // Issue #1558 — user-facing "Replay the welcome tour" affordance.
-            // Reuses the existing resetOnboardingV1() flip (same path as the QA
-            // debug row), then routes to LIBRARY so the reactive OnboardingHost
-            // re-shows the wizard immediately — no app restart.
+            // replayTour() flips the onboarding flag NonCancellably and only
+            // then navigates, so the nav-pop that clears this ViewModel can't
+            // cancel the write mid-flight (Gemini HIGH on #1559). Routing to
+            // LIBRARY lets the reactive OnboardingHost re-show the wizard
+            // immediately — no app restart.
             SettingsGroupCard {
                 SettingsLinkRow(
                     title = stringResource(R.string.settings_about_replay_tour),
                     subtitle = stringResource(R.string.settings_about_replay_tour_subtitle),
-                    onClick = {
-                        viewModel.resetOnboarding()
-                        onReplayTour()
-                    },
+                    onClick = { viewModel.replayTour(onReplayTour) },
                 )
             }
         }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/AboutSettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/AboutSettingsScreen.kt
@@ -60,6 +60,12 @@ fun AboutSettingsScreen(
     /** Issue #1463 — open the "About impact sharing" explainer subscreen. Default
      *  no-op keeps previews / tests simple; the NavHost passes a real navigate. */
     onOpenImpactSharing: () -> Unit = {},
+    /** Issue #1558 — after resetting onboarding, navigate to the LIBRARY route
+     *  (the app's start destination) so the root-level [OnboardingHost] — whose
+     *  `shouldShow` is a reactive flow — re-shows the welcome overlay over a
+     *  clean base WITHOUT an app restart. Default no-op keeps previews / tests
+     *  simple; the NavHost passes the real navigate. */
+    onReplayTour: () -> Unit = {},
     viewModel: SettingsViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -140,6 +146,20 @@ fun AboutSettingsScreen(
                     title = stringResource(R.string.settings_about_licenses),
                     subtitle = stringResource(R.string.settings_about_licenses_subtitle),
                     onClick = onOpenLicenses,
+                )
+            }
+            // Issue #1558 — user-facing "Replay the welcome tour" affordance.
+            // Reuses the existing resetOnboardingV1() flip (same path as the QA
+            // debug row), then routes to LIBRARY so the reactive OnboardingHost
+            // re-shows the wizard immediately — no app restart.
+            SettingsGroupCard {
+                SettingsLinkRow(
+                    title = stringResource(R.string.settings_about_replay_tour),
+                    subtitle = stringResource(R.string.settings_about_replay_tour_subtitle),
+                    onClick = {
+                        viewModel.resetOnboarding()
+                        onReplayTour()
+                    },
                 )
             }
         }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
@@ -872,14 +872,14 @@ fun SettingsScreen(
             )
             // Issue #599 (v1.0) — manual reset of the first-launch
             // welcome flow. Flips `pref_onboarding_completed_v1` back
-            // to false so the three-screen welcome runs on next cold
-            // launch (or, on a hot re-entry to the LIBRARY route, on
-            // the next OnboardingHost recomposition). Surfaced here
-            // rather than as a top-level affordance because it's
-            // strictly a QA / dress-rehearsal control.
+            // to false; OnboardingHost's `shouldShow` is a reactive flow,
+            // so the welcome re-shows on the next visit to Library with no
+            // restart (#1558 added the user-facing About equivalent).
+            // Surfaced here rather than as a top-level affordance because
+            // it's strictly a QA / dress-rehearsal control.
             SettingsLinkRow(
                 title = "Reset onboarding",
-                subtitle = "Show the first-launch welcome flow again. Restart the app to see it.",
+                subtitle = "Show the first-launch welcome flow again — appears on the next visit to Library.",
                 onClick = { viewModel.resetOnboarding() },
             )
         }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsSearchIndex.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsSearchIndex.kt
@@ -94,7 +94,11 @@ val SettingsSearchSections: List<SettingsSearchSection> = listOf(
     SettingsSearchSection(
         label = "About",
         descriptor = "Build identity for bug reports.",
-        keywords = listOf("version", "sigil", "build", "license", "open source"),
+        keywords = listOf(
+            "version", "sigil", "build", "license", "open source",
+            // #1558 — the "Replay the welcome tour" row lives in the About surface.
+            "welcome", "tour", "wizard", "replay",
+        ),
     ),
 )
 

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
@@ -26,6 +26,7 @@ import `in`.jphe.storyvox.llm.LlmRepository
 import `in`.jphe.storyvox.llm.ProbeResult
 import `in`.jphe.storyvox.llm.ProviderId
 import javax.inject.Inject
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -34,6 +35,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @Immutable
 data class SettingsUiState(
@@ -179,7 +181,28 @@ class SettingsViewModel @Inject constructor(
      *  so the OnboardingHost shows the three-screen welcome again on
      *  the next composition. Strictly a QA / dress-rehearsal hook;
      *  surfaced in Settings → Developer. */
-    fun resetOnboarding() = viewModelScope.launch { repo.resetOnboardingV1() }
+    fun resetOnboarding() = viewModelScope.launch { resetOnboardingFlagDurably() }
+
+    /**
+     * #1558 — replay the welcome tour from a *navigating* affordance (the About
+     * row). The flag write runs to completion FIRST and [onNavigate] fires only
+     * after it, so popping the settings back stack — which clears this ViewModel
+     * and cancels [viewModelScope] — can no longer cancel the DataStore write
+     * mid-flight. That ordering race (navigate-then-write, write lost on slow
+     * devices) was Gemini's HIGH on #1559; [resetOnboardingFlagDurably]'s
+     * [NonCancellable] guard removes it by construction.
+     */
+    fun replayTour(onNavigate: () -> Unit) = viewModelScope.launch {
+        resetOnboardingFlagDurably()
+        onNavigate()
+    }
+
+    /** #1558 — flip the onboarding flag so the write survives cancellation of
+     *  [viewModelScope] (a fire-and-forget QA tap, or a navigating caller that
+     *  pops this VM immediately after). Without [NonCancellable] the DataStore
+     *  write races the scope teardown and can be dropped. */
+    private suspend fun resetOnboardingFlagDurably() =
+        withContext(NonCancellable) { repo.resetOnboardingV1() }
     /** Issue #85 — Voice-Determinism preset (Steady / Expressive). */
     fun setVoiceSteady(enabled: Boolean) = viewModelScope.launch { repo.setVoiceSteady(enabled) }
     /** Issue #1233 — auto-detect language & switch voice (Kokoro). */

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -801,6 +801,10 @@
     <!-- Settings · About → Report objectionable content (#1140, IARC content-rating compliance) -->
     <string name="settings_about_report_content">Report objectionable content</string>
     <string name="settings_about_report_content_subtitle">Flag inappropriate content from third-party sources</string>
+    <!-- Settings · About → Replay the welcome tour (#1558) -->
+    <string name="settings_about_replay_tour">Replay the welcome tour</string>
+    <string name="settings_about_replay_tour_subtitle">Show the first-launch welcome again — no restart needed.</string>
+
     <!-- Settings · About → Open-source licenses (#1142) -->
     <string name="settings_about_licenses">Open-source licenses</string>
     <string name="settings_about_licenses_subtitle">The libraries that power Candela.</string>

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsSearchIndexTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsSearchIndexTest.kt
@@ -93,6 +93,15 @@ class SettingsSearchIndexTest {
     }
 
     @Test
+    fun `replay-tour synonyms surface the About section`() {
+        // #1558 — the "Replay the welcome tour" row lives in the About surface;
+        // its findability synonyms must resolve to About and nowhere spurious.
+        for (q in listOf("welcome", "tour", "wizard", "replay")) {
+            assertEquals("'$q' should surface only About", listOf("About"), matchingLabels(q))
+        }
+    }
+
+    @Test
     fun `every section carries a non-blank label and descriptor`() {
         for (section in SettingsSearchSections) {
             assertFalse("Blank label", section.label.isBlank())


### PR DESCRIPTION
## What
Adds a user-visible **"Replay the welcome tour"** row to the **About** settings surface (`AboutSettingsScreen`).

## How it works (no restart)
- `SettingsViewModel.replayTour(onNavigate)` flips the onboarding flag under **`NonCancellable`**, then invokes the nav callback.
- `StoryvoxNavHost` wires `onReplayTour` to `navigate(LIBRARY) { popUpTo(start, inclusive); launchSingleTop }`, clearing the settings back stack and landing on the start destination.
- `OnboardingHost` is mounted at the nav root and its `shouldShow` is a **reactive** `StateFlow` over `onboardingCompletedV1`, so the welcome overlay re-shows immediately over the clean LIBRARY base — the wizard's own CTAs then navigate normally. **No app restart.**

## Review fix (Gemini HIGH, verified) — race closed
The first cut fired `resetOnboarding()` (a `viewModelScope.launch`) then navigated immediately; the nav-pop clears the ViewModel and cancels `viewModelScope` **mid-DataStore-write**, so the flag could fail to flip and the button intermittently no-op (worst on slow devices). Fixed in the ViewModel: `replayTour()` writes under `NonCancellable` and navigates only **after** the write completes — the ordering race is gone by construction. The shared `resetOnboardingFlagDurably()` helper also hardens the QA `resetOnboarding()` debug path.

## Findability
Added `welcome`, `tour`, `wizard`, `replay` to the **About** section's keywords in `SettingsSearchIndex.kt`, with a test pinning each query resolves to About (and nowhere spurious).

## Debug row (issue point 3) — resolved
#1553 merged mid-flight, freeing `SettingsScreen.kt`. The QA **"Reset onboarding"** row is kept; its stale *"Restart the app to see it"* subtitle is updated to *"appears on the next visit to Library"* (reactive host — no restart), and its write is now cancellation-proof via the shared helper.

Closes #1558
