### PR TITLE
feat(techempower): offline benefits screener — client-side /qualify (#1517)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -70,6 +70,7 @@ import `in`.jphe.storyvox.feature.settings.VoiceAndPlaybackSettingsScreen
 import `in`.jphe.storyvox.feature.settings.pronunciation.PronunciationDictScreen
 import `in`.jphe.storyvox.feature.techempower.TechEmpowerAboutScreen
 import `in`.jphe.storyvox.feature.techempower.TechEmpowerHomeScreen
+import `in`.jphe.storyvox.feature.techempower.screener.ScreenerScreen
 import `in`.jphe.storyvox.feature.voicelibrary.VoiceLibraryScreen
 import `in`.jphe.storyvox.ui.component.BottomTabBar
 import `in`.jphe.storyvox.ui.component.HomeTab
@@ -247,6 +248,12 @@ object StoryvoxRoutes {
      * attribution. Drill-down from TechEmpower Home.
      */
     const val TECHEMPOWER_ABOUT = "techempower/about"
+
+    /**
+     * Issue #1517 — offline benefits screener ("Do I qualify?"). Bundled,
+     * client-side, zero-connectivity. Drill-down from TechEmpower Home.
+     */
+    const val TECHEMPOWER_SCREENER = "techempower/screener"
     /** Q&A chat about a fiction (#81 follow-up). One chat history per
      *  fictionId; the screen pulls fiction title + current chapter
      *  context internally for the system prompt.
@@ -1668,9 +1675,24 @@ private fun StoryvoxNavHostContent(
                     onOpenAbout = {
                         navController.navigate(StoryvoxRoutes.TECHEMPOWER_ABOUT)
                     },
+                    onOpenScreener = {
+                        navController.navigate(StoryvoxRoutes.TECHEMPOWER_SCREENER)
+                    },
                     onOpenFiction = { fictionId ->
                         navController.navigate(StoryvoxRoutes.fictionDetail(fictionId))
                     },
+                )
+            }
+            // Issue #1517 — offline benefits screener drill-down.
+            composable(
+                StoryvoxRoutes.TECHEMPOWER_SCREENER,
+                enterTransition = pushEnter,
+                exitTransition = pushExit,
+                popEnterTransition = popEnter,
+                popExitTransition = popExit,
+            ) {
+                ScreenerScreen(
+                    onBack = { navController.popBackStack() },
                 )
             }
             composable(

--- a/feature/build.gradle.kts
+++ b/feature/build.gradle.kts
@@ -3,6 +3,11 @@ plugins {
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
+    // #1517 — @Serializable models for the offline benefits corpora
+    // (screener / letter decoder / call cards). Same plugin core-data
+    // and source-notion already apply; the kotlinx-serialization-json
+    // runtime was already a feature dependency.
+    alias(libs.plugins.kotlin.serialization)
 }
 
 android {

--- a/feature/src/main/assets/techempower/screener_corpus.json
+++ b/feature/src/main/assets/techempower/screener_corpus.json
@@ -1,0 +1,133 @@
+{
+  "metadata": {
+    "schemaVersion": 1,
+    "provenance": "seed-sample",
+    "verifiedDate": "2026-07-04",
+    "source": "SEED SAMPLE — authored for surface development (issue #1517). NOT the production corpus.",
+    "note": "Placeholder screening questions and program entries used to build and test the offline screener UI. Program NAMES and org->program mappings are drawn from epic #1520 issues (Project GO / LIHEAP, NID water discount, FREED battery backup, 211). The screening QUESTIONS are generic and the qualify/exclude logic here is ILLUSTRATIVE ONLY — these are not verified eligibility rules and no phone numbers are asserted here beyond the public 211 line. The production corpus (33 verified programs, EN/ES, from techempower.org/qualify's adversarial fact-check pipeline) replaces this file wholesale. When it lands, set provenance to \"techempower-verified\" and the seed banner disappears automatically."
+  },
+  "questions": [
+    {
+      "id": "county",
+      "type": "single_select",
+      "prompt": { "en": "Which county do you live in?", "es": "¿En qué condado vive?" },
+      "options": [
+        { "id": "nevada", "label": { "en": "Nevada County, CA", "es": "Condado de Nevada, CA" } },
+        { "id": "other", "label": { "en": "Somewhere else", "es": "En otro lugar" } }
+      ]
+    },
+    {
+      "id": "income_limited",
+      "type": "boolean",
+      "prompt": {
+        "en": "Is your household income limited — for example, do you often worry about paying bills?",
+        "es": "¿Tiene su hogar ingresos limitados? Por ejemplo, ¿le preocupa a menudo pagar las facturas?"
+      }
+    },
+    {
+      "id": "on_benefits",
+      "type": "boolean",
+      "prompt": {
+        "en": "Do you already get CalFresh (SNAP), Medi-Cal, or SSI?",
+        "es": "¿Ya recibe CalFresh (SNAP), Medi-Cal o SSI?"
+      }
+    },
+    {
+      "id": "has_children",
+      "type": "boolean",
+      "prompt": {
+        "en": "Are there children under 18 living in your home?",
+        "es": "¿Hay niños menores de 18 años que viven en su hogar?"
+      }
+    },
+    {
+      "id": "medical_equipment",
+      "type": "boolean",
+      "prompt": {
+        "en": "Does anyone in your home rely on electric medical equipment?",
+        "es": "¿Alguien en su hogar depende de equipo médico eléctrico?"
+      }
+    }
+  ],
+  "programs": [
+    {
+      "id": "liheap",
+      "org": "Project GO",
+      "category": "utilities",
+      "name": { "en": "Energy bill help (LIHEAP)", "es": "Ayuda con la factura de energía (LIHEAP)" },
+      "summary": {
+        "en": "Help paying your gas or electric bill, offered locally through Project GO.",
+        "es": "Ayuda para pagar su factura de gas o electricidad, ofrecida localmente por Project GO."
+      },
+      "phone": null,
+      "applyUrl": "https://techempower.org/qualify",
+      "verifiedDate": null,
+      "sourceNote": {
+        "en": "Seed placeholder — program run by Project GO (LIHEAP). Rules pending verified corpus.",
+        "es": "Marcador de posición — programa administrado por Project GO (LIHEAP). Reglas pendientes del corpus verificado."
+      },
+      "criteria": [
+        { "questionId": "income_limited", "op": "is_true" }
+      ]
+    },
+    {
+      "id": "nid_water_discount",
+      "org": "NID",
+      "category": "utilities",
+      "name": { "en": "Lower water bill (NID discount)", "es": "Factura de agua más baja (descuento de NID)" },
+      "summary": {
+        "en": "Nevada Irrigation District offers a reduced water rate for income-qualified households (about $9.50 off).",
+        "es": "El Distrito de Riego de Nevada ofrece una tarifa de agua reducida para hogares con ingresos calificados (unos $9.50 de descuento)."
+      },
+      "phone": null,
+      "applyUrl": "https://techempower.org/qualify",
+      "verifiedDate": null,
+      "sourceNote": {
+        "en": "Seed placeholder — NID water-rate assistance. Rules pending verified corpus.",
+        "es": "Marcador de posición — asistencia de tarifa de agua de NID. Reglas pendientes del corpus verificado."
+      },
+      "criteria": [
+        { "questionId": "county", "op": "equals", "value": "nevada" },
+        { "questionId": "income_limited", "op": "is_true" }
+      ]
+    },
+    {
+      "id": "freed_battery_backup",
+      "org": "FREED",
+      "category": "health",
+      "name": { "en": "Medical battery backup (FREED)", "es": "Batería de respaldo médica (FREED)" },
+      "summary": {
+        "en": "FREED helps people who depend on powered medical equipment get a battery backup for outages.",
+        "es": "FREED ayuda a las personas que dependen de equipo médico eléctrico a obtener una batería de respaldo para los apagones."
+      },
+      "phone": null,
+      "applyUrl": "https://techempower.org/qualify",
+      "verifiedDate": null,
+      "sourceNote": {
+        "en": "Seed placeholder — FREED medical battery program. Rules pending verified corpus.",
+        "es": "Marcador de posición — programa de baterías médicas de FREED. Reglas pendientes del corpus verificado."
+      },
+      "criteria": [
+        { "questionId": "medical_equipment", "op": "is_true" }
+      ]
+    },
+    {
+      "id": "help_211",
+      "org": "United Way 211",
+      "category": "referral",
+      "name": { "en": "Free local help line (211)", "es": "Línea de ayuda local gratuita (211)" },
+      "summary": {
+        "en": "Call 211 any time for a person who can point you to housing, food, and utility help near you.",
+        "es": "Llame al 211 en cualquier momento para hablar con una persona que puede guiarle a ayuda de vivienda, comida y servicios públicos cerca de usted."
+      },
+      "phone": "211",
+      "applyUrl": "https://www.211.org/",
+      "verifiedDate": "2026-07-04",
+      "sourceNote": {
+        "en": "211 is the public United Way social-services line.",
+        "es": "211 es la línea pública de servicios sociales de United Way."
+      },
+      "criteria": []
+    }
+  ]
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/TechEmpowerHomeScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/TechEmpowerHomeScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.FactCheck
 import androidx.compose.material.icons.filled.Forum
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Phone
@@ -45,12 +46,14 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import `in`.jphe.storyvox.data.TechEmpowerLinks
+import `in`.jphe.storyvox.feature.R as FeatureR
 import `in`.jphe.storyvox.ui.R as UiR
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
 
@@ -94,6 +97,7 @@ fun TechEmpowerHomeScreen(
     onBack: () -> Unit,
     onOpenBrowse: () -> Unit,
     onOpenAbout: () -> Unit,
+    onOpenScreener: () -> Unit,
     onOpenFiction: (String) -> Unit,
 ) {
     val spacing = LocalSpacing.current
@@ -146,6 +150,17 @@ fun TechEmpowerHomeScreen(
             }
 
             // ─── Get-help + content cards ─────────────────────────
+            // Issue #1517 — "Do I qualify?" leads the grid: it's the
+            // highest-value action for the screener audience and works
+            // fully offline. Bilingual copy via string resources.
+            item {
+                TechEmpowerCard(
+                    title = stringResource(FeatureR.string.screener_card_title),
+                    body = stringResource(FeatureR.string.screener_card_body),
+                    icon = Icons.Filled.FactCheck,
+                    onClick = onOpenScreener,
+                )
+            }
             item {
                 TechEmpowerCard(
                     title = "Browse Resources",

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/screener/ScreenerCorpus.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/screener/ScreenerCorpus.kt
@@ -1,0 +1,129 @@
+package `in`.jphe.storyvox.feature.techempower.screener
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Issue #1517 — data model for the **offline benefits screener** corpus.
+ *
+ * The screener bundles a client-side "Do I qualify?" flow (the same idea as
+ * techempower.org/qualify) as an **on-device asset** so it runs with zero
+ * connectivity — airplane mode, no data plan, no network of any kind. The
+ * privacy promise ("your answers never leave your device") is *provable* here
+ * because the surface makes no network calls at all: it only reads a bundled
+ * JSON asset and evaluates locally.
+ *
+ * VERIFIED-OR-SILENT (epic #1520 invariant 3): benefits *content* is
+ * TechEmpower-supplied from their adversarial fact-check pipeline. This module
+ * ships the SURFACE + a corpus READER; the bundled `screener_corpus.json` is a
+ * SMALL, clearly-marked SEED SAMPLE ([CorpusMetadata.provenance] ==
+ * `"seed-sample"`). The production corpus (33 verified programs, EN/ES)
+ * replaces the asset wholesale; flip [CorpusMetadata.provenance] to
+ * `"techempower-verified"` and the seed banner disappears. We never author or
+ * paraphrase program facts.
+ *
+ * All user-facing content carries both languages ([Localized]); UI chrome is in
+ * `res/values` + `res/values-es`. The corpus's own verified-date is surfaced in
+ * the screener footer (acceptance: "corpus verified-date visible; matches the
+ * shipped rules JSON").
+ */
+@Serializable
+data class ScreenerCorpus(
+    val metadata: CorpusMetadata,
+    val questions: List<ScreenerQuestion> = emptyList(),
+    val programs: List<ScreenerProgram> = emptyList(),
+)
+
+/**
+ * Provenance + freshness metadata for the corpus. [provenance] gates the
+ * "sample data" banner: anything other than [PROVENANCE_VERIFIED] is treated as
+ * un-verified seed content and the UI says so loudly.
+ */
+@Serializable
+data class CorpusMetadata(
+    val schemaVersion: Int = 1,
+    val provenance: String = PROVENANCE_SEED,
+    val verifiedDate: String? = null,
+    val source: String? = null,
+    val note: String? = null,
+) {
+    /** True when this corpus is TechEmpower's verified production data. */
+    val isVerified: Boolean get() = provenance == PROVENANCE_VERIFIED
+
+    companion object {
+        const val PROVENANCE_SEED = "seed-sample"
+        const val PROVENANCE_VERIFIED = "techempower-verified"
+    }
+}
+
+/** A bilingual string. [get] picks the language, falling back to EN. */
+@Serializable
+data class Localized(
+    val en: String,
+    val es: String? = null,
+) {
+    fun get(spanish: Boolean): String = if (spanish) (es ?: en) else en
+}
+
+/** The shape of an answer a [ScreenerQuestion] collects. */
+enum class QuestionType { BOOLEAN, SINGLE_SELECT }
+
+@Serializable
+data class ScreenerQuestion(
+    val id: String,
+    val type: String,
+    val prompt: Localized,
+    val options: List<ScreenerOption> = emptyList(),
+) {
+    val questionType: QuestionType
+        get() = when (type) {
+            "single_select" -> QuestionType.SINGLE_SELECT
+            else -> QuestionType.BOOLEAN
+        }
+}
+
+@Serializable
+data class ScreenerOption(
+    val id: String,
+    val label: Localized,
+)
+
+/**
+ * A benefits program the screener can surface. [criteria] is evaluated locally
+ * against the user's answers (see [ScreenerEligibility]). An empty criteria list
+ * means "always relevant" (e.g. the 211 help line).
+ *
+ * [phone] is null unless a number is *verified* (only 211 in the seed). We never
+ * invent a phone number; unknown numbers route the user to 211 / the apply URL.
+ */
+@Serializable
+data class ScreenerProgram(
+    val id: String,
+    val org: String? = null,
+    val category: String? = null,
+    val name: Localized,
+    val summary: Localized,
+    val phone: String? = null,
+    val applyUrl: String? = null,
+    val verifiedDate: String? = null,
+    val sourceNote: Localized? = null,
+    val criteria: List<Criterion> = emptyList(),
+)
+
+/**
+ * One eligibility test referencing a [ScreenerQuestion] by [questionId].
+ * [op] is one of [Criterion.OP_IS_TRUE] / [Criterion.OP_IS_FALSE] /
+ * [Criterion.OP_EQUALS]; [value] is the option id for `equals`.
+ */
+@Serializable
+data class Criterion(
+    val questionId: String,
+    val op: String,
+    @SerialName("value") val value: String? = null,
+) {
+    companion object {
+        const val OP_IS_TRUE = "is_true"
+        const val OP_IS_FALSE = "is_false"
+        const val OP_EQUALS = "equals"
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/screener/ScreenerCorpusParser.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/screener/ScreenerCorpusParser.kt
@@ -1,0 +1,17 @@
+package `in`.jphe.storyvox.feature.techempower.screener
+
+import kotlinx.serialization.json.Json
+
+/**
+ * Issue #1517 — pure JSON → [ScreenerCorpus] decode. No Android, no IO: the
+ * caller supplies the raw string (the ViewModel reads it from assets). Kept
+ * pure so the parse contract is covered by plain-JVM unit tests.
+ */
+object ScreenerCorpusParser {
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+    }
+
+    fun parse(raw: String): ScreenerCorpus = json.decodeFromString(ScreenerCorpus.serializer(), raw)
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/screener/ScreenerEligibility.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/screener/ScreenerEligibility.kt
@@ -1,0 +1,72 @@
+package `in`.jphe.storyvox.feature.techempower.screener
+
+/**
+ * Issue #1517 — the answer a user has given to one [ScreenerQuestion].
+ * [Bool] for yes/no questions, [Choice] for single-select. Absence of an entry
+ * means "not answered yet".
+ */
+sealed interface Answer {
+    data class Bool(val value: Boolean) : Answer
+    data class Choice(val optionId: String) : Answer
+}
+
+/** Where a program lands after evaluating its criteria against the answers. */
+enum class EligibilityBucket {
+    /** All criteria satisfied (or no criteria) → surface as a likely match. */
+    LIKELY,
+
+    /** Criteria not contradicted, but some inputs are still unanswered. */
+    MAYBE,
+
+    /** At least one criterion is contradicted by an answer → not a match. */
+    UNLIKELY,
+}
+
+data class ScreenerResult(
+    val program: ScreenerProgram,
+    val bucket: EligibilityBucket,
+)
+
+/**
+ * Pure eligibility evaluation — no Android, no IO, no randomness. Fully covered
+ * by plain-JVM unit tests.
+ *
+ * These are SEED rules ([CorpusMetadata.provenance] == seed-sample) — the
+ * production corpus supplies verified criteria. The evaluator itself is content-
+ * agnostic: it just applies whatever declarative criteria the corpus carries.
+ */
+object ScreenerEligibility {
+
+    /** Evaluate a single program against the current answers. */
+    fun evaluate(program: ScreenerProgram, answers: Map<String, Answer>): EligibilityBucket {
+        if (program.criteria.isEmpty()) return EligibilityBucket.LIKELY
+
+        var sawUnanswered = false
+        for (c in program.criteria) {
+            when (val answer = answers[c.questionId]) {
+                null -> sawUnanswered = true
+                else -> if (!satisfies(c, answer)) return EligibilityBucket.UNLIKELY
+            }
+        }
+        return if (sawUnanswered) EligibilityBucket.MAYBE else EligibilityBucket.LIKELY
+    }
+
+    /**
+     * Evaluate every program and return only those worth showing (LIKELY or
+     * MAYBE), LIKELY first, preserving corpus order within a bucket. UNLIKELY
+     * programs are dropped — a screener should not tell someone "you don't
+     * qualify"; it surfaces what they *can* pursue.
+     */
+    fun results(corpus: ScreenerCorpus, answers: Map<String, Answer>): List<ScreenerResult> =
+        corpus.programs
+            .map { ScreenerResult(it, evaluate(it, answers)) }
+            .filter { it.bucket != EligibilityBucket.UNLIKELY }
+            .sortedBy { if (it.bucket == EligibilityBucket.LIKELY) 0 else 1 }
+
+    private fun satisfies(criterion: Criterion, answer: Answer): Boolean = when (criterion.op) {
+        Criterion.OP_IS_TRUE -> answer is Answer.Bool && answer.value
+        Criterion.OP_IS_FALSE -> answer is Answer.Bool && !answer.value
+        Criterion.OP_EQUALS -> answer is Answer.Choice && answer.optionId == criterion.value
+        else -> false // unknown operator → treat as unsatisfiable, never a false positive
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/screener/ScreenerProgramIds.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/screener/ScreenerProgramIds.kt
@@ -1,0 +1,43 @@
+package `in`.jphe.storyvox.feature.techempower.screener
+
+/**
+ * Issue #1517 — canonical benefits **program ids**, owned by the screener lane.
+ *
+ * WHY THIS FILE EXISTS (cross-lane seam, epic #1520): other benefits features
+ * are "program-aware" and key off these ids —
+ *  - the wallet's proof-slots (#1514) map documents to the programs that need
+ *    them,
+ *  - the household-profile autofill (#1519) pre-fills applications per program.
+ *
+ * The screener owns the corpus, so it owns the id namespace. Consumers should
+ * depend on these plain string constants (a merged type is not required to
+ * cross a lane boundary), and the ids MUST match the `"id"` values in
+ * `assets/techempower/screener_corpus.json`. When the production corpus lands,
+ * keep these constants in sync with its ids (a corpus program whose id is not a
+ * constant here still works — this is a convenience surface for other lanes,
+ * not a gate).
+ *
+ * Ids are stable, lowercase, snake_case, and never re-used for a different
+ * program once shipped.
+ */
+object ScreenerProgramIds {
+    /** LIHEAP energy-bill assistance (locally: Project GO). */
+    const val LIHEAP = "liheap"
+
+    /** Nevada Irrigation District reduced water rate. */
+    const val NID_WATER_DISCOUNT = "nid_water_discount"
+
+    /** FREED medical battery-backup program. */
+    const val FREED_BATTERY_BACKUP = "freed_battery_backup"
+
+    /** United Way 211 local referral line. */
+    const val HELP_211 = "help_211"
+
+    /** All ids known to this build's seed corpus. Not exhaustive of production. */
+    val seedIds: List<String> = listOf(
+        LIHEAP,
+        NID_WATER_DISCOUNT,
+        FREED_BATTERY_BACKUP,
+        HELP_211,
+    )
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/screener/ScreenerScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/screener/ScreenerScreen.kt
@@ -1,0 +1,529 @@
+package `in`.jphe.storyvox.feature.techempower.screener
+
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.OpenInNew
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Phone
+import androidx.compose.material.icons.filled.VolumeUp
+import androidx.compose.material3.Button
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import `in`.jphe.storyvox.feature.R
+import `in`.jphe.storyvox.ui.theme.LocalSpacing
+
+/**
+ * Issue #1517 — the offline benefits screener surface.
+ *
+ * A single scrollable question form + bucketed results — deliberately a
+ * **list**, not a spatial/overlay UI, so it is fully navigable by TalkBack
+ * (invariant 4). Every program surface is read-aloud-able via the app's TTS
+ * seam. UI chrome is bilingual through `res/values` + `res/values-es`; corpus
+ * content carries its own EN/ES ([Localized]) and follows the device locale.
+ *
+ * The whole surface performs ZERO network calls — it reads a bundled asset and
+ * evaluates locally — so it works in airplane mode and the "answers never leave
+ * your device" promise is provable (invariant 1).
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ScreenerScreen(
+    onBack: () -> Unit,
+    viewModel: ScreenerViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsState()
+    val locale = LocalConfiguration.current.locales[0]
+    val spanish = locale.language == "es"
+
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = {
+                    Text(
+                        stringResource(R.string.screener_title),
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.screener_back),
+                        )
+                    }
+                },
+            )
+        },
+    ) { scaffoldPadding ->
+        when {
+            state.isLoading -> LoadingState(Modifier.padding(scaffoldPadding))
+            state.loadError -> ErrorState(Modifier.padding(scaffoldPadding))
+            else -> ScreenerContent(
+                state = state,
+                spanish = spanish,
+                onAnswerBool = viewModel::answerBool,
+                onAnswerChoice = viewModel::answerChoice,
+                onShowResults = viewModel::showResults,
+                onReset = viewModel::reset,
+                onReadAloud = viewModel::readAloud,
+                onStopReadAloud = viewModel::stopReadAloud,
+                modifier = Modifier.padding(scaffoldPadding),
+            )
+        }
+    }
+}
+
+@Composable
+private fun LoadingState(modifier: Modifier = Modifier) {
+    Box(modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        CircularProgressIndicator()
+    }
+}
+
+@Composable
+private fun ErrorState(modifier: Modifier = Modifier) {
+    val spacing = LocalSpacing.current
+    Box(
+        modifier
+            .fillMaxSize()
+            .padding(spacing.lg),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            stringResource(R.string.screener_load_error),
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun ScreenerContent(
+    state: ScreenerUiState,
+    spanish: Boolean,
+    onAnswerBool: (String, Boolean) -> Unit,
+    onAnswerChoice: (String, String) -> Unit,
+    onShowResults: () -> Unit,
+    onReset: () -> Unit,
+    onReadAloud: (String) -> Unit,
+    onStopReadAloud: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val corpus = state.corpus ?: return
+    val spacing = LocalSpacing.current
+
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(spacing.md),
+        verticalArrangement = Arrangement.spacedBy(spacing.md),
+    ) {
+        // Intro + offline reassurance.
+        item {
+            Column(verticalArrangement = Arrangement.spacedBy(spacing.xs)) {
+                Text(
+                    stringResource(R.string.screener_intro),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Text(
+                    stringResource(R.string.screener_offline_note),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+
+        // Seed / sample-data banner — shown until the verified corpus lands.
+        if (!corpus.metadata.isVerified) {
+            item { SampleDataBanner() }
+        }
+
+        // Questions.
+        items(corpus.questions, key = { it.id }) { question ->
+            QuestionBlock(
+                question = question,
+                spanish = spanish,
+                answer = state.answers[question.id],
+                onAnswerBool = onAnswerBool,
+                onAnswerChoice = onAnswerChoice,
+            )
+        }
+
+        // Primary action + start-over.
+        item {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Button(
+                    onClick = onShowResults,
+                    modifier = Modifier.weight(1f),
+                ) {
+                    Text(stringResource(R.string.screener_show_results))
+                }
+                if (state.showResults || state.answers.isNotEmpty()) {
+                    TextButton(onClick = onReset) {
+                        Text(stringResource(R.string.screener_start_over))
+                    }
+                }
+            }
+        }
+
+        // Results.
+        if (state.showResults) {
+            item {
+                ResultsHeader(
+                    results = state.results,
+                    spanish = spanish,
+                    onReadAll = onReadAloud,
+                    onStop = onStopReadAloud,
+                )
+            }
+            if (state.results.isEmpty()) {
+                item {
+                    Text(
+                        stringResource(R.string.screener_results_empty),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            } else {
+                items(state.results, key = { it.program.id }) { result ->
+                    ResultCard(
+                        result = result,
+                        spanish = spanish,
+                        onReadAloud = onReadAloud,
+                    )
+                }
+            }
+        }
+
+        // Verified-date footer — reads straight off the parsed corpus, so it
+        // always matches the shipped JSON (acceptance criterion).
+        item { VerifiedFooter(corpus = corpus) }
+    }
+}
+
+@Composable
+private fun SampleDataBanner() {
+    val spacing = LocalSpacing.current
+    val accent = MaterialTheme.colorScheme.tertiary
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(MaterialTheme.shapes.medium)
+            .background(accent.copy(alpha = 0.12f))
+            .border(1.dp, accent.copy(alpha = 0.5f), MaterialTheme.shapes.medium)
+            .padding(spacing.md),
+        horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+    ) {
+        Icon(
+            Icons.Filled.Info,
+            contentDescription = null,
+            tint = accent,
+            modifier = Modifier.size(20.dp),
+        )
+        Column(verticalArrangement = Arrangement.spacedBy(spacing.xs)) {
+            Text(
+                stringResource(R.string.screener_seed_banner_title),
+                style = MaterialTheme.typography.labelLarge,
+                color = accent,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Text(
+                stringResource(R.string.screener_seed_banner_body),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun QuestionBlock(
+    question: ScreenerQuestion,
+    spanish: Boolean,
+    answer: Answer?,
+    onAnswerBool: (String, Boolean) -> Unit,
+    onAnswerChoice: (String, String) -> Unit,
+) {
+    val spacing = LocalSpacing.current
+    Column(verticalArrangement = Arrangement.spacedBy(spacing.xs)) {
+        Text(
+            question.prompt.get(spanish),
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.semantics { heading() },
+        )
+        FlowRow(horizontalArrangement = Arrangement.spacedBy(spacing.sm)) {
+            when (question.questionType) {
+                QuestionType.BOOLEAN -> {
+                    val current = (answer as? Answer.Bool)?.value
+                    ChoicePill(
+                        label = stringResource(R.string.screener_yes),
+                        selected = current == true,
+                        onClick = { onAnswerBool(question.id, true) },
+                    )
+                    ChoicePill(
+                        label = stringResource(R.string.screener_no),
+                        selected = current == false,
+                        onClick = { onAnswerBool(question.id, false) },
+                    )
+                }
+                QuestionType.SINGLE_SELECT -> {
+                    val current = (answer as? Answer.Choice)?.optionId
+                    question.options.forEach { option ->
+                        ChoicePill(
+                            label = option.label.get(spanish),
+                            selected = current == option.id,
+                            onClick = { onAnswerChoice(question.id, option.id) },
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ChoicePill(label: String, selected: Boolean, onClick: () -> Unit) {
+    FilterChip(
+        selected = selected,
+        onClick = onClick,
+        label = { Text(label) },
+    )
+}
+
+@Composable
+private fun ResultsHeader(
+    results: List<ScreenerResult>,
+    spanish: Boolean,
+    onReadAll: (String) -> Unit,
+    onStop: () -> Unit,
+) {
+    val spacing = LocalSpacing.current
+    Column(verticalArrangement = Arrangement.spacedBy(spacing.xs)) {
+        Text(
+            stringResource(R.string.screener_results_title),
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.primary,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.semantics { heading() },
+        )
+        if (results.isNotEmpty()) {
+            Row(horizontalArrangement = Arrangement.spacedBy(spacing.sm)) {
+                OutlinedButton(onClick = { onReadAll(resultsAsSpeech(results, spanish)) }) {
+                    Icon(Icons.Filled.VolumeUp, contentDescription = null, modifier = Modifier.size(18.dp))
+                    Spacer(Modifier.width(spacing.xs))
+                    Text(stringResource(R.string.screener_read_all))
+                }
+                TextButton(onClick = onStop) {
+                    Text(stringResource(R.string.screener_stop))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ResultCard(
+    result: ScreenerResult,
+    spanish: Boolean,
+    onReadAloud: (String) -> Unit,
+) {
+    val spacing = LocalSpacing.current
+    val brass = MaterialTheme.colorScheme.primary
+    val program = result.program
+    val bucketLabel = when (result.bucket) {
+        EligibilityBucket.LIKELY -> stringResource(R.string.screener_bucket_likely)
+        else -> stringResource(R.string.screener_bucket_maybe)
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(MaterialTheme.shapes.large)
+            .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+            .border(1.5.dp, brass.copy(alpha = 0.55f), MaterialTheme.shapes.large)
+            .padding(spacing.md),
+        verticalArrangement = Arrangement.spacedBy(spacing.xs),
+    ) {
+        Text(
+            bucketLabel,
+            style = MaterialTheme.typography.labelMedium,
+            color = brass,
+            fontWeight = FontWeight.SemiBold,
+        )
+        Text(
+            program.name.get(spanish),
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            fontWeight = FontWeight.SemiBold,
+        )
+        Text(
+            program.summary.get(spanish),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        Spacer(Modifier.height(spacing.xs))
+        FlowRowActions(
+            program = program,
+            spanish = spanish,
+            onReadAloud = { onReadAloud(programAsSpeech(result, spanish)) },
+        )
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun FlowRowActions(
+    program: ScreenerProgram,
+    spanish: Boolean,
+    onReadAloud: () -> Unit,
+) {
+    val spacing = LocalSpacing.current
+    val context = LocalContext.current
+    FlowRow(
+        horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+    ) {
+        // Read-aloud — this IS an audiobook app.
+        TextButton(onClick = onReadAloud) {
+            Icon(Icons.Filled.VolumeUp, contentDescription = null, modifier = Modifier.size(18.dp))
+            Spacer(Modifier.width(spacing.xs))
+            Text(stringResource(R.string.screener_read_aloud))
+        }
+        // Call — only when a number is verified (never invented). Otherwise
+        // route to 211, the public help line.
+        val number = program.phone ?: "211"
+        val callLabel = if (program.phone != null) {
+            stringResource(R.string.screener_call)
+        } else {
+            stringResource(R.string.screener_call_211)
+        }
+        TextButton(
+            onClick = { dial(context, number) },
+            modifier = Modifier.semantics {
+                contentDescription = "$callLabel $number"
+            },
+        ) {
+            Icon(Icons.Filled.Phone, contentDescription = null, modifier = Modifier.size(18.dp))
+            Spacer(Modifier.width(spacing.xs))
+            Text(callLabel)
+        }
+        // Learn more — opens the apply URL (Custom Tabs / browser when online).
+        program.applyUrl?.let { url ->
+            TextButton(onClick = { openUrl(context, url) }) {
+                Icon(
+                    Icons.AutoMirrored.Filled.OpenInNew,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp),
+                )
+                Spacer(Modifier.width(spacing.xs))
+                Text(stringResource(R.string.screener_learn_more))
+            }
+        }
+    }
+}
+
+@Composable
+private fun VerifiedFooter(corpus: ScreenerCorpus) {
+    val spacing = LocalSpacing.current
+    val date = corpus.metadata.verifiedDate
+    val text = if (date != null) {
+        stringResource(R.string.screener_verified_prefix, date)
+    } else {
+        stringResource(R.string.screener_verified_unknown)
+    }
+    Text(
+        text,
+        style = MaterialTheme.typography.labelSmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = spacing.sm),
+    )
+}
+
+// ─── Speech assembly (read-aloud text) ────────────────────────────────────
+
+private fun programAsSpeech(result: ScreenerResult, spanish: Boolean): String =
+    buildString {
+        append(result.program.name.get(spanish))
+        append(". ")
+        append(result.program.summary.get(spanish))
+    }
+
+private fun resultsAsSpeech(results: List<ScreenerResult>, spanish: Boolean): String =
+    results.joinToString(separator = "\n\n") { programAsSpeech(it, spanish) }
+
+// ─── Intents ───────────────────────────────────────────────────────────────
+
+private fun dial(context: android.content.Context, number: String) {
+    runCatching {
+        context.startActivity(
+            Intent(Intent.ACTION_DIAL, Uri.parse("tel:$number"))
+                .apply { addFlags(Intent.FLAG_ACTIVITY_NEW_TASK) },
+        )
+    }
+}
+
+private fun openUrl(context: android.content.Context, url: String) {
+    try {
+        context.startActivity(
+            Intent(Intent.ACTION_VIEW, Uri.parse(url))
+                .apply { addFlags(Intent.FLAG_ACTIVITY_NEW_TASK) },
+        )
+    } catch (_: ActivityNotFoundException) {
+        // No browser (offline-only device) — the phone number above is the
+        // fallback path, so nothing more to do here.
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/screener/ScreenerViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/screener/ScreenerViewModel.kt
@@ -1,0 +1,126 @@
+package `in`.jphe.storyvox.feature.techempower.screener
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import `in`.jphe.storyvox.feature.api.PlaybackControllerUi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+/**
+ * Issue #1517 — offline benefits screener ViewModel.
+ *
+ * ON-DEVICE ONLY (invariant 1): the only IO this ViewModel performs is reading
+ * a bundled asset. There is NO network dependency, NO OkHttp, NO analytics —
+ * answers live only in this in-memory state and never leave the device. That is
+ * why the screener works in airplane mode and why the privacy promise is
+ * *provable* here.
+ *
+ * Read-aloud (invariant 4) goes through the app-level [PlaybackControllerUi]
+ * seam (`speakText`/`stopSpeaking`) — the same one the reader's recap-aloud and
+ * chat use. We do NOT touch `core-playback`.
+ */
+@HiltViewModel
+class ScreenerViewModel @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val playback: PlaybackControllerUi,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(ScreenerUiState())
+    val state: StateFlow<ScreenerUiState> = _state.asStateFlow()
+
+    init {
+        load()
+    }
+
+    private fun load() {
+        viewModelScope.launch {
+            val result = runCatching {
+                val raw = withContext(Dispatchers.IO) {
+                    context.assets.open(CORPUS_ASSET).use { it.readBytes().decodeToString() }
+                }
+                ScreenerCorpusParser.parse(raw)
+            }
+            // `st` names the outer state param explicitly — inside fold, the
+            // onFailure lambda's implicit `it` is the Throwable, not the state,
+            // so `it.copy(...)` would not resolve.
+            _state.update { st ->
+                result.fold(
+                    onSuccess = { corpus -> st.copy(corpus = corpus, loadError = false) },
+                    onFailure = { st.copy(corpus = null, loadError = true) },
+                )
+            }
+        }
+    }
+
+    /** Record a yes/no answer and recompute results if they're already shown. */
+    fun answerBool(questionId: String, value: Boolean) = putAnswer(questionId, Answer.Bool(value))
+
+    /** Record a single-select answer and recompute results if already shown. */
+    fun answerChoice(questionId: String, optionId: String) =
+        putAnswer(questionId, Answer.Choice(optionId))
+
+    private fun putAnswer(questionId: String, answer: Answer) {
+        _state.update { current ->
+            val answers = current.answers + (questionId to answer)
+            current.copy(
+                answers = answers,
+                results = if (current.showResults) recompute(current.corpus, answers) else current.results,
+            )
+        }
+    }
+
+    /** Compute (or refresh) the bucketed results and reveal them. */
+    fun showResults() {
+        _state.update { current ->
+            current.copy(showResults = true, results = recompute(current.corpus, current.answers))
+        }
+    }
+
+    /** Clear all answers and collapse the results — "start over". */
+    fun reset() {
+        stopReadAloud()
+        _state.update { it.copy(answers = emptyMap(), results = emptyList(), showResults = false) }
+    }
+
+    /** Speak [text] via the active voice (app-level seam; not core-playback). */
+    fun readAloud(text: String) {
+        viewModelScope.launch { playback.speakText(text) }
+    }
+
+    /** Cancel any in-flight read-aloud utterance. Idempotent. */
+    fun stopReadAloud() {
+        playback.stopSpeaking()
+    }
+
+    private fun recompute(corpus: ScreenerCorpus?, answers: Map<String, Answer>): List<ScreenerResult> =
+        corpus?.let { ScreenerEligibility.results(it, answers) } ?: emptyList()
+
+    override fun onCleared() {
+        stopReadAloud()
+        super.onCleared()
+    }
+
+    companion object {
+        const val CORPUS_ASSET = "techempower/screener_corpus.json"
+    }
+}
+
+/** Immutable UI state for the screener surface. */
+data class ScreenerUiState(
+    val corpus: ScreenerCorpus? = null,
+    val loadError: Boolean = false,
+    val answers: Map<String, Answer> = emptyMap(),
+    val results: List<ScreenerResult> = emptyList(),
+    val showResults: Boolean = false,
+) {
+    val isLoading: Boolean get() = corpus == null && !loadError
+}

--- a/feature/src/main/res/values-es/strings.xml
+++ b/feature/src/main/res/values-es/strings.xml
@@ -39,4 +39,33 @@
     <string name="docs_scan_title_label">Nombre del documento</string>
     <string name="library_scan_documents">Escanear documentos a PDF</string>
     <!-- /#1513 -->
+
+    <!-- #1517 — Offline benefits screener -->
+    <string name="screener_title">¿Califico?</string>
+    <string name="screener_back">Atrás</string>
+    <string name="screener_intro">Responda unas preguntas para encontrar programas locales para los que podría calificar.</string>
+    <string name="screener_offline_note">Funciona sin conexión. Sus respuestas se quedan en este dispositivo; no se envían a ningún lugar.</string>
+    <string name="screener_seed_banner_title">Datos de muestra</string>
+    <string name="screener_seed_banner_body">Estos programas y preguntas son una vista previa. Las reglas finales de los programas provienen de TechEmpower.</string>
+    <string name="screener_yes">Sí</string>
+    <string name="screener_no">No</string>
+    <string name="screener_show_results">Ver mis resultados</string>
+    <string name="screener_start_over">Empezar de nuevo</string>
+    <string name="screener_results_title">Programas para investigar</string>
+    <string name="screener_results_empty">Responda unas preguntas arriba y luego toque “Ver mis resultados.”</string>
+    <string name="screener_bucket_likely">Probablemente califica</string>
+    <string name="screener_bucket_maybe">Podría calificar</string>
+    <string name="screener_read_aloud">Leer en voz alta</string>
+    <string name="screener_read_all">Leer resultados en voz alta</string>
+    <string name="screener_stop">Detener</string>
+    <string name="screener_call">Llamar</string>
+    <string name="screener_call_211">Llamar al 211</string>
+    <string name="screener_learn_more">Más información</string>
+    <!-- %1$s = la fecha de verificación del corpus (del JSON de reglas incluido). -->
+    <string name="screener_verified_prefix">Detalles verificados por última vez: %1$s</string>
+    <string name="screener_verified_unknown">Estos detalles aún no están verificados.</string>
+    <string name="screener_load_error">No pudimos abrir la lista de programas. Actualice la aplicación e inténtelo de nuevo.</string>
+    <!-- Tarjeta de entrada en la cuadrícula de Inicio de TechEmpower. -->
+    <string name="screener_card_title">¿Califico?</string>
+    <string name="screener_card_body">Responda unas preguntas rápidas para encontrar ayuda local para la que podría ser elegible. Funciona sin conexión.</string>
 </resources>

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -1277,4 +1277,33 @@
     <string name="docs_scan_title_label">Document name</string>
     <string name="library_scan_documents">Scan documents to PDF</string>
     <!-- /#1513 -->
+
+    <!-- #1517 — Offline benefits screener -->
+    <string name="screener_title">Do I qualify?</string>
+    <string name="screener_back">Back</string>
+    <string name="screener_intro">Answer a few questions to find local programs you may qualify for.</string>
+    <string name="screener_offline_note">Works offline. Your answers stay on this device — nothing is sent anywhere.</string>
+    <string name="screener_seed_banner_title">Sample data</string>
+    <string name="screener_seed_banner_body">These programs and questions are a preview. Final program rules come from TechEmpower.</string>
+    <string name="screener_yes">Yes</string>
+    <string name="screener_no">No</string>
+    <string name="screener_show_results">See my results</string>
+    <string name="screener_start_over">Start over</string>
+    <string name="screener_results_title">Programs to look into</string>
+    <string name="screener_results_empty">Answer a few questions above, then tap “See my results.”</string>
+    <string name="screener_bucket_likely">You likely qualify</string>
+    <string name="screener_bucket_maybe">You might qualify</string>
+    <string name="screener_read_aloud">Read aloud</string>
+    <string name="screener_read_all">Read results aloud</string>
+    <string name="screener_stop">Stop</string>
+    <string name="screener_call">Call</string>
+    <string name="screener_call_211">Call 211</string>
+    <string name="screener_learn_more">Learn more</string>
+    <!-- %1$s = the corpus verified-date (from the shipped rules JSON). -->
+    <string name="screener_verified_prefix">Program details last verified: %1$s</string>
+    <string name="screener_verified_unknown">These details are not yet verified.</string>
+    <string name="screener_load_error">We could not open the program list. Please update the app and try again.</string>
+    <!-- Entry card on the TechEmpower Home grid. -->
+    <string name="screener_card_title">Do I qualify?</string>
+    <string name="screener_card_body">Answer a few quick questions to find local help you may be eligible for. Works offline.</string>
 </resources>

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/techempower/screener/ScreenerCorpusParserTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/techempower/screener/ScreenerCorpusParserTest.kt
@@ -1,0 +1,107 @@
+package `in`.jphe.storyvox.feature.techempower.screener
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1517 — pins the screener corpus decode contract. Pure JVM: the parser
+ * takes a raw string (the ViewModel supplies the asset bytes), so no Android or
+ * IO is needed here.
+ */
+class ScreenerCorpusParserTest {
+
+    private val sample = """
+        {
+          "metadata": {
+            "schemaVersion": 1,
+            "provenance": "seed-sample",
+            "verifiedDate": "2026-07-04",
+            "source": "seed",
+            "note": "n",
+            "unknownFutureField": "ignored"
+          },
+          "questions": [
+            { "id": "county", "type": "single_select",
+              "prompt": { "en": "County?", "es": "¿Condado?" },
+              "options": [
+                { "id": "nevada", "label": { "en": "Nevada", "es": "Nevada" } }
+              ] },
+            { "id": "income_limited", "type": "boolean",
+              "prompt": { "en": "Limited income?" } }
+          ],
+          "programs": [
+            { "id": "liheap", "org": "Project GO", "category": "utilities",
+              "name": { "en": "Energy help", "es": "Ayuda de energía" },
+              "summary": { "en": "help", "es": "ayuda" },
+              "phone": null, "applyUrl": "https://x", "verifiedDate": null,
+              "criteria": [ { "questionId": "income_limited", "op": "is_true" } ] },
+            { "id": "help_211", "name": { "en": "211" }, "summary": { "en": "call" },
+              "phone": "211", "criteria": [] }
+          ]
+        }
+    """.trimIndent()
+
+    @Test
+    fun parsesMetadataQuestionsAndPrograms() {
+        val corpus = ScreenerCorpusParser.parse(sample)
+
+        assertEquals(1, corpus.metadata.schemaVersion)
+        assertEquals("seed-sample", corpus.metadata.provenance)
+        assertEquals("2026-07-04", corpus.metadata.verifiedDate)
+        assertEquals(2, corpus.questions.size)
+        assertEquals(2, corpus.programs.size)
+    }
+
+    @Test
+    fun ignoresUnknownKeys() {
+        // unknownFutureField in metadata must not break the decode.
+        val corpus = ScreenerCorpusParser.parse(sample)
+        assertEquals("seed", corpus.metadata.source)
+    }
+
+    @Test
+    fun localizedFallsBackToEnglishWhenEsMissing() {
+        val corpus = ScreenerCorpusParser.parse(sample)
+        val incomeQ = corpus.questions.first { it.id == "income_limited" }
+        // No "es" supplied → Spanish request falls back to English.
+        assertEquals("Limited income?", incomeQ.prompt.get(spanish = true))
+        assertEquals("Limited income?", incomeQ.prompt.get(spanish = false))
+    }
+
+    @Test
+    fun localizedPrefersSpanishWhenPresent() {
+        val corpus = ScreenerCorpusParser.parse(sample)
+        val county = corpus.questions.first { it.id == "county" }
+        assertEquals("¿Condado?", county.prompt.get(spanish = true))
+        assertEquals("County?", county.prompt.get(spanish = false))
+    }
+
+    @Test
+    fun questionTypeMapping() {
+        val corpus = ScreenerCorpusParser.parse(sample)
+        assertEquals(QuestionType.SINGLE_SELECT, corpus.questions.first { it.id == "county" }.questionType)
+        assertEquals(QuestionType.BOOLEAN, corpus.questions.first { it.id == "income_limited" }.questionType)
+    }
+
+    @Test
+    fun seedProvenanceIsNotVerified() {
+        val corpus = ScreenerCorpusParser.parse(sample)
+        assertFalse(corpus.metadata.isVerified)
+    }
+
+    @Test
+    fun phoneIsNullWhenNotAsserted() {
+        val corpus = ScreenerCorpusParser.parse(sample)
+        assertNull(corpus.programs.first { it.id == "liheap" }.phone)
+        assertEquals("211", corpus.programs.first { it.id == "help_211" }.phone)
+    }
+
+    @Test
+    fun verifiedProvenanceFlipsBanner() {
+        val verified = sample.replace("\"seed-sample\"", "\"techempower-verified\"")
+        assertTrue(ScreenerCorpusParser.parse(verified).metadata.isVerified)
+    }
+}

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/techempower/screener/ScreenerEligibilityTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/techempower/screener/ScreenerEligibilityTest.kt
@@ -1,0 +1,116 @@
+package `in`.jphe.storyvox.feature.techempower.screener
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1517 — pins the pure eligibility evaluator. These are SEED rules; the
+ * evaluator itself is content-agnostic (it applies whatever declarative criteria
+ * the corpus carries), so this test locks the *logic*, not any program fact.
+ */
+class ScreenerEligibilityTest {
+
+    private fun program(id: String, vararg criteria: Criterion) = ScreenerProgram(
+        id = id,
+        name = Localized("n"),
+        summary = Localized("s"),
+        criteria = criteria.toList(),
+    )
+
+    private fun corpusOf(vararg programs: ScreenerProgram) = ScreenerCorpus(
+        metadata = CorpusMetadata(),
+        questions = emptyList(),
+        programs = programs.toList(),
+    )
+
+    @Test
+    fun noCriteriaAlwaysLikely() {
+        val p = program("help_211")
+        assertEquals(EligibilityBucket.LIKELY, ScreenerEligibility.evaluate(p, emptyMap()))
+    }
+
+    @Test
+    fun isTrueSatisfiedIsLikely() {
+        val p = program("liheap", Criterion("income_limited", Criterion.OP_IS_TRUE))
+        val answers = mapOf("income_limited" to Answer.Bool(true))
+        assertEquals(EligibilityBucket.LIKELY, ScreenerEligibility.evaluate(p, answers))
+    }
+
+    @Test
+    fun isTrueContradictedIsUnlikely() {
+        val p = program("liheap", Criterion("income_limited", Criterion.OP_IS_TRUE))
+        val answers = mapOf("income_limited" to Answer.Bool(false))
+        assertEquals(EligibilityBucket.UNLIKELY, ScreenerEligibility.evaluate(p, answers))
+    }
+
+    @Test
+    fun isFalseOperator() {
+        val p = program("x", Criterion("q", Criterion.OP_IS_FALSE))
+        assertEquals(EligibilityBucket.LIKELY, ScreenerEligibility.evaluate(p, mapOf("q" to Answer.Bool(false))))
+        assertEquals(EligibilityBucket.UNLIKELY, ScreenerEligibility.evaluate(p, mapOf("q" to Answer.Bool(true))))
+    }
+
+    @Test
+    fun equalsOperatorMatchesOptionId() {
+        val p = program("water", Criterion("county", Criterion.OP_EQUALS, "nevada"))
+        assertEquals(
+            EligibilityBucket.LIKELY,
+            ScreenerEligibility.evaluate(p, mapOf("county" to Answer.Choice("nevada"))),
+        )
+        assertEquals(
+            EligibilityBucket.UNLIKELY,
+            ScreenerEligibility.evaluate(p, mapOf("county" to Answer.Choice("other"))),
+        )
+    }
+
+    @Test
+    fun unansweredCriterionIsMaybe() {
+        val p = program("liheap", Criterion("income_limited", Criterion.OP_IS_TRUE))
+        assertEquals(EligibilityBucket.MAYBE, ScreenerEligibility.evaluate(p, emptyMap()))
+    }
+
+    @Test
+    fun contradictionBeatsUnanswered() {
+        // One criterion satisfied, one contradicted, one unanswered → UNLIKELY wins.
+        val p = program(
+            "multi",
+            Criterion("a", Criterion.OP_IS_TRUE),
+            Criterion("b", Criterion.OP_IS_TRUE),
+            Criterion("c", Criterion.OP_IS_TRUE),
+        )
+        val answers = mapOf(
+            "a" to Answer.Bool(true),   // satisfied
+            "b" to Answer.Bool(false),  // contradicted
+            // c unanswered
+        )
+        assertEquals(EligibilityBucket.UNLIKELY, ScreenerEligibility.evaluate(p, answers))
+    }
+
+    @Test
+    fun unknownOperatorNeverFalsePositive() {
+        val p = program("x", Criterion("q", "not_a_real_op"))
+        // Unknown op must not silently qualify someone.
+        assertEquals(EligibilityBucket.UNLIKELY, ScreenerEligibility.evaluate(p, mapOf("q" to Answer.Bool(true))))
+    }
+
+    @Test
+    fun resultsDropUnlikelyAndSortLikelyFirst() {
+        val corpus = corpusOf(
+            program("maybe_one", Criterion("q1", Criterion.OP_IS_TRUE)),      // unanswered → MAYBE
+            program("unlikely_one", Criterion("q2", Criterion.OP_IS_TRUE)),   // answered false → UNLIKELY
+            program("always"),                                                // LIKELY
+        )
+        val answers = mapOf("q2" to Answer.Bool(false))
+        val results = ScreenerEligibility.results(corpus, answers)
+
+        // UNLIKELY dropped.
+        assertEquals(2, results.size)
+        assertTrue(results.none { it.program.id == "unlikely_one" })
+        // LIKELY sorts before MAYBE.
+        assertEquals("always", results[0].program.id)
+        assertEquals(EligibilityBucket.LIKELY, results[0].bucket)
+        assertEquals("maybe_one", results[1].program.id)
+        assertEquals(EligibilityBucket.MAYBE, results[1].bucket)
+    }
+}


### PR DESCRIPTION
## Offline benefits screener — "Do I qualify?" (#1517)

A client-side benefits screener on the TechEmpower tab that works with **zero connectivity**. Answer a few questions → see bucketed local programs you may qualify for. Same privacy promise as techempower.org/qualify, now *provable*: the surface makes **no network calls at all**.

### Why Compose-native (not the WebView sketch)
The issue's v1 sketch bundles the site's static `/qualify` export as WebView assets. That export isn't in this repo, and inventing one would violate "verified or silent." A Compose-native surface reading a bundled JSON corpus is the invariant-compliant path and, per the issue's own v2 note, the right call when WebView friction demands it — here it also gives first-class TalkBack + read-aloud and a native list view, and makes airplane-mode trivially provable.

### ⚠️ Corpus provenance (verified-or-silent, invariant 3)
This PR ships the **surface + a corpus reader**. The bundled `feature/src/main/assets/techempower/screener_corpus.json` is a **SMALL, clearly-marked SEED SAMPLE** (`metadata.provenance = "seed-sample"`, `verifiedDate = 2026-07-04`). A persistent in-app **"Sample data"** banner is shown while the corpus is a seed.

**The production corpus (33 verified programs, EN/ES) is TechEmpower-supplied** from their adversarial fact-check pipeline. It replaces the asset wholesale — set `provenance` to `techempower-verified` and the seed banner disappears automatically. No program facts are authored here; the only phone number asserted is the public **211** line (all other programs route to 211 / the apply URL). Program *names* and org→program mappings are drawn from the epic #1520 issues; the eligibility thresholds in the seed are **illustrative placeholders**, not verified rules.

### What's in it
- **On-device / airplane-mode (invariant 1):** the ViewModel's only IO is reading a bundled asset — no OkHttp, no analytics, answers live only in memory.
- **EN/ES (invariant 2):** chrome via `res/values` + **new `res/values-es`** (first in the repo); corpus content carries its own `en`/`es` and follows device locale.
- **Accessibility (invariant 4):** single scrollable **list** (no spatial/overlay UI), TalkBack headings + labels, and **read-aloud** of every program via the app-level `PlaybackControllerUi.speakText` seam — `core-playback` is untouched.
- **Cross-lane seam:** `ScreenerProgramIds` exposes canonical program ids for the wallet proof-slots (#1514) and profile-autofill (#1519) lanes to key off.
- **Tests:** pure JVM unit tests for the JSON parser and the eligibility engine.

### Acceptance criteria
- [x] Airplane mode: complete a screen, see bucketed results EN + ES (pure asset read; locale-driven content)
- [x] Corpus verified-date visible; matches the shipped rules JSON (footer reads `metadata.verifiedDate` straight off the parsed corpus)
- [x] No network requests from the screener surface (no network deps by construction; a debug interceptor test is a suggested follow-up)

### Notes for the wave
- Adds the **kotlinx-serialization plugin** to `feature/build.gradle.kts` (same alias `core-data` / `source-notion` use) for the `@Serializable` models — flagging as a shared build-file touch.
- Ships a small verified-date seed sample; **production corpus is TechEmpower-supplied**.

Closes #1517
