### PR TITLE
feat(docs): multi-page document scanner → shareable PDF (#1513)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/data/docs/PdfDocumentExporter.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/docs/PdfDocumentExporter.kt
@@ -1,0 +1,161 @@
+package `in`.jphe.storyvox.data.docs
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.RectF
+import android.graphics.pdf.PdfDocument
+import android.net.Uri
+import androidx.annotation.VisibleForTesting
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.File
+import java.io.FileOutputStream
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Issue #1513 — production [DocPdfExporter] backed by Android's
+ * [android.graphics.pdf.PdfDocument].
+ *
+ * Each captured page (a `content://`/`file://` image URI) is decoded,
+ * downscaled so its long edge is at most [MAX_EDGE_PX] — the single
+ * biggest lever on output size — and drawn, aspect-fit and centred, onto
+ * a US-Letter PDF page (portrait or landscape to match the scan). The
+ * result is written to `cacheDir/exports/`, which the app's FileProvider
+ * shares via `ACTION_SEND` (authority `${packageName}.fileprovider`,
+ * scoped to `exports/` in `xml/file_paths.xml`).
+ *
+ * Runs entirely on-device (no network); the scanned image, and the PDF
+ * built from it, never leave the phone.
+ */
+@Singleton
+class PdfDocumentExporter @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : DocPdfExporter {
+
+    override suspend fun exportToPdf(request: DocPdfRequest): DocPdfResult =
+        withContext(Dispatchers.IO) {
+            if (request.pages.isEmpty()) {
+                return@withContext DocPdfResult.Failure(
+                    "Add at least one page before exporting.",
+                )
+            }
+            val document = PdfDocument()
+            try {
+                var placed = 0
+                request.pages.forEachIndexed { index, page ->
+                    val bitmap = decodeScaled(Uri.parse(page.uri)) ?: return@forEachIndexed
+                    try {
+                        drawPage(document, bitmap, pageNumber = placed + 1)
+                        placed++
+                    } finally {
+                        bitmap.recycle()
+                    }
+                }
+                if (placed == 0) {
+                    return@withContext DocPdfResult.Failure(
+                        "Couldn't read any of the captured pages. Try re-scanning.",
+                    )
+                }
+                val dir = File(context.cacheDir, EXPORT_DIR).apply { mkdirs() }
+                val fileName = safeFileName(request.title)
+                val outFile = File(dir, fileName)
+                FileOutputStream(outFile).use { document.writeTo(it) }
+                DocPdfResult.Success(
+                    filePath = outFile.absolutePath,
+                    fileName = fileName,
+                    pageCount = placed,
+                    byteSize = outFile.length(),
+                )
+            } catch (t: Throwable) {
+                DocPdfResult.Failure("Couldn't build the PDF. Please try again.", t)
+            } finally {
+                document.close()
+            }
+        }
+
+    /** Draw [bitmap] aspect-fit + centred on a Letter page whose
+     *  orientation matches the bitmap. */
+    private fun drawPage(document: PdfDocument, bitmap: Bitmap, pageNumber: Int) {
+        val landscape = bitmap.width > bitmap.height
+        val pageW = if (landscape) LETTER_LONG_PT else LETTER_SHORT_PT
+        val pageH = if (landscape) LETTER_SHORT_PT else LETTER_LONG_PT
+        val info = PdfDocument.PageInfo.Builder(pageW, pageH, pageNumber).create()
+        val pdfPage = document.startPage(info)
+        val canvas = pdfPage.canvas
+        canvas.drawColor(Color.WHITE)
+        val scale = minOf(pageW.toFloat() / bitmap.width, pageH.toFloat() / bitmap.height)
+        val drawW = bitmap.width * scale
+        val drawH = bitmap.height * scale
+        val left = (pageW - drawW) / 2f
+        val top = (pageH - drawH) / 2f
+        val dst = RectF(left, top, left + drawW, top + drawH)
+        canvas.drawBitmap(bitmap, null, dst, FILTER_PAINT)
+        document.finishPage(pdfPage)
+    }
+
+    /**
+     * Decode [uri] with an `inSampleSize` that keeps the long edge at or
+     * below [MAX_EDGE_PX], then fine-scale if a power-of-two sample left
+     * it oversized. Two-pass (bounds first) so we never allocate the
+     * full-resolution bitmap for an 8-megapixel camera shot.
+     */
+    private fun decodeScaled(uri: Uri): Bitmap? {
+        val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        openStream(uri)?.use { BitmapFactory.decodeStream(it, null, bounds) } ?: return null
+        val longEdge = maxOf(bounds.outWidth, bounds.outHeight)
+        if (longEdge <= 0) return null
+
+        var sample = 1
+        while (longEdge / (sample * 2) >= MAX_EDGE_PX) sample *= 2
+        val opts = BitmapFactory.Options().apply { inSampleSize = sample }
+        val decoded = openStream(uri)?.use { BitmapFactory.decodeStream(it, null, opts) }
+            ?: return null
+
+        val curLong = maxOf(decoded.width, decoded.height)
+        if (curLong <= MAX_EDGE_PX) return decoded
+        val ratio = MAX_EDGE_PX.toFloat() / curLong
+        val scaled = Bitmap.createScaledBitmap(
+            decoded,
+            (decoded.width * ratio).toInt().coerceAtLeast(1),
+            (decoded.height * ratio).toInt().coerceAtLeast(1),
+            true,
+        )
+        if (scaled !== decoded) decoded.recycle()
+        return scaled
+    }
+
+    private fun openStream(uri: Uri) =
+        runCatching { context.contentResolver.openInputStream(uri) }.getOrNull()
+
+    /** Derive a filesystem-safe `.pdf` name from the user's title. */
+    private fun safeFileName(title: String): String {
+        val base = title.trim()
+            .replace(Regex("[^A-Za-z0-9 _-]"), "")
+            .replace(Regex("\\s+"), "-")
+            .take(60)
+            .trim('-')
+            .ifBlank { "Scanned-document" }
+        return "$base.pdf"
+    }
+
+    companion object {
+        /** Longest bitmap edge, in pixels, before drawing into the PDF.
+         *  ~150 DPI on a Letter page — legible for text scans and keeps a
+         *  multi-page packet well under an email-friendly size. */
+        @VisibleForTesting
+        const val MAX_EDGE_PX = 1500
+
+        private const val EXPORT_DIR = "exports"
+
+        // US Letter in PostScript points (1/72"): 8.5" x 11".
+        private const val LETTER_SHORT_PT = 612
+        private const val LETTER_LONG_PT = 792
+
+        private val FILTER_PAINT = Paint(Paint.FILTER_BITMAP_FLAG or Paint.ANTI_ALIAS_FLAG)
+    }
+}

--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -272,6 +272,13 @@ object AppBindings {
     @Provides @Singleton
     fun provideOcrTextRecognizer(impl: `in`.jphe.storyvox.data.ocr.MlKitOcrTextRecognizer): `in`.jphe.storyvox.data.ocr.OcrTextRecognizer = impl
 
+    /** Issue #1513 — bridges the :core-data [DocPdfExporter] seam to the
+     *  Android PdfDocument-backed impl. On-device PDF composition for the
+     *  multi-page document scanner (#1513); reused by the fillable-form
+     *  export (#1512) and the wallet's proof re-export (#1514). */
+    @Provides @Singleton
+    fun provideDocPdfExporter(impl: `in`.jphe.storyvox.data.docs.PdfDocumentExporter): `in`.jphe.storyvox.data.docs.DocPdfExporter = impl
+
     /** Bridges the source-pdf [PdfConfig] read interface (#996) to the
      *  concrete app-side SAF-backed impl. Exposed concretely is not
      *  needed here (the Settings/Browse mutators go through

--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -97,6 +97,12 @@ object StoryvoxRoutes {
      *  Library add-flow ("Scan a page"); CameraX / gallery capture →
      *  on-device ML Kit OCR → a fiction the reader narrates. */
     const val OCR_CAPTURE = "ocr/capture"
+    /** Issue #1513 — multi-page document scanner → shareable PDF ("no
+     *  scanner at home"; benefits paperwork companion, epic #1520).
+     *  Reached from the Library add-flow ("Scan documents to PDF");
+     *  ML Kit Document Scanner / gallery capture → one compact on-device
+     *  PDF the share sheet emails. */
+    const val DOCS_SCAN = "docs/scan"
     const val FICTION_DETAIL = "fiction/{fictionId}"
     const val READER = "reader/{fictionId}/{chapterId}"
     const val AUDIOBOOK = "audiobook/{fictionId}/{chapterId}"
@@ -809,6 +815,9 @@ private fun StoryvoxNavHostContent(
                     // Issue #995 — "Scan a page" add-flow entry routes to
                     // the OCR capture surface.
                     onScanPage = { navController.navigate(StoryvoxRoutes.OCR_CAPTURE) },
+                    // Issue #1513 — "Scan documents to PDF" add-flow entry
+                    // routes to the document scanner (scan → shareable PDF).
+                    onScanDocuments = { navController.navigate(StoryvoxRoutes.DOCS_SCAN) },
                     // v0.5.72 — Browse is a first-class bottom-nav tab
                     // now; the standalone Browse route owns RR + AO3
                     // sign-in deep-links. Follows is still embedded
@@ -891,6 +900,18 @@ private fun StoryvoxNavHostContent(
                             popUpTo(StoryvoxRoutes.OCR_CAPTURE) { inclusive = true }
                         }
                     },
+                )
+            }
+            composable(
+                // Issue #1513 — document scanner → shareable PDF.
+                StoryvoxRoutes.DOCS_SCAN,
+                enterTransition = pushEnter,
+                exitTransition = pushExit,
+                popEnterTransition = popEnter,
+                popExitTransition = popExit,
+            ) {
+                `in`.jphe.storyvox.feature.docs.DocScanScreen(
+                    onNavigateBack = { navController.popBackStack() },
                 )
             }
             composable(

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/docs/DocPdfExporter.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/docs/DocPdfExporter.kt
@@ -1,0 +1,81 @@
+package `in`.jphe.storyvox.data.docs
+
+/**
+ * Issue #1513 — on-device seam that composes captured page images into
+ * one compact, shareable PDF ("no scanner at home").
+ *
+ * The production implementation (`PdfDocumentExporter` in `:app`) draws
+ * each page bitmap onto an `android.graphics.pdf.PdfDocument`,
+ * downscaling so the result stays email-sized (~100-300 KB/page). It
+ * runs entirely on-device: nothing about the user's scanned ID / pay
+ * stub / award letter leaves the phone — the same promise as
+ * techempower.org/qualify.
+ *
+ * ## Why this lives in :core-data
+ *
+ * The document scanner (#1513) and the photo→fillable-PDF flow (#1512)
+ * both need PDF composition, and the encrypted wallet (#1514) re-exports
+ * stored proofs the same way. Putting the seam here — alongside
+ * [`in`.jphe.storyvox.data.ocr.OcrTextRecognizer] — lets the
+ * `:feature` UI depend on the contract without pulling any
+ * `android.graphics.*` type into the ViewModel, so the VM stays plain
+ * JVM and unit-testable with a fake exporter (no Robolectric).
+ *
+ * ## Android-types-free by design
+ *
+ * Pages are addressed by their `content://` / `file://` URI **as a
+ * String** ([DocPageRef.uri]), never as an `android.net.Uri`. The
+ * Android impl parses the string and resolves the bytes through the
+ * `ContentResolver` on its side.
+ */
+interface DocPdfExporter {
+
+    /**
+     * Compose [request]'s pages, in order, into a single PDF written to
+     * the app's private export cache. Runs on a background dispatcher.
+     * Never throws — undecodable pages are skipped, and a request that
+     * yields zero usable pages returns [DocPdfResult.Failure].
+     */
+    suspend fun exportToPdf(request: DocPdfRequest): DocPdfResult
+}
+
+/**
+ * One export job: a human [title] (used to name the output file) and the
+ * ordered [pages] to place, one per PDF page.
+ */
+data class DocPdfRequest(
+    val title: String,
+    val pages: List<DocPageRef>,
+)
+
+/**
+ * A single page image to place in the PDF, addressed by its
+ * `content://` or `file://` URI string. Kept a String (not
+ * `android.net.Uri`) so the seam carries no Android type — see the
+ * class KDoc on [DocPdfExporter].
+ */
+data class DocPageRef(val uri: String)
+
+/** Result of one [DocPdfExporter.exportToPdf] call. */
+sealed interface DocPdfResult {
+
+    /**
+     * PDF written successfully. [filePath] is the absolute path under
+     * the app's export cache (`cacheDir/exports/`), which the
+     * FileProvider shares via `ACTION_SEND`. [byteSize] is the finished
+     * file size so the UI can reassure the user it is email-sized.
+     */
+    data class Success(
+        val filePath: String,
+        val fileName: String,
+        val pageCount: Int,
+        val byteSize: Long,
+    ) : DocPdfResult
+
+    /**
+     * Export could not produce a usable PDF (no pages, all pages
+     * undecodable, or an I/O failure). [message] is user-facing;
+     * [cause] carries the original throwable for logging.
+     */
+    data class Failure(val message: String, val cause: Throwable? = null) : DocPdfResult
+}

--- a/feature/build.gradle.kts
+++ b/feature/build.gradle.kts
@@ -89,6 +89,11 @@ dependencies {
     // the capture surface (camera-view's PreviewView + CameraController).
     implementation(project(":source-ocr"))
     implementation(libs.bundles.camerax)
+    // #1513 — ML Kit Document Scanner (Play services) drives the
+    // scan-to-PDF capture UI (edge detection + shadow removal + multipage).
+    // No camera permission needed; de-Googled devices use the gallery-pick
+    // fallback in DocScanScreen.
+    implementation(libs.mlkit.document.scanner)
     // Issue #1367 — Recording mode adds video capture on top of the OCR
     // preview stack: LifecycleCameraController.startRecording needs the
     // camera-video artifact (Recorder / MediaStoreOutputOptions / AudioConfig).

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/docs/DocScanScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/docs/DocScanScreen.kt
@@ -1,0 +1,447 @@
+package `in`.jphe.storyvox.feature.docs
+
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.Intent
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.IntentSenderRequest
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material.icons.filled.PhotoLibrary
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import androidx.core.content.FileProvider
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import coil3.compose.AsyncImage
+import com.google.mlkit.vision.documentscanner.GmsDocumentScannerOptions
+import com.google.mlkit.vision.documentscanner.GmsDocumentScanning
+import com.google.mlkit.vision.documentscanner.GmsDocumentScanningResult
+import `in`.jphe.storyvox.feature.R
+import `in`.jphe.storyvox.ui.component.BrassButton
+import `in`.jphe.storyvox.ui.component.BrassButtonVariant
+import `in`.jphe.storyvox.ui.theme.LocalSpacing
+import java.io.File
+import java.util.Locale
+
+/**
+ * Issue #1513 — multi-page document scanner → clean shareable PDF
+ * ("no scanner at home"). The capture foundation of the benefits
+ * paperwork companion (epic #1520).
+ *
+ * Two capture paths:
+ *  1. **ML Kit Document Scanner** (primary) — Play-services capture UI
+ *     with edge detection, perspective crop, shadow removal, multipage.
+ *     Runs on-device; needs no camera permission (Play services owns the
+ *     camera). Returns cleaned page images.
+ *  2. **Gallery pick** (fallback) — the system Photo Picker, for
+ *     de-Googled devices where the scanner client can't start, or for
+ *     photos already on the device.
+ *
+ * Captured pages accumulate in [DocScanViewModel]; the user reorders /
+ * deletes them in a **list** (the TalkBack-friendly alternative to a
+ * spatial drag grid), names the document, and exports one compact PDF
+ * via the on-device [`in`.jphe.storyvox.data.docs.DocPdfExporter] seam.
+ * The finished PDF is shared through the app FileProvider with
+ * `ACTION_SEND`. Nothing about the document leaves the phone.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DocScanScreen(
+    onNavigateBack: () -> Unit,
+    viewModel: DocScanViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+    val spacing = LocalSpacing.current
+    val shareChooserTitle = stringResource(R.string.docs_scan_share_chooser)
+
+    // ── ML Kit Document Scanner launcher ───────────────────────────────
+    val scannerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.StartIntentSenderForResult(),
+    ) { result ->
+        if (result.resultCode == Activity.RESULT_OK) {
+            val scanResult = GmsDocumentScanningResult.fromActivityResultIntent(result.data)
+            val uris = scanResult?.pages?.mapNotNull { it.imageUri?.toString() } ?: emptyList()
+            viewModel.onPagesCaptured(uris)
+        }
+    }
+
+    // ── Gallery multi-pick fallback (permissionless Photo Picker) ───────
+    val galleryLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.PickMultipleVisualMedia(),
+    ) { uris: List<Uri> ->
+        viewModel.onPagesCaptured(uris.map { it.toString() })
+    }
+
+    fun launchScanner() {
+        val activity = context.findActivity()
+        if (activity == null) {
+            viewModel.onScannerUnavailable()
+            return
+        }
+        val options = GmsDocumentScannerOptions.Builder()
+            .setGalleryImportAllowed(true)
+            .setResultFormats(GmsDocumentScannerOptions.RESULT_FORMAT_JPEG)
+            .setScannerMode(GmsDocumentScannerOptions.SCANNER_MODE_FULL)
+            .build()
+        GmsDocumentScanning.getClient(options)
+            .getStartScanIntent(activity)
+            .addOnSuccessListener { intentSender ->
+                scannerLauncher.launch(IntentSenderRequest.Builder(intentSender).build())
+            }
+            .addOnFailureListener { viewModel.onScannerUnavailable() }
+    }
+
+    // One-shot: fire the share sheet when an export completes.
+    LaunchedEffect(state.shareRequest) {
+        state.shareRequest?.let { ready ->
+            sharePdf(context, ready.filePath, ready.fileName, shareChooserTitle)
+            viewModel.onShareHandled()
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.docs_scan_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.docs_scan_back_cd),
+                        )
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .padding(horizontal = spacing.md),
+            verticalArrangement = Arrangement.spacedBy(spacing.md),
+            contentPadding = androidx.compose.foundation.layout.PaddingValues(vertical = spacing.md),
+        ) {
+            item {
+                Text(
+                    stringResource(R.string.docs_scan_intro),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            // ── Capture actions ────────────────────────────────────────
+            item {
+                Column(verticalArrangement = Arrangement.spacedBy(spacing.sm)) {
+                    BrassButton(
+                        label = stringResource(R.string.docs_scan_button),
+                        onClick = { launchScanner() },
+                        variant = BrassButtonVariant.Primary,
+                        enabled = !state.isExporting,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        BrassButton(
+                            label = stringResource(R.string.docs_scan_pick_gallery),
+                            onClick = {
+                                galleryLauncher.launch(
+                                    PickVisualMediaRequest(
+                                        ActivityResultContracts.PickVisualMedia.ImageOnly,
+                                    ),
+                                )
+                            },
+                            variant = BrassButtonVariant.Secondary,
+                            enabled = !state.isExporting,
+                            modifier = Modifier.weight(1f),
+                        )
+                        Icon(
+                            Icons.Filled.PhotoLibrary,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+
+            if (state.scannerUnavailable) {
+                item { InfoCard(text = stringResource(R.string.docs_scan_scanner_unavailable)) }
+            }
+
+            // Privacy reassurance (invariant #1 — on-device only).
+            item { InfoCard(text = stringResource(R.string.docs_scan_privacy_note)) }
+
+            state.error?.let { err ->
+                item {
+                    Surface(
+                        color = MaterialTheme.colorScheme.errorContainer,
+                        shape = RoundedCornerShape(12.dp),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .semantics { liveRegion = LiveRegionMode.Assertive },
+                    ) {
+                        Text(
+                            err,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onErrorContainer,
+                            modifier = Modifier.padding(spacing.md),
+                        )
+                    }
+                }
+            }
+
+            if (state.pages.isEmpty()) {
+                item {
+                    Text(
+                        stringResource(R.string.docs_scan_empty),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            } else {
+                item {
+                    OutlinedTextField(
+                        value = state.title,
+                        onValueChange = viewModel::onTitleChanged,
+                        label = { Text(stringResource(R.string.docs_scan_title_label)) },
+                        singleLine = true,
+                        enabled = !state.isExporting,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+                item {
+                    Text(
+                        pluralStringResource(
+                            R.plurals.docs_scan_pages_ready,
+                            state.pageCount,
+                            state.pageCount,
+                        ),
+                        style = MaterialTheme.typography.labelLarge,
+                        // a11y — re-announce the tally after each capture /
+                        // reorder / delete so a non-visual user hears it.
+                        modifier = Modifier.semantics { liveRegion = LiveRegionMode.Polite },
+                    )
+                }
+                itemsIndexed(state.pages, key = { _, page -> page.id }) { index, page ->
+                    PageRow(
+                        pageNumber = index + 1,
+                        uri = page.uri,
+                        isFirst = index == 0,
+                        isLast = index == state.pages.lastIndex,
+                        enabled = !state.isExporting,
+                        onMoveUp = { viewModel.movePageUp(page.id) },
+                        onMoveDown = { viewModel.movePageDown(page.id) },
+                        onRemove = { viewModel.removePage(page.id) },
+                    )
+                }
+                item {
+                    BrassButton(
+                        label = stringResource(
+                            if (state.isExporting) R.string.docs_scan_exporting else R.string.docs_scan_export,
+                        ),
+                        onClick = viewModel::export,
+                        variant = BrassButtonVariant.Primary,
+                        enabled = state.canExport,
+                        loading = state.isExporting,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+                state.exportResult?.let { ready ->
+                    item {
+                        Surface(
+                            color = MaterialTheme.colorScheme.secondaryContainer,
+                            shape = RoundedCornerShape(12.dp),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .semantics { liveRegion = LiveRegionMode.Polite },
+                        ) {
+                            Column(
+                                modifier = Modifier.padding(spacing.md),
+                                verticalArrangement = Arrangement.spacedBy(spacing.sm),
+                            ) {
+                                Text(
+                                    stringResource(
+                                        R.string.docs_scan_exported,
+                                        ready.fileName,
+                                        formatBytes(ready.byteSize),
+                                    ),
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                                )
+                                BrassButton(
+                                    label = stringResource(R.string.docs_scan_share_again),
+                                    onClick = viewModel::shareAgain,
+                                    variant = BrassButtonVariant.Secondary,
+                                    modifier = Modifier.fillMaxWidth(),
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/** One page row: thumbnail + "Page N" + reorder/delete controls. A list
+ *  (not a spatial grid) so it is fully reachable and labeled under
+ *  TalkBack (invariant #4). */
+@Composable
+private fun PageRow(
+    pageNumber: Int,
+    uri: String,
+    isFirst: Boolean,
+    isLast: Boolean,
+    enabled: Boolean,
+    onMoveUp: () -> Unit,
+    onMoveDown: () -> Unit,
+    onRemove: () -> Unit,
+) {
+    val spacing = LocalSpacing.current
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        shape = RoundedCornerShape(12.dp),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = spacing.md, vertical = spacing.sm),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+        ) {
+            AsyncImage(
+                model = uri,
+                contentDescription = null, // decorative; the label text carries the page number
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .size(48.dp, 64.dp)
+                    .clip(RoundedCornerShape(6.dp)),
+            )
+            Text(
+                stringResource(R.string.docs_scan_page_label, pageNumber),
+                style = MaterialTheme.typography.titleSmall,
+                modifier = Modifier.weight(1f),
+            )
+            IconButton(onClick = onMoveUp, enabled = enabled && !isFirst) {
+                Icon(
+                    Icons.Filled.KeyboardArrowUp,
+                    contentDescription = stringResource(R.string.docs_scan_move_up_cd, pageNumber),
+                )
+            }
+            IconButton(onClick = onMoveDown, enabled = enabled && !isLast) {
+                Icon(
+                    Icons.Filled.KeyboardArrowDown,
+                    contentDescription = stringResource(R.string.docs_scan_move_down_cd, pageNumber),
+                )
+            }
+            IconButton(onClick = onRemove, enabled = enabled) {
+                Icon(
+                    Icons.Filled.Delete,
+                    contentDescription = stringResource(R.string.docs_scan_remove_cd, pageNumber),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun InfoCard(text: String) {
+    val spacing = LocalSpacing.current
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        shape = RoundedCornerShape(12.dp),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Text(
+            text,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(spacing.md),
+        )
+    }
+}
+
+/** Unwrap the Activity from the Compose LocalContext (needed by ML Kit's
+ *  getStartScanIntent). */
+private fun Context.findActivity(): Activity? {
+    var ctx: Context? = this
+    while (ctx is ContextWrapper) {
+        if (ctx is Activity) return ctx
+        ctx = ctx.baseContext
+    }
+    return null
+}
+
+/** Share the finished PDF via the app FileProvider (mirrors
+ *  CreateAudiobookSheet.shareAudiobook). */
+private fun sharePdf(context: Context, filePath: String, fileName: String, chooserTitle: String) {
+    val uri = FileProvider.getUriForFile(
+        context,
+        "${context.packageName}.fileprovider",
+        File(filePath),
+    )
+    val send = Intent(Intent.ACTION_SEND).apply {
+        type = "application/pdf"
+        putExtra(Intent.EXTRA_STREAM, uri)
+        putExtra(Intent.EXTRA_TITLE, fileName)
+        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+    }
+    context.startActivity(
+        Intent.createChooser(send, chooserTitle).also {
+            it.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        },
+    )
+}
+
+/** Human-readable byte size ("245 KB" / "1.2 MB"). */
+private fun formatBytes(bytes: Long): String = when {
+    bytes >= 1_000_000L -> String.format(Locale.US, "%.1f MB", bytes / 1_000_000.0)
+    bytes >= 1_000L -> "${bytes / 1_000L} KB"
+    else -> "$bytes B"
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/docs/DocScanViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/docs/DocScanViewModel.kt
@@ -1,0 +1,191 @@
+package `in`.jphe.storyvox.feature.docs
+
+import androidx.compose.runtime.Immutable
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import `in`.jphe.storyvox.data.docs.DocPageRef
+import `in`.jphe.storyvox.data.docs.DocPdfExporter
+import `in`.jphe.storyvox.data.docs.DocPdfRequest
+import `in`.jphe.storyvox.data.docs.DocPdfResult
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * Issue #1513 — drives the multi-page document scanner → shareable PDF
+ * flow ("no scanner at home").
+ *
+ * The screen captures pages (ML Kit Document Scanner, or a gallery pick
+ * fallback on de-Googled devices) and hands their image URIs to
+ * [onPagesCaptured]. This VM accumulates them, lets the user reorder /
+ * delete before export, and composes them into one compact PDF through
+ * the on-device [DocPdfExporter] seam. The export result carries the
+ * finished file path, which the screen shares via `ACTION_SEND`.
+ *
+ * All Android / ML Kit specifics live in the screen and behind the
+ * [DocPdfExporter] interface, so this VM is plain JVM logic and
+ * unit-testable with a fake exporter (no Robolectric) — the same posture
+ * as [`in`.jphe.storyvox.feature.ocr.OcrCaptureViewModel].
+ */
+@HiltViewModel
+class DocScanViewModel @Inject constructor(
+    private val exporter: DocPdfExporter,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(DocScanUiState())
+    val state: StateFlow<DocScanUiState> = _state.asStateFlow()
+
+    /** Append freshly captured / picked page images, in the order given. */
+    fun onPagesCaptured(uris: List<String>) {
+        val clean = uris.filter { it.isNotBlank() }
+        if (clean.isEmpty()) return
+        _state.update { prev ->
+            var nextId = prev.nextId
+            val added = clean.map { DocScanPage(id = nextId++, uri = it) }
+            prev.copy(
+                pages = prev.pages + added,
+                nextId = nextId,
+                error = null,
+                // A new capture invalidates any prior export.
+                exportResult = null,
+                shareRequest = null,
+            )
+        }
+    }
+
+    /** The scanner client couldn't start (Play services missing / a
+     *  de-Googled device). Surface the fallback hint; the gallery-pick
+     *  path stays available. */
+    fun onScannerUnavailable() {
+        _state.update { it.copy(scannerUnavailable = true) }
+    }
+
+    /** Update the user-editable document title (names the exported file). */
+    fun onTitleChanged(title: String) {
+        _state.update { it.copy(title = title) }
+    }
+
+    /** Drop a page (a bad shot, or a duplicate). */
+    fun removePage(id: Int) {
+        _state.update { prev ->
+            prev.copy(
+                pages = prev.pages.filterNot { it.id == id },
+                exportResult = null,
+                shareRequest = null,
+            )
+        }
+    }
+
+    /** Move a page one slot earlier (list-based reorder — the
+     *  TalkBack-friendly alternative to a drag handle). No-op at the top. */
+    fun movePageUp(id: Int) = reorder(id, -1)
+
+    /** Move a page one slot later. No-op at the bottom. */
+    fun movePageDown(id: Int) = reorder(id, +1)
+
+    private fun reorder(id: Int, delta: Int) {
+        _state.update { prev ->
+            val list = prev.pages
+            val i = list.indexOfFirst { it.id == id }
+            val j = i + delta
+            if (i < 0 || j < 0 || j > list.lastIndex) return@update prev
+            val mutable = list.toMutableList()
+            mutable[i] = mutable[j].also { mutable[j] = mutable[i] }
+            prev.copy(pages = mutable, exportResult = null, shareRequest = null)
+        }
+    }
+
+    /** Compose the accumulated pages into a single PDF and, on success,
+     *  raise a one-shot [DocScanUiState.shareRequest] the screen consumes
+     *  to open the share sheet. */
+    fun export() {
+        val snapshot = _state.value
+        if (snapshot.pages.isEmpty() || snapshot.isExporting) return
+        _state.update { it.copy(isExporting = true, error = null) }
+        viewModelScope.launch {
+            val request = DocPdfRequest(
+                title = snapshot.title.ifBlank { DEFAULT_TITLE }.trim(),
+                pages = snapshot.pages.map { DocPageRef(it.uri) },
+            )
+            when (val result = exporter.exportToPdf(request)) {
+                is DocPdfResult.Success -> {
+                    val ready = DocExportReady(
+                        filePath = result.filePath,
+                        fileName = result.fileName,
+                        pageCount = result.pageCount,
+                        byteSize = result.byteSize,
+                    )
+                    _state.update {
+                        it.copy(isExporting = false, exportResult = ready, shareRequest = ready)
+                    }
+                }
+
+                is DocPdfResult.Failure -> _state.update {
+                    it.copy(isExporting = false, error = result.message)
+                }
+            }
+        }
+    }
+
+    /** Re-open the share sheet for an already-exported PDF. */
+    fun shareAgain() {
+        _state.update { it.copy(shareRequest = it.exportResult) }
+    }
+
+    /** Consume the one-shot share signal after the chooser is launched. */
+    fun onShareHandled() {
+        _state.update { it.copy(shareRequest = null) }
+    }
+
+    /** Clear a surfaced error once acknowledged. */
+    fun clearError() {
+        _state.update { it.copy(error = null) }
+    }
+
+    private companion object {
+        const val DEFAULT_TITLE = "Scanned document"
+    }
+}
+
+/** UI state for the document-scanner screen. */
+@Immutable
+data class DocScanUiState(
+    val title: String = "",
+    val pages: List<DocScanPage> = emptyList(),
+    val isExporting: Boolean = false,
+    /** True once a scanner launch failed — the UI leans on gallery pick. */
+    val scannerUnavailable: Boolean = false,
+    /** User-facing recoverable error (export failed). */
+    val error: String? = null,
+    /** The most recent successful export (drives the "Share again" row). */
+    val exportResult: DocExportReady? = null,
+    /** One-shot: non-null exactly until the screen fires the share sheet,
+     *  then cleared via [DocScanViewModel.onShareHandled]. */
+    val shareRequest: DocExportReady? = null,
+    /** Monotonic id source for [DocScanPage]s. */
+    val nextId: Int = 0,
+) {
+    val canExport: Boolean get() = pages.isNotEmpty() && !isExporting
+    val pageCount: Int get() = pages.size
+}
+
+/** One captured page held in the scan session. [uri] is a
+ *  `content://`/`file://` image URI string. */
+@Immutable
+data class DocScanPage(
+    val id: Int,
+    val uri: String,
+)
+
+/** A finished PDF ready to share. */
+@Immutable
+data class DocExportReady(
+    val filePath: String,
+    val fileName: String,
+    val pageCount: Int,
+    val byteSize: Long,
+)

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
@@ -147,6 +147,13 @@ fun LibraryScreen(
      * test / preview surfaces that don't exercise it still compile.
      */
     onScanPage: () -> Unit = {},
+    /**
+     * Issue #1513 — "Scan documents to PDF" add-flow entry. Routes to the
+     * document scanner ([StoryvoxRoutes.DOCS_SCAN]) — the "no scanner at
+     * home" benefits-paperwork flow. Default no-op so test / preview
+     * surfaces that don't exercise it still compile.
+     */
+    onScanDocuments: () -> Unit = {},
     viewModel: LibraryViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -344,6 +351,16 @@ fun LibraryScreen(
                                         "text/*",
                                     ),
                                 )
+                            },
+                        )
+                        // Issue #1513 — "no scanner at home": scan a paper
+                        // packet into one shareable PDF (benefits paperwork
+                        // companion, epic #1520).
+                        androidx.compose.material3.DropdownMenuItem(
+                            text = { Text(stringResource(R.string.library_scan_documents)) },
+                            onClick = {
+                                addMenuOpen = false
+                                onScanDocuments()
                             },
                         )
                     }

--- a/feature/src/main/res/values-es/strings.xml
+++ b/feature/src/main/res/values-es/strings.xml
@@ -12,28 +12,31 @@
 -->
 <resources>
 
-    <!-- #1513: multi-page document scanner → shareable PDF -->
-    <string name="docs_scan_title">Escanear documentos</string>
+    <!-- #1513: multi-page document scanner → shareable PDF. Keys
+         alphabetical, same order as values/strings.xml; wrapped so
+         cross-lane rebases are mechanical. -->
     <string name="docs_scan_back_cd">Atrás</string>
-    <string name="docs_scan_intro">Convierte una pila de papeles en un solo PDF que puedes enviar por correo, sin necesidad de escáner. Las páginas se limpian y se combinan en tu dispositivo.</string>
     <string name="docs_scan_button">Escanear páginas</string>
-    <string name="docs_scan_pick_gallery">Añadir desde fotos</string>
-    <string name="docs_scan_scanner_unavailable">El escáner de documentos no está disponible en este dispositivo. Aún puedes añadir fotos de páginas desde tu galería.</string>
     <string name="docs_scan_empty">Aún no hay páginas. Toca «Escanear páginas» para capturar un documento, o añade fotos desde tu galería.</string>
-    <string name="docs_scan_page_label">Página %1$d</string>
-    <string name="docs_scan_move_up_cd">Mover la página %1$d hacia arriba</string>
+    <string name="docs_scan_export">Exportar y compartir PDF</string>
+    <string name="docs_scan_exported">Guardado %1$s · %2$s</string>
+    <string name="docs_scan_exporting">Creando tu PDF…</string>
+    <string name="docs_scan_intro">Convierte una pila de papeles en un solo PDF que puedes enviar por correo, sin necesidad de escáner. Las páginas se limpian y se combinan en tu dispositivo.</string>
     <string name="docs_scan_move_down_cd">Mover la página %1$d hacia abajo</string>
-    <string name="docs_scan_remove_cd">Eliminar la página %1$d</string>
-    <string name="docs_scan_title_label">Nombre del documento</string>
+    <string name="docs_scan_move_up_cd">Mover la página %1$d hacia arriba</string>
+    <string name="docs_scan_page_label">Página %1$d</string>
     <plurals name="docs_scan_pages_ready">
         <item quantity="one">%1$d página lista</item>
         <item quantity="other">%1$d páginas listas</item>
     </plurals>
-    <string name="docs_scan_export">Exportar y compartir PDF</string>
-    <string name="docs_scan_exporting">Creando tu PDF…</string>
-    <string name="docs_scan_exported">Guardado %1$s · %2$s</string>
+    <string name="docs_scan_pick_gallery">Añadir desde fotos</string>
+    <string name="docs_scan_privacy_note">El escaneo y la creación del PDF ocurren en tu dispositivo. Tus documentos nunca salen de tu teléfono.</string>
+    <string name="docs_scan_remove_cd">Eliminar la página %1$d</string>
+    <string name="docs_scan_scanner_unavailable">El escáner de documentos no está disponible en este dispositivo. Aún puedes añadir fotos de páginas desde tu galería.</string>
     <string name="docs_scan_share_again">Compartir de nuevo</string>
     <string name="docs_scan_share_chooser">Compartir PDF</string>
-    <string name="docs_scan_privacy_note">El escaneo y la creación del PDF ocurren en tu dispositivo. Tus documentos nunca salen de tu teléfono.</string>
+    <string name="docs_scan_title">Escanear documentos</string>
+    <string name="docs_scan_title_label">Nombre del documento</string>
     <string name="library_scan_documents">Escanear documentos a PDF</string>
+    <!-- /#1513 -->
 </resources>

--- a/feature/src/main/res/values-es/strings.xml
+++ b/feature/src/main/res/values-es/strings.xml
@@ -17,9 +17,7 @@
     <string name="docs_scan_back_cd">Atrás</string>
     <string name="docs_scan_intro">Convierte una pila de papeles en un solo PDF que puedes enviar por correo, sin necesidad de escáner. Las páginas se limpian y se combinan en tu dispositivo.</string>
     <string name="docs_scan_button">Escanear páginas</string>
-    <string name="docs_scan_button_cd">Abrir el escáner de documentos</string>
     <string name="docs_scan_pick_gallery">Añadir desde fotos</string>
-    <string name="docs_scan_pick_gallery_cd">Añadir fotos de páginas desde tu galería</string>
     <string name="docs_scan_scanner_unavailable">El escáner de documentos no está disponible en este dispositivo. Aún puedes añadir fotos de páginas desde tu galería.</string>
     <string name="docs_scan_empty">Aún no hay páginas. Toca «Escanear páginas» para capturar un documento, o añade fotos desde tu galería.</string>
     <string name="docs_scan_page_label">Página %1$d</string>

--- a/feature/src/main/res/values-es/strings.xml
+++ b/feature/src/main/res/values-es/strings.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Spanish (es) translations for Candela's :feature module.
+
+    Bootstrapped in #1513 (benefits paperwork companion, epic #1520) — the
+    first Spanish locale in the app. It intentionally contains ONLY the
+    keys that have been translated so far; Android falls back to the
+    default (values/) strings for every untranslated key, so a partial
+    file is correct and does not break the build. Add new keys here in the
+    SAME PR that adds them to values/strings.xml (bilingual-at-launch is a
+    hard invariant for every benefits surface).
+-->
+<resources>
+
+    <!-- #1513: multi-page document scanner → shareable PDF -->
+    <string name="docs_scan_title">Escanear documentos</string>
+    <string name="docs_scan_back_cd">Atrás</string>
+    <string name="docs_scan_intro">Convierte una pila de papeles en un solo PDF que puedes enviar por correo, sin necesidad de escáner. Las páginas se limpian y se combinan en tu dispositivo.</string>
+    <string name="docs_scan_button">Escanear páginas</string>
+    <string name="docs_scan_button_cd">Abrir el escáner de documentos</string>
+    <string name="docs_scan_pick_gallery">Añadir desde fotos</string>
+    <string name="docs_scan_pick_gallery_cd">Añadir fotos de páginas desde tu galería</string>
+    <string name="docs_scan_scanner_unavailable">El escáner de documentos no está disponible en este dispositivo. Aún puedes añadir fotos de páginas desde tu galería.</string>
+    <string name="docs_scan_empty">Aún no hay páginas. Toca «Escanear páginas» para capturar un documento, o añade fotos desde tu galería.</string>
+    <string name="docs_scan_page_label">Página %1$d</string>
+    <string name="docs_scan_move_up_cd">Mover la página %1$d hacia arriba</string>
+    <string name="docs_scan_move_down_cd">Mover la página %1$d hacia abajo</string>
+    <string name="docs_scan_remove_cd">Eliminar la página %1$d</string>
+    <string name="docs_scan_title_label">Nombre del documento</string>
+    <plurals name="docs_scan_pages_ready">
+        <item quantity="one">%1$d página lista</item>
+        <item quantity="other">%1$d páginas listas</item>
+    </plurals>
+    <string name="docs_scan_export">Exportar y compartir PDF</string>
+    <string name="docs_scan_exporting">Creando tu PDF…</string>
+    <string name="docs_scan_exported">Guardado %1$s · %2$s</string>
+    <string name="docs_scan_share_again">Compartir de nuevo</string>
+    <string name="docs_scan_share_chooser">Compartir PDF</string>
+    <string name="docs_scan_privacy_note">El escaneo y la creación del PDF ocurren en tu dispositivo. Tus documentos nunca salen de tu teléfono.</string>
+    <string name="library_scan_documents">Escanear documentos a PDF</string>
+</resources>

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -1253,27 +1253,28 @@
          home"). Benefits paperwork companion (epic #1520). Capture happens
          on-device via the ML Kit Document Scanner (Play services); PDF
          composition is on-device too — no content leaves the phone. -->
-    <string name="docs_scan_title">Scan documents</string>
     <string name="docs_scan_back_cd">Back</string>
-    <string name="docs_scan_intro">Turn a stack of paper into one clean PDF you can email — no scanner needed. Pages are cleaned up and combined on your device.</string>
     <string name="docs_scan_button">Scan pages</string>
-    <string name="docs_scan_pick_gallery">Add from photos</string>
-    <string name="docs_scan_scanner_unavailable">The document scanner isn\'t available on this device. You can still add page photos from your gallery.</string>
     <string name="docs_scan_empty">No pages yet. Tap “Scan pages” to capture a document, or add photos from your gallery.</string>
-    <string name="docs_scan_page_label">Page %1$d</string>
-    <string name="docs_scan_move_up_cd">Move page %1$d up</string>
+    <string name="docs_scan_export">Export &amp; share PDF</string>
+    <string name="docs_scan_exported">Saved %1$s · %2$s</string>
+    <string name="docs_scan_exporting">Building your PDF…</string>
+    <string name="docs_scan_intro">Turn a stack of paper into one clean PDF you can email — no scanner needed. Pages are cleaned up and combined on your device.</string>
     <string name="docs_scan_move_down_cd">Move page %1$d down</string>
-    <string name="docs_scan_remove_cd">Remove page %1$d</string>
-    <string name="docs_scan_title_label">Document name</string>
+    <string name="docs_scan_move_up_cd">Move page %1$d up</string>
+    <string name="docs_scan_page_label">Page %1$d</string>
     <plurals name="docs_scan_pages_ready">
         <item quantity="one">%1$d page ready</item>
         <item quantity="other">%1$d pages ready</item>
     </plurals>
-    <string name="docs_scan_export">Export &amp; share PDF</string>
-    <string name="docs_scan_exporting">Building your PDF…</string>
-    <string name="docs_scan_exported">Saved %1$s · %2$s</string>
+    <string name="docs_scan_pick_gallery">Add from photos</string>
+    <string name="docs_scan_privacy_note">Scanning and PDF creation happen on your device. Your documents never leave your phone.</string>
+    <string name="docs_scan_remove_cd">Remove page %1$d</string>
+    <string name="docs_scan_scanner_unavailable">The document scanner isn\'t available on this device. You can still add page photos from your gallery.</string>
     <string name="docs_scan_share_again">Share again</string>
     <string name="docs_scan_share_chooser">Share PDF</string>
-    <string name="docs_scan_privacy_note">Scanning and PDF creation happen on your device. Your documents never leave your phone.</string>
+    <string name="docs_scan_title">Scan documents</string>
+    <string name="docs_scan_title_label">Document name</string>
     <string name="library_scan_documents">Scan documents to PDF</string>
+    <!-- /#1513 -->
 </resources>

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -1248,4 +1248,34 @@
     <!-- #1268 — onClickLabel: the dependency-name link opens its license page
          in a browser; the visible text is just the name, so describe the action. -->
     <string name="oss_open_license_page">Open license page in browser</string>
+
+    <!-- #1513: multi-page document scanner → shareable PDF ("no scanner at
+         home"). Benefits paperwork companion (epic #1520). Capture happens
+         on-device via the ML Kit Document Scanner (Play services); PDF
+         composition is on-device too — no content leaves the phone. -->
+    <string name="docs_scan_title">Scan documents</string>
+    <string name="docs_scan_back_cd">Back</string>
+    <string name="docs_scan_intro">Turn a stack of paper into one clean PDF you can email — no scanner needed. Pages are cleaned up and combined on your device.</string>
+    <string name="docs_scan_button">Scan pages</string>
+    <string name="docs_scan_button_cd">Open the document scanner</string>
+    <string name="docs_scan_pick_gallery">Add from photos</string>
+    <string name="docs_scan_pick_gallery_cd">Add page photos from your gallery</string>
+    <string name="docs_scan_scanner_unavailable">The document scanner isn\'t available on this device. You can still add page photos from your gallery.</string>
+    <string name="docs_scan_empty">No pages yet. Tap “Scan pages” to capture a document, or add photos from your gallery.</string>
+    <string name="docs_scan_page_label">Page %1$d</string>
+    <string name="docs_scan_move_up_cd">Move page %1$d up</string>
+    <string name="docs_scan_move_down_cd">Move page %1$d down</string>
+    <string name="docs_scan_remove_cd">Remove page %1$d</string>
+    <string name="docs_scan_title_label">Document name</string>
+    <plurals name="docs_scan_pages_ready">
+        <item quantity="one">%1$d page ready</item>
+        <item quantity="other">%1$d pages ready</item>
+    </plurals>
+    <string name="docs_scan_export">Export &amp; share PDF</string>
+    <string name="docs_scan_exporting">Building your PDF…</string>
+    <string name="docs_scan_exported">Saved %1$s · %2$s</string>
+    <string name="docs_scan_share_again">Share again</string>
+    <string name="docs_scan_share_chooser">Share PDF</string>
+    <string name="docs_scan_privacy_note">Scanning and PDF creation happen on your device. Your documents never leave your phone.</string>
+    <string name="library_scan_documents">Scan documents to PDF</string>
 </resources>

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -1257,9 +1257,7 @@
     <string name="docs_scan_back_cd">Back</string>
     <string name="docs_scan_intro">Turn a stack of paper into one clean PDF you can email — no scanner needed. Pages are cleaned up and combined on your device.</string>
     <string name="docs_scan_button">Scan pages</string>
-    <string name="docs_scan_button_cd">Open the document scanner</string>
     <string name="docs_scan_pick_gallery">Add from photos</string>
-    <string name="docs_scan_pick_gallery_cd">Add page photos from your gallery</string>
     <string name="docs_scan_scanner_unavailable">The document scanner isn\'t available on this device. You can still add page photos from your gallery.</string>
     <string name="docs_scan_empty">No pages yet. Tap “Scan pages” to capture a document, or add photos from your gallery.</string>
     <string name="docs_scan_page_label">Page %1$d</string>

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/docs/DocScanViewModelTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/docs/DocScanViewModelTest.kt
@@ -1,0 +1,168 @@
+package `in`.jphe.storyvox.feature.docs
+
+import `in`.jphe.storyvox.data.docs.DocPdfExporter
+import `in`.jphe.storyvox.data.docs.DocPdfRequest
+import `in`.jphe.storyvox.data.docs.DocPdfResult
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Issue #1513 — DocScanViewModel logic over a fake exporter (no
+ * PdfDocument, no ContentResolver, no Robolectric). Verifies capture
+ * accumulation, list-based reorder/delete, and the export → share-signal
+ * flow including the failure path.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class DocScanViewModelTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    @Before fun setUp() = Dispatchers.setMain(dispatcher)
+
+    @After fun tearDown() = Dispatchers.resetMain()
+
+    private class FakeExporter(var next: DocPdfResult) : DocPdfExporter {
+        var calls = 0
+        var lastRequest: DocPdfRequest? = null
+        override suspend fun exportToPdf(request: DocPdfRequest): DocPdfResult {
+            calls++
+            lastRequest = request
+            return next
+        }
+    }
+
+    private fun ok() = DocPdfResult.Success(
+        filePath = "/cache/exports/Doc.pdf",
+        fileName = "Doc.pdf",
+        pageCount = 2,
+        byteSize = 245_000L,
+    )
+
+    @Test
+    fun `captured pages accumulate in order`() = runTest(dispatcher) {
+        val vm = DocScanViewModel(FakeExporter(ok()))
+
+        vm.onPagesCaptured(listOf("content://a", "content://b"))
+        vm.onPagesCaptured(listOf("content://c"))
+
+        val pages = vm.state.value.pages
+        assertEquals(listOf("content://a", "content://b", "content://c"), pages.map { it.uri })
+        // Ids are unique + monotonic so reorder/delete key stably.
+        assertEquals(3, pages.map { it.id }.toSet().size)
+        assertTrue(vm.state.value.canExport)
+    }
+
+    @Test
+    fun `blank uris are ignored`() = runTest(dispatcher) {
+        val vm = DocScanViewModel(FakeExporter(ok()))
+        vm.onPagesCaptured(listOf("", "  ", "content://a"))
+        assertEquals(listOf("content://a"), vm.state.value.pages.map { it.uri })
+    }
+
+    @Test
+    fun `move up and down reorders pages, no-op at the ends`() = runTest(dispatcher) {
+        val vm = DocScanViewModel(FakeExporter(ok()))
+        vm.onPagesCaptured(listOf("a", "b", "c"))
+        val (id0, id1, id2) = vm.state.value.pages.map { it.id }
+
+        vm.movePageDown(id0) // a,b,c -> b,a,c
+        assertEquals(listOf("b", "a", "c"), vm.state.value.pages.map { it.uri })
+
+        vm.movePageUp(id2) // b,a,c -> b,c,a
+        assertEquals(listOf("b", "c", "a"), vm.state.value.pages.map { it.uri })
+
+        vm.movePageUp(vm.state.value.pages.first().id) // already top -> no-op
+        assertEquals(listOf("b", "c", "a"), vm.state.value.pages.map { it.uri })
+
+        vm.movePageDown(vm.state.value.pages.last().id) // already bottom -> no-op
+        assertEquals(listOf("b", "c", "a"), vm.state.value.pages.map { it.uri })
+    }
+
+    @Test
+    fun `removePage drops the matching page`() = runTest(dispatcher) {
+        val vm = DocScanViewModel(FakeExporter(ok()))
+        vm.onPagesCaptured(listOf("a", "b"))
+        val id = vm.state.value.pages.first().id
+        vm.removePage(id)
+        assertEquals(listOf("b"), vm.state.value.pages.map { it.uri })
+    }
+
+    @Test
+    fun `export success sets result and a one-shot share request`() = runTest(dispatcher) {
+        val exporter = FakeExporter(ok())
+        val vm = DocScanViewModel(exporter)
+        vm.onPagesCaptured(listOf("a", "b"))
+        vm.onTitleChanged("My packet")
+
+        vm.export()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(1, exporter.calls)
+        assertEquals("My packet", exporter.lastRequest?.title)
+        assertEquals(listOf("a", "b"), exporter.lastRequest?.pages?.map { it.uri })
+        assertFalse(vm.state.value.isExporting)
+        assertEquals("Doc.pdf", vm.state.value.exportResult?.fileName)
+        // share is one-shot: present until the screen handles it.
+        assertEquals("Doc.pdf", vm.state.value.shareRequest?.fileName)
+        vm.onShareHandled()
+        assertNull(vm.state.value.shareRequest)
+        // exportResult persists so "Share again" still works.
+        assertEquals("Doc.pdf", vm.state.value.exportResult?.fileName)
+    }
+
+    @Test
+    fun `blank title falls back to a default`() = runTest(dispatcher) {
+        val exporter = FakeExporter(ok())
+        val vm = DocScanViewModel(exporter)
+        vm.onPagesCaptured(listOf("a"))
+        vm.export()
+        dispatcher.scheduler.advanceUntilIdle()
+        assertEquals("Scanned document", exporter.lastRequest?.title)
+    }
+
+    @Test
+    fun `export failure surfaces an error and no share request`() = runTest(dispatcher) {
+        val vm = DocScanViewModel(FakeExporter(DocPdfResult.Failure("boom")))
+        vm.onPagesCaptured(listOf("a"))
+
+        vm.export()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals("boom", vm.state.value.error)
+        assertNull(vm.state.value.shareRequest)
+        assertNull(vm.state.value.exportResult)
+    }
+
+    @Test
+    fun `export is a no-op with no pages`() = runTest(dispatcher) {
+        val exporter = FakeExporter(ok())
+        val vm = DocScanViewModel(exporter)
+        vm.export()
+        dispatcher.scheduler.advanceUntilIdle()
+        assertEquals(0, exporter.calls)
+    }
+
+    @Test
+    fun `capturing after an export invalidates the stale result`() = runTest(dispatcher) {
+        val vm = DocScanViewModel(FakeExporter(ok()))
+        vm.onPagesCaptured(listOf("a"))
+        vm.export()
+        dispatcher.scheduler.advanceUntilIdle()
+        assertEquals("Doc.pdf", vm.state.value.exportResult?.fileName)
+
+        vm.onPagesCaptured(listOf("b"))
+        assertNull(vm.state.value.exportResult)
+        assertNull(vm.state.value.shareRequest)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -119,6 +119,11 @@ documentfile = "1.1.0"
 # settings. CameraX drives the capture surface; the gallery-pick
 # alternative needs no extra dep (ActivityResultContracts.GetContent).
 mlkit-text-recognition = "16.0.1"
+# #1513 — ML Kit Document Scanner (Play services). Supplies the capture
+# UI + edge detection + shadow removal + multipage output on-device; no
+# camera permission needed (runs in Play services). De-Googled devices
+# fall back to the gallery-pick path in DocScanScreen.
+mlkit-document-scanner = "16.0.0-beta1"
 camerax = "1.6.1"
 
 [libraries]
@@ -137,6 +142,9 @@ androidx-documentfile = { module = "androidx.documentfile:documentfile", version
 # capture stack. ML Kit lib is consumed by :app (the MlKitOcrTextRecognizer
 # impl); CameraX libs by :feature (the OcrCaptureScreen).
 mlkit-text-recognition = { module = "com.google.mlkit:text-recognition", version.ref = "mlkit-text-recognition" }
+# #1513 — document scanner (capture UI + cleanup + multipage). Consumed by
+# :feature's DocScanScreen (the scan-to-PDF flow).
+mlkit-document-scanner = { module = "com.google.android.gms:play-services-mlkit-document-scanner", version.ref = "mlkit-document-scanner" }
 androidx-camera-core = { module = "androidx.camera:camera-core", version.ref = "camerax" }
 androidx-camera-camera2 = { module = "androidx.camera:camera-camera2", version.ref = "camerax" }
 androidx-camera-lifecycle = { module = "androidx.camera:camera-lifecycle", version.ref = "camerax" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -123,7 +123,7 @@ mlkit-text-recognition = "16.0.1"
 # UI + edge detection + shadow removal + multipage output on-device; no
 # camera permission needed (runs in Play services). De-Googled devices
 # fall back to the gallery-pick path in DocScanScreen.
-mlkit-document-scanner = "16.0.0-beta1"
+mlkit-document-scanner = "16.0.0"
 camerax = "1.6.1"
 
 [libraries]


### PR DESCRIPTION
## What

The **capture foundation** of the benefits paperwork companion (epic #1520): a first-class **multi-page document scanner → one clean, shareable PDF** — "no scanner at home."

Every benefits application asks for document proofs (ID, pay stubs, award letters, utility bills); our audience largely has no scanner, and raw camera photos get rejected as unreadable. This flow captures a stack of paper, cleans it up on-device, and produces a compact PDF the share sheet can email.

## How

- **Capture** — ML Kit **Document Scanner** (Play services): capture UI + edge detection + perspective crop + shadow removal + multipage, all on-device, **no camera permission** (Play services owns the camera). De-Googled devices fall back to the system **Photo Picker** (permissionless). Both paths yield page-image URIs, so the same pipeline feeds the follow-on issues (#1512 fill, #1514 wallet re-export).
- **Compose/reorder** — captured pages accumulate in `DocScanViewModel` (plain JVM, unit-tested with a fake exporter). The user reorders/deletes them in a **list** — the TalkBack-friendly alternative to a spatial drag grid — names the document, and exports.
- **Export** — `DocPdfExporter` seam (`:core-data`, Android-types-free) → `PdfDocumentExporter` (`:app`) draws each page bitmap onto a US-Letter `android.graphics.pdf.PdfDocument`, downscaled (~150 DPI) to stay email-sized. Written to `cacheDir/exports/` and shared via `ACTION_SEND` through the existing app FileProvider (already scoped to `exports/` in `file_paths.xml`).
- **Entry** — Library add-menu → "Scan documents to PDF" → new `DOCS_SCAN` route.

## Architecture

New `feature/docs/` package + a reusable PDF-export seam that #1512 (fillable PDF) and #1514 (wallet) build on. Hilt binding lives at `:app` (`AppBindings`) per the resolve-at-`:app` rule.

## Invariants (epic #1520)

1. **On-device only** — no network with document content; PDF composition is local. Caveat: the *first* scan fetches the Play-services scanner module (then works offline) — the same posture the issue calls out ("processes on-device via Play services"). Gallery fallback + local PDF compose are fully offline.
2. **Bilingual EN/ES** — every new string in `values/` **and** a new `values-es/` (this PR **bootstraps the app's first Spanish locale**; partial file is correct — Android falls back to default for untranslated keys).
3. **Verified or silent** — N/A: this feature carries **no benefits *content***, it's a pure scan→PDF tool.
4. **Accessibility** — list-view reorder (not spatial), `contentDescription` on every control, `liveRegion` announcements for export status/errors.

**No new permission** → **no Data-Safety lock-step** for this PR.

## Tests

`DocScanViewModelTest` (JVM, no Robolectric): capture accumulation, blank-URI filtering, list reorder (+ no-op at ends), delete, export success → one-shot share signal, blank-title default, failure path, empty-export no-op, stale-result invalidation.

## Acceptance criteria

- [x] 3-page paper packet → single PDF (downscaled, email-sized) → shareable from the share sheet
- [x] Pages reorderable/deletable before export
- [x] Works offline (gallery + compose local; scanner module caches after first use)
- [x] ES strings complete

## Shared / hot files touched

- `feature/src/main/res/values/strings.xml` — new keys in a wrapped `<!-- #1513 --> … <!-- /#1513 -->` block, alphabetical.
- `feature/src/main/res/values-es/strings.xml` — **NEW file** (bootstraps the app's first Spanish locale); same wrapped block. Other A-lanes: append your keys to this file.
- `app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt` — `DOCS_SCAN` route const + composable + `onScanDocuments` wire-up (additive).
- `feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt` — add-menu item appended at the END of the menu.
- `gradle/libs.versions.toml` + `feature/build.gradle.kts` — ML Kit doc-scanner dep (additive; last-merger rebases).
- `app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt` — `DocPdfExporter` Hilt binding (additive).

Closes #1513

🤖 Generated with [Claude Code](https://claude.com/claude-code)
