### PR TITLE
feat(settings): 'Read the handbook' entry point in About (#1563, #1544)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -345,6 +345,17 @@ object StoryvoxRoutes {
     }
 }
 
+/**
+ * Issue #1563 / #1544 — the bundled Candela Handbook's single fiction id, used
+ * by the Settings → About "Read the handbook" deep link. Inlined as a literal
+ * (mirrors OnboardingHost's `notion:guides` constant) so `:app` doesn't take a
+ * compile dependency on `:source-handbook` just for one string. MUST stay equal
+ * to `CandelaHandbookSource.HANDBOOK_FICTION_ID`; the `handbook:` prefix is what
+ * routes the fiction-detail load to the handbook source (a one-grep audit —
+ * this comment — catches a drift if that id ever changes).
+ */
+private const val HANDBOOK_FICTION_ID = "handbook:guide"
+
 @Composable
 fun StoryvoxNavHost(
     navController: NavHostController,
@@ -1473,6 +1484,14 @@ private fun StoryvoxNavHostContent(
                     onOpenLicenses = { navController.navigate(StoryvoxRoutes.SETTINGS_LICENSES) },
                     // Issue #1463 — route into the impact-sharing explainer.
                     onOpenImpactSharing = { navController.navigate(StoryvoxRoutes.SETTINGS_IMPACT_SHARING) },
+                    // Issue #1563 / #1544 — deep-link into the bundled Candela
+                    // Handbook. The id is a string literal (NOT an import of
+                    // source-handbook's CandelaHandbookSource.HANDBOOK_FICTION_ID)
+                    // to avoid an app→source-handbook module dependency; the
+                    // `handbook:` prefix must stay in lockstep with that source's
+                    // SOURCE_ID. The fiction-detail route auto-loads (the prefix
+                    // resolves to the handbook source), so no startListening/seed.
+                    onReadHandbook = { navController.navigate(StoryvoxRoutes.fictionDetail(HANDBOOK_FICTION_ID)) },
                     // Issue #1558 — clear the whole settings back stack down to
                     // the start destination and land on LIBRARY, so the reactive
                     // root-level OnboardingHost re-shows the welcome over a clean

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/AboutSettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/AboutSettingsScreen.kt
@@ -60,6 +60,11 @@ fun AboutSettingsScreen(
     /** Issue #1463 — open the "About impact sharing" explainer subscreen. Default
      *  no-op keeps previews / tests simple; the NavHost passes a real navigate. */
     onOpenImpactSharing: () -> Unit = {},
+    /** Issue #1563 / #1544 — deep-link into the bundled Candela Handbook fiction
+     *  (`handbook:guide`). The NavHost routes to its fiction-detail screen, which
+     *  auto-loads (the `handbook:` id prefix resolves to the handbook source, so
+     *  no pre-seed is needed). Default no-op keeps previews / tests simple. */
+    onReadHandbook: () -> Unit = {},
     /** Issue #1558 — after resetting onboarding, navigate to the LIBRARY route
      *  (the app's start destination) so the root-level [OnboardingHost] — whose
      *  `shouldShow` is a reactive flow — re-shows the welcome overlay over a
@@ -110,6 +115,17 @@ fun AboutSettingsScreen(
                 }
             }
 
+            // Issue #1563 / #1544 — the explicit "Read the handbook" entry point.
+            // Placed first among the link rows: the in-app user guide is the most
+            // useful help affordance to surface. Deep-links to the handbook
+            // fiction's detail page (chapter list), same as tapping its Browse card.
+            SettingsGroupCard {
+                SettingsLinkRow(
+                    title = stringResource(R.string.settings_about_handbook),
+                    subtitle = stringResource(R.string.settings_about_handbook_subtitle),
+                    onClick = onReadHandbook,
+                )
+            }
             SettingsGroupCard {
                 SettingsLinkRow(
                     title = stringResource(R.string.settings_about_privacy_policy),

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -801,6 +801,10 @@
     <!-- Settings · About → Report objectionable content (#1140, IARC content-rating compliance) -->
     <string name="settings_about_report_content">Report objectionable content</string>
     <string name="settings_about_report_content_subtitle">Flag inappropriate content from third-party sources</string>
+    <!-- Settings · About → Read the handbook (#1563 / #1544) -->
+    <string name="settings_about_handbook">Read the handbook</string>
+    <string name="settings_about_handbook_subtitle">The Candela user guide — narrated, and it works offline.</string>
+
     <!-- Settings · About → Replay the welcome tour (#1558) -->
     <string name="settings_about_replay_tour">Replay the welcome tour</string>
     <string name="settings_about_replay_tour_subtitle">Show the first-launch welcome again — no restart needed.</string>


### PR DESCRIPTION
Follow-up to #1544 — the last open sub-item of the in-app Candela Handbook (#1561): the explicit **"Read the handbook"** entry point from Settings → About. Deferred from #1561 to avoid a file collision with #1558 (PR #1559) on `AboutSettingsScreen.kt`; #1559 is now merged.

## Change
- New **"Read the handbook"** row in `AboutSettingsScreen`, placed first among the link rows (the in-app guide is the most useful help affordance to surface).
- `onReadHandbook` nav callback → `navigate(fictionDetail("handbook:guide"))` — the same navigation as tapping the handbook's Browse card.

## Why the detail route is safe (no startListening / no seed)
`refreshDetail` resolves an un-cached fiction's source via its id prefix (`sourceIdForFictionId` → `substringBefore(':')`). Nebula's `CandelaHandbookSource` documents that the `handbook:` prefix **equals** its `SOURCE_ID`, so `handbook:guide` routes to the handbook source and the detail screen auto-loads — **no pre-seed** (unlike onboarding's `notion:guides`→`notion-techempower` mismatch) and **no `startListening`** (the #1343 passive-reader trap is the `/reader` route, not fiction-detail).

## No module coupling
`HANDBOOK_FICTION_ID` is a **string literal** in `:app` (mirrors `OnboardingHost`'s inline `notion:guides`) — `:app` takes no compile dependency on `:source-handbook`. The `handbook:` prefix must stay in lockstep with that source's `SOURCE_ID` (comment cross-references it).

## ⚠️ Merge order
Compiles independently (the id is just a string), but the deep link only **resolves at runtime** once **#1561** (`:source-handbook`) is merged. **Merge #1561 before this.**

Closes #1563
Closes #1544

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Read the handbook” link in the About screen.
  * Users can now open the bundled handbook directly from Settings → About.
  * Added supporting text describing the handbook as available offline and narrated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->