### PR TITLE
feat(techempower): benefits letter decoder — NOA form-number → verified explainer (#1516)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -70,6 +70,7 @@ import `in`.jphe.storyvox.feature.settings.VoiceAndPlaybackSettingsScreen
 import `in`.jphe.storyvox.feature.settings.pronunciation.PronunciationDictScreen
 import `in`.jphe.storyvox.feature.techempower.TechEmpowerAboutScreen
 import `in`.jphe.storyvox.feature.techempower.TechEmpowerHomeScreen
+import `in`.jphe.storyvox.feature.techempower.decoder.DecoderScreen
 import `in`.jphe.storyvox.feature.techempower.screener.ScreenerScreen
 import `in`.jphe.storyvox.feature.voicelibrary.VoiceLibraryScreen
 import `in`.jphe.storyvox.ui.component.BottomTabBar
@@ -254,6 +255,13 @@ object StoryvoxRoutes {
      * client-side, zero-connectivity. Drill-down from TechEmpower Home.
      */
     const val TECHEMPOWER_SCREENER = "techempower/screener"
+
+    /**
+     * Issue #1516 — benefits letter decoder ("Understand a letter"). Photo /
+     * form-number → verified plain-language explainer. Drill-down from
+     * TechEmpower Home.
+     */
+    const val TECHEMPOWER_DECODER = "techempower/decoder"
     /** Q&A chat about a fiction (#81 follow-up). One chat history per
      *  fictionId; the screen pulls fiction title + current chapter
      *  context internally for the system prompt.
@@ -1678,6 +1686,9 @@ private fun StoryvoxNavHostContent(
                     onOpenScreener = {
                         navController.navigate(StoryvoxRoutes.TECHEMPOWER_SCREENER)
                     },
+                    onOpenDecoder = {
+                        navController.navigate(StoryvoxRoutes.TECHEMPOWER_DECODER)
+                    },
                     onOpenFiction = { fictionId ->
                         navController.navigate(StoryvoxRoutes.fictionDetail(fictionId))
                     },
@@ -1693,6 +1704,20 @@ private fun StoryvoxNavHostContent(
             ) {
                 ScreenerScreen(
                     onBack = { navController.popBackStack() },
+                )
+            }
+            // Issue #1516 — benefits letter decoder drill-down. "Scan a letter"
+            // reuses the existing OCR capture surface.
+            composable(
+                StoryvoxRoutes.TECHEMPOWER_DECODER,
+                enterTransition = pushEnter,
+                exitTransition = pushExit,
+                popEnterTransition = popEnter,
+                popExitTransition = popExit,
+            ) {
+                DecoderScreen(
+                    onBack = { navController.popBackStack() },
+                    onScan = { navController.navigate(StoryvoxRoutes.OCR_CAPTURE) },
                 )
             }
             composable(

--- a/feature/src/main/assets/techempower/notice_explainers.json
+++ b/feature/src/main/assets/techempower/notice_explainers.json
@@ -1,0 +1,90 @@
+{
+  "metadata": {
+    "schemaVersion": 1,
+    "provenance": "seed-sample",
+    "verifiedDate": "2026-07-04",
+    "freshnessMaxAgeDays": 365,
+    "source": "SEED SAMPLE — authored for surface development (issue #1516). NOT the production corpus.",
+    "note": "Placeholder Notice-of-Action explainers used to build and test the letter decoder. Form NUMBERS and the fact that these are template CA county notices come from epic #1520; the explainer TEXT here is provisional placeholder guidance, NOT verified content. The production corpus is TechEmpower-supplied from their adversarial fact-check pipeline (v1 = top ~10 CA notice types by volume, EN/ES, each explainer carrying verifiedAt + source). It replaces this file wholesale; set provenance to \"techempower-verified\" and the seed banner disappears. We never paraphrase or summarize the user's actual letter — unknown forms get an honest fallback, never a guess."
+  },
+  "explainers": [
+    {
+      "formNumber": "NA 200",
+      "aliases": ["NA200", "NA-200"],
+      "title": {
+        "en": "Notice of Action (NA 200)",
+        "es": "Aviso de Acción (NA 200)"
+      },
+      "whatItMeans": {
+        "en": "A Notice of Action is the standard letter a county sends when something about your benefits is changing — starting, stopping, going up, or going down.",
+        "es": "Un Aviso de Acción es la carta estándar que envía el condado cuando algo sobre sus beneficios va a cambiar: comenzar, terminar, subir o bajar."
+      },
+      "whyYouGotIt": {
+        "en": "Counties send this when they act on your case — after an application, a review, a reported change, or a scheduled recertification.",
+        "es": "El condado lo envía cuando actúa sobre su caso: después de una solicitud, una revisión, un cambio reportado o una recertificación programada."
+      },
+      "whatToDo": {
+        "en": "Read the date and the amount. If something looks wrong, you usually have a limited number of days to ask for a hearing. Call your county worker or 211 to confirm the deadline before it passes.",
+        "es": "Lea la fecha y el monto. Si algo parece incorrecto, normalmente tiene un número limitado de días para pedir una audiencia. Llame a su trabajador del condado o al 211 para confirmar la fecha límite antes de que pase."
+      },
+      "phone": "211",
+      "verifiedAt": "2026-07-04",
+      "source": {
+        "en": "Seed placeholder — pending TechEmpower verified explainer.",
+        "es": "Marcador de posición — pendiente del explicador verificado de TechEmpower."
+      }
+    },
+    {
+      "formNumber": "SAR 7",
+      "aliases": ["SAR7", "SAR-7"],
+      "title": {
+        "en": "Semi-Annual Report reminder (SAR 7)",
+        "es": "Recordatorio de Informe Semestral (SAR 7)"
+      },
+      "whatItMeans": {
+        "en": "The SAR 7 is a form you fill out twice a year to keep your benefits. This reminder means one is due soon.",
+        "es": "El SAR 7 es un formulario que completa dos veces al año para mantener sus beneficios. Este recordatorio significa que uno vence pronto."
+      },
+      "whyYouGotIt": {
+        "en": "Your county sends it on a schedule. Missing it is one of the most common reasons benefits stop.",
+        "es": "Su condado lo envía según un calendario. No entregarlo es una de las razones más comunes por las que se detienen los beneficios."
+      },
+      "whatToDo": {
+        "en": "Return it by the due date on the form. If you have lost it, call your county worker or 211 right away — do not wait.",
+        "es": "Devuélvalo antes de la fecha de vencimiento en el formulario. Si lo perdió, llame a su trabajador del condado o al 211 de inmediato; no espere."
+      },
+      "phone": "211",
+      "verifiedAt": "2026-07-04",
+      "source": {
+        "en": "Seed placeholder — pending TechEmpower verified explainer.",
+        "es": "Marcador de posición — pendiente del explicador verificado de TechEmpower."
+      }
+    },
+    {
+      "formNumber": "MC 355",
+      "aliases": ["MC355", "MC-355"],
+      "title": {
+        "en": "Medi-Cal notice (MC 355)",
+        "es": "Aviso de Medi-Cal (MC 355)"
+      },
+      "whatItMeans": {
+        "en": "This is a Medi-Cal notice about your health coverage — often about renewing or a change in your case.",
+        "es": "Este es un aviso de Medi-Cal sobre su cobertura de salud, a menudo sobre una renovación o un cambio en su caso."
+      },
+      "whyYouGotIt": {
+        "en": "Medi-Cal sends notices when coverage is renewed, changed, or needs information from you.",
+        "es": "Medi-Cal envía avisos cuando la cobertura se renueva, cambia o necesita información de usted."
+      },
+      "whatToDo": {
+        "en": "Check whether it asks for anything by a date. If it does, respond before that date. Call 211 if you are unsure what it is asking for.",
+        "es": "Verifique si pide algo antes de una fecha. Si es así, responda antes de esa fecha. Llame al 211 si no está seguro de qué le está pidiendo."
+      },
+      "phone": "211",
+      "verifiedAt": "2026-07-04",
+      "source": {
+        "en": "Seed placeholder — pending TechEmpower verified explainer.",
+        "es": "Marcador de posición — pendiente del explicador verificado de TechEmpower."
+      }
+    }
+  ]
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/TechEmpowerHomeScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/TechEmpowerHomeScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.FactCheck
 import androidx.compose.material.icons.filled.Forum
 import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Mail
 import androidx.compose.material.icons.filled.Phone
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -98,6 +99,7 @@ fun TechEmpowerHomeScreen(
     onOpenBrowse: () -> Unit,
     onOpenAbout: () -> Unit,
     onOpenScreener: () -> Unit,
+    onOpenDecoder: () -> Unit,
     onOpenFiction: (String) -> Unit,
 ) {
     val spacing = LocalSpacing.current
@@ -167,6 +169,16 @@ fun TechEmpowerHomeScreen(
                     body = "Free tech guides, EBT support, and digital safety — read or listen.",
                     icon = null,
                     onClick = onOpenBrowse,
+                )
+            }
+            // Issue #1516 — "Understand a letter" decoder card. Bilingual copy
+            // via string resources.
+            item {
+                TechEmpowerCard(
+                    title = stringResource(FeatureR.string.decoder_card_title),
+                    body = stringResource(FeatureR.string.decoder_card_body),
+                    icon = Icons.Filled.Mail,
+                    onClick = onOpenDecoder,
                 )
             }
             item {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/decoder/DecoderScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/decoder/DecoderScreen.kt
@@ -1,0 +1,437 @@
+package `in`.jphe.storyvox.feature.techempower.decoder
+
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.OpenInNew
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.CameraAlt
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Phone
+import androidx.compose.material.icons.filled.VolumeUp
+import androidx.compose.material3.Button
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import `in`.jphe.storyvox.data.TechEmpowerLinks
+import `in`.jphe.storyvox.feature.R
+import `in`.jphe.storyvox.ui.theme.LocalSpacing
+
+/**
+ * Issue #1516 — benefits letter decoder surface.
+ *
+ * Photograph (or type) a Notice of Action → detect its form number → show a
+ * hand-written **verified** plain-language explainer (EN/ES), listenable via
+ * TTS. Unknown form → honest fallback (read-aloud + call 211), never a guess.
+ *
+ * A plain scrolling form (not a spatial/overlay UI) so it's fully TalkBack-
+ * navigable (invariant 4). Chrome is bilingual via `res/values` + `res/values-es`;
+ * explainer content carries its own EN/ES and follows the device locale.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DecoderScreen(
+    onBack: () -> Unit,
+    onScan: () -> Unit,
+    viewModel: DecoderViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsState()
+    val spanish = LocalConfiguration.current.locales[0].language == "es"
+
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = {
+                    Text(
+                        stringResource(R.string.decoder_title),
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.decoder_back),
+                        )
+                    }
+                },
+            )
+        },
+    ) { scaffoldPadding ->
+        when {
+            state.isLoading -> CenteredBox(Modifier.padding(scaffoldPadding)) { CircularProgressIndicator() }
+            state.loadError -> CenteredBox(Modifier.padding(scaffoldPadding)) {
+                Text(
+                    stringResource(R.string.decoder_load_error),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            else -> DecoderContent(
+                state = state,
+                spanish = spanish,
+                onScan = onScan,
+                onInputChange = viewModel::onInputChange,
+                onDecode = viewModel::decode,
+                onUseLastScan = viewModel::useMostRecentScan,
+                onReadAloud = viewModel::readAloud,
+                onStop = viewModel::stopReadAloud,
+                onReset = viewModel::reset,
+                modifier = Modifier.padding(scaffoldPadding),
+            )
+        }
+    }
+}
+
+@Composable
+private fun CenteredBox(modifier: Modifier = Modifier, content: @Composable () -> Unit) {
+    Box(modifier.fillMaxSize(), contentAlignment = Alignment.Center) { content() }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun DecoderContent(
+    state: DecoderUiState,
+    spanish: Boolean,
+    onScan: () -> Unit,
+    onInputChange: (String) -> Unit,
+    onDecode: () -> Unit,
+    onUseLastScan: () -> Unit,
+    onReadAloud: (String) -> Unit,
+    onStop: () -> Unit,
+    onReset: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val corpus = state.corpus ?: return
+    val spacing = LocalSpacing.current
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(spacing.md),
+        verticalArrangement = Arrangement.spacedBy(spacing.md),
+    ) {
+        Column(verticalArrangement = Arrangement.spacedBy(spacing.xs)) {
+            Text(
+                stringResource(R.string.decoder_intro),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            Text(
+                stringResource(R.string.decoder_offline_note),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
+        if (!corpus.metadata.isVerified) SampleDataBanner()
+
+        // Capture / reuse-scan affordances.
+        FlowRow(horizontalArrangement = Arrangement.spacedBy(spacing.sm)) {
+            OutlinedButton(onClick = onScan) {
+                Icon(Icons.Filled.CameraAlt, contentDescription = null, modifier = Modifier.size(18.dp))
+                Spacer(Modifier.width(spacing.xs))
+                Text(stringResource(R.string.decoder_scan))
+            }
+            if (state.hasRecentScan) {
+                TextButton(onClick = onUseLastScan) {
+                    Text(stringResource(R.string.decoder_use_last_scan))
+                }
+            }
+        }
+
+        // Manual entry (paste text or a form number).
+        OutlinedTextField(
+            value = state.inputText,
+            onValueChange = onInputChange,
+            label = { Text(stringResource(R.string.decoder_input_label)) },
+            placeholder = { Text(stringResource(R.string.decoder_input_placeholder)) },
+            modifier = Modifier.fillMaxWidth(),
+            minLines = 2,
+        )
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+        ) {
+            Button(onClick = onDecode, modifier = Modifier.weight(1f)) {
+                Text(stringResource(R.string.decoder_decode))
+            }
+            if (state.result != null || state.inputText.isNotEmpty()) {
+                TextButton(onClick = onReset) {
+                    Text(stringResource(R.string.decoder_start_over))
+                }
+            }
+        }
+
+        when (val result = state.result) {
+            is DecodeResult.Known -> KnownExplainerCard(
+                explainer = result.explainer,
+                spanish = spanish,
+                onReadAloud = onReadAloud,
+                onStop = onStop,
+            )
+            is DecodeResult.Unknown -> UnknownFallbackCard(
+                scannedText = result.scannedText,
+                onReadAloud = onReadAloud,
+                onStop = onStop,
+            )
+            null -> Unit
+        }
+
+        VerifiedFooter(corpus)
+    }
+}
+
+@Composable
+private fun SampleDataBanner() {
+    val spacing = LocalSpacing.current
+    val accent = MaterialTheme.colorScheme.tertiary
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(MaterialTheme.shapes.medium)
+            .background(accent.copy(alpha = 0.12f))
+            .border(1.dp, accent.copy(alpha = 0.5f), MaterialTheme.shapes.medium)
+            .padding(spacing.md),
+        horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+    ) {
+        Icon(Icons.Filled.Info, contentDescription = null, tint = accent, modifier = Modifier.size(20.dp))
+        Column(verticalArrangement = Arrangement.spacedBy(spacing.xs)) {
+            Text(
+                stringResource(R.string.decoder_seed_banner_title),
+                style = MaterialTheme.typography.labelLarge,
+                color = accent,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Text(
+                stringResource(R.string.decoder_seed_banner_body),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun KnownExplainerCard(
+    explainer: NoticeExplainer,
+    spanish: Boolean,
+    onReadAloud: (String) -> Unit,
+    onStop: () -> Unit,
+) {
+    val spacing = LocalSpacing.current
+    val context = LocalContext.current
+    val brass = MaterialTheme.colorScheme.primary
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(MaterialTheme.shapes.large)
+            .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+            .border(1.5.dp, brass.copy(alpha = 0.55f), MaterialTheme.shapes.large)
+            .padding(spacing.md),
+        verticalArrangement = Arrangement.spacedBy(spacing.sm),
+    ) {
+        Text(
+            explainer.title.get(spanish),
+            style = MaterialTheme.typography.titleMedium,
+            color = brass,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.semantics { heading() },
+        )
+        ExplainerSection(stringResource(R.string.decoder_section_meaning), explainer.whatItMeans.get(spanish))
+        ExplainerSection(stringResource(R.string.decoder_section_why), explainer.whyYouGotIt.get(spanish))
+        ExplainerSection(stringResource(R.string.decoder_section_todo), explainer.whatToDo.get(spanish))
+
+        FlowRow(horizontalArrangement = Arrangement.spacedBy(spacing.sm)) {
+            OutlinedButton(onClick = { onReadAloud(explainerAsSpeech(explainer, spanish)) }) {
+                Icon(Icons.Filled.VolumeUp, contentDescription = null, modifier = Modifier.size(18.dp))
+                Spacer(Modifier.width(spacing.xs))
+                Text(stringResource(R.string.decoder_read_aloud))
+            }
+            TextButton(onClick = onStop) { Text(stringResource(R.string.decoder_stop)) }
+            val number = explainer.phone ?: TechEmpowerLinks.PRIMARY_HELP_NUMBER
+            TextButton(onClick = { dial(context, number) }) {
+                Icon(Icons.Filled.Phone, contentDescription = null, modifier = Modifier.size(18.dp))
+                Spacer(Modifier.width(spacing.xs))
+                Text(if (explainer.phone != null) stringResource(R.string.decoder_call) else stringResource(R.string.decoder_call_211))
+            }
+        }
+
+        explainer.verifiedAt?.let {
+            Text(
+                stringResource(R.string.decoder_verified_prefix, it),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        } ?: Text(
+            stringResource(R.string.decoder_verified_unknown),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun ExplainerSection(label: String, body: String) {
+    val spacing = LocalSpacing.current
+    Column(verticalArrangement = Arrangement.spacedBy(spacing.xs)) {
+        Text(
+            label,
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.semantics { heading() },
+        )
+        Text(body, style = MaterialTheme.typography.bodyMedium)
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun UnknownFallbackCard(
+    scannedText: String,
+    onReadAloud: (String) -> Unit,
+    onStop: () -> Unit,
+) {
+    val spacing = LocalSpacing.current
+    val context = LocalContext.current
+    val accent = MaterialTheme.colorScheme.tertiary
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(MaterialTheme.shapes.large)
+            .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+            .border(1.5.dp, accent.copy(alpha = 0.5f), MaterialTheme.shapes.large)
+            .padding(spacing.md),
+        verticalArrangement = Arrangement.spacedBy(spacing.sm),
+    ) {
+        Text(
+            stringResource(R.string.decoder_unknown_title),
+            style = MaterialTheme.typography.titleMedium,
+            color = accent,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.semantics { heading() },
+        )
+        Text(
+            stringResource(R.string.decoder_unknown_body),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        FlowRow(horizontalArrangement = Arrangement.spacedBy(spacing.sm)) {
+            // Read-aloud the scanned text (OCR → TTS) — no interpretation, just
+            // the user's own letter read back to them.
+            if (scannedText.isNotBlank()) {
+                OutlinedButton(onClick = { onReadAloud(scannedText) }) {
+                    Icon(Icons.Filled.VolumeUp, contentDescription = null, modifier = Modifier.size(18.dp))
+                    Spacer(Modifier.width(spacing.xs))
+                    Text(stringResource(R.string.decoder_read_scanned))
+                }
+                TextButton(onClick = onStop) { Text(stringResource(R.string.decoder_stop)) }
+            }
+            TextButton(onClick = { dial(context, TechEmpowerLinks.PRIMARY_HELP_NUMBER) }) {
+                Icon(Icons.Filled.Phone, contentDescription = null, modifier = Modifier.size(18.dp))
+                Spacer(Modifier.width(spacing.xs))
+                Text(stringResource(R.string.decoder_call_211))
+            }
+            TextButton(onClick = { openUrl(context, TechEmpowerLinks.WEBSITE_URL) }) {
+                Icon(Icons.AutoMirrored.Filled.OpenInNew, contentDescription = null, modifier = Modifier.size(18.dp))
+                Spacer(Modifier.width(spacing.xs))
+                Text(stringResource(R.string.decoder_learn_more))
+            }
+        }
+    }
+}
+
+@Composable
+private fun VerifiedFooter(corpus: ExplainerCorpus) {
+    val spacing = LocalSpacing.current
+    val date = corpus.metadata.verifiedDate
+    val text = if (date != null) {
+        stringResource(R.string.decoder_verified_prefix, date)
+    } else {
+        stringResource(R.string.decoder_verified_unknown)
+    }
+    Text(
+        text,
+        style = MaterialTheme.typography.labelSmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = spacing.sm),
+    )
+}
+
+// ─── Speech + intents ──────────────────────────────────────────────────────
+
+private fun explainerAsSpeech(e: NoticeExplainer, spanish: Boolean): String =
+    buildString {
+        append(e.title.get(spanish)); append(". ")
+        append(e.whatItMeans.get(spanish)); append(" ")
+        append(e.whyYouGotIt.get(spanish)); append(" ")
+        append(e.whatToDo.get(spanish))
+    }
+
+private fun dial(context: Context, number: String) {
+    runCatching {
+        context.startActivity(
+            Intent(Intent.ACTION_DIAL, Uri.parse(TechEmpowerLinks.telUri(number)))
+                .apply { addFlags(Intent.FLAG_ACTIVITY_NEW_TASK) },
+        )
+    }
+}
+
+private fun openUrl(context: Context, url: String) {
+    try {
+        context.startActivity(
+            Intent(Intent.ACTION_VIEW, Uri.parse(url))
+                .apply { addFlags(Intent.FLAG_ACTIVITY_NEW_TASK) },
+        )
+    } catch (_: ActivityNotFoundException) {
+        // No browser available (offline-only device) — the call affordance
+        // above remains the actionable fallback.
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/decoder/DecoderViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/decoder/DecoderViewModel.kt
@@ -1,0 +1,153 @@
+package `in`.jphe.storyvox.feature.techempower.decoder
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import `in`.jphe.storyvox.feature.api.PlaybackControllerUi
+import `in`.jphe.storyvox.source.ocr.config.OcrConfig
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+/**
+ * Issue #1516 — benefits letter decoder ViewModel.
+ *
+ * Pipeline: notice text (typed, pasted, or reused from the most recent OCR
+ * scan) → [NoticeFormDetector] → verified [NoticeExplainer] from the corpus.
+ * Unknown form → honest [DecodeResult.Unknown] fallback (read-aloud of the
+ * scanned text + call 211), NEVER a generated explanation (invariant 3).
+ *
+ * REUSE (epic #1520): OCR text comes from the existing scan pipeline via
+ * [OcrConfig] (no camera code here); read-aloud goes through the app-level
+ * [PlaybackControllerUi] seam. `core-playback` is untouched.
+ *
+ * ON-DEVICE ONLY: the only IO is reading a bundled asset + the local OCR store.
+ * No network, no analytics — the letter's text never leaves the device.
+ */
+@HiltViewModel
+class DecoderViewModel @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val playback: PlaybackControllerUi,
+    private val ocrConfig: OcrConfig,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(DecoderUiState())
+    val state: StateFlow<DecoderUiState> = _state.asStateFlow()
+
+    init {
+        loadCorpus()
+        observeScans()
+    }
+
+    private fun loadCorpus() {
+        viewModelScope.launch {
+            val result = runCatching {
+                val raw = withContext(Dispatchers.IO) {
+                    context.assets.open(CORPUS_ASSET).use { it.readBytes().decodeToString() }
+                }
+                ExplainerCorpusParser.parse(raw)
+            }
+            // `st` names the outer state param explicitly — inside fold, the
+            // onFailure lambda's implicit `it` is the Throwable, not the state,
+            // so `it.copy(...)` would not resolve.
+            _state.update { st ->
+                result.fold(
+                    onSuccess = { corpus -> st.copy(corpus = corpus, loadError = false) },
+                    onFailure = { st.copy(corpus = null, loadError = true) },
+                )
+            }
+        }
+    }
+
+    private fun observeScans() {
+        viewModelScope.launch {
+            ocrConfig.documents.collect { docs ->
+                _state.update { it.copy(hasRecentScan = docs.isNotEmpty()) }
+            }
+        }
+    }
+
+    fun onInputChange(text: String) {
+        _state.update { it.copy(inputText = text) }
+    }
+
+    /** Detect the form number in the current input and resolve an explainer. */
+    fun decode() {
+        _state.update { current ->
+            val corpus = current.corpus ?: return@update current
+            val text = current.inputText
+            val explainer = NoticeFormDetector.firstKnown(text, corpus)
+            val result = if (explainer != null) {
+                DecodeResult.Known(explainer)
+            } else {
+                DecodeResult.Unknown(text)
+            }
+            current.copy(result = result)
+        }
+    }
+
+    /** Pull the newest OCR scan's text into the input, then decode it. */
+    fun useMostRecentScan() {
+        viewModelScope.launch {
+            val text = withContext(Dispatchers.IO) {
+                ocrConfig.documents().firstOrNull()
+                    ?.pages
+                    ?.joinToString("\n") { it.text }
+                    .orEmpty()
+            }
+            if (text.isNotBlank()) {
+                _state.update { it.copy(inputText = text) }
+                decode()
+            }
+        }
+    }
+
+    fun readAloud(text: String) {
+        if (text.isBlank()) return
+        viewModelScope.launch { playback.speakText(text) }
+    }
+
+    fun stopReadAloud() {
+        playback.stopSpeaking()
+    }
+
+    fun reset() {
+        stopReadAloud()
+        _state.update { it.copy(inputText = "", result = null) }
+    }
+
+    override fun onCleared() {
+        stopReadAloud()
+        super.onCleared()
+    }
+
+    companion object {
+        const val CORPUS_ASSET = "techempower/notice_explainers.json"
+    }
+}
+
+/** Result of decoding notice text. */
+sealed interface DecodeResult {
+    /** A verified explainer matched the detected form number. */
+    data class Known(val explainer: NoticeExplainer) : DecodeResult
+
+    /** No verified explainer — honest fallback. [scannedText] feeds read-aloud. */
+    data class Unknown(val scannedText: String) : DecodeResult
+}
+
+data class DecoderUiState(
+    val corpus: ExplainerCorpus? = null,
+    val loadError: Boolean = false,
+    val inputText: String = "",
+    val result: DecodeResult? = null,
+    val hasRecentScan: Boolean = false,
+) {
+    val isLoading: Boolean get() = corpus == null && !loadError
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/decoder/ExplainerCorpus.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/decoder/ExplainerCorpus.kt
@@ -1,0 +1,90 @@
+package `in`.jphe.storyvox.feature.techempower.decoder
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Issue #1516 — data model for the **benefits letter decoder** corpus.
+ *
+ * The decoder photographs a Notice of Action → OCR → detects the form number →
+ * shows a plain-language, **hand-written verified explainer** (EN/ES) of what
+ * that notice type means and what to do. NO generative summarization of the
+ * user's actual letter: a wrong paraphrase of a benefits notice is a harm.
+ *
+ * VERIFIED-OR-SILENT (epic #1520 invariant 3): this module ships the SURFACE +
+ * detection + a corpus READER. The bundled `notice_explainers.json` is a SMALL,
+ * clearly-marked SEED SAMPLE ([DecoderMetadata.provenance] == `"seed-sample"`).
+ * The production corpus (top ~10 CA notice types, EN/ES, each explainer with
+ * verifiedAt + source) is TechEmpower-supplied and replaces the asset wholesale.
+ * An UNKNOWN form number → honest fallback, never a guess.
+ */
+@Serializable
+data class ExplainerCorpus(
+    val metadata: DecoderMetadata,
+    val explainers: List<NoticeExplainer> = emptyList(),
+) {
+    /** Normalized form-number → explainer, including aliases. Built once. */
+    private val byNormalizedForm: Map<String, NoticeExplainer> by lazy {
+        buildMap {
+            for (e in explainers) {
+                put(normalizeFormNumber(e.formNumber), e)
+                for (alias in e.aliases) put(normalizeFormNumber(alias), e)
+            }
+        }
+    }
+
+    /** Look up a verified explainer for [rawFormNumber]; null when we have none. */
+    fun find(rawFormNumber: String): NoticeExplainer? =
+        byNormalizedForm[normalizeFormNumber(rawFormNumber)]
+}
+
+@Serializable
+data class DecoderMetadata(
+    val schemaVersion: Int = 1,
+    val provenance: String = PROVENANCE_SEED,
+    val verifiedDate: String? = null,
+    val freshnessMaxAgeDays: Long = 365,
+    val source: String? = null,
+    val note: String? = null,
+) {
+    val isVerified: Boolean get() = provenance == PROVENANCE_VERIFIED
+
+    companion object {
+        const val PROVENANCE_SEED = "seed-sample"
+        const val PROVENANCE_VERIFIED = "techempower-verified"
+    }
+}
+
+/** A bilingual string; [get] picks the language, falling back to EN. */
+@Serializable
+data class Localized(
+    val en: String,
+    val es: String? = null,
+) {
+    fun get(spanish: Boolean): String = if (spanish) (es ?: en) else en
+}
+
+/**
+ * One verified explainer for a notice type. All fields are hand-written verified
+ * content in the production corpus; the seed carries placeholder text plainly
+ * labeled in [source].
+ */
+@Serializable
+data class NoticeExplainer(
+    val formNumber: String,
+    val aliases: List<String> = emptyList(),
+    val title: Localized,
+    val whatItMeans: Localized,
+    val whyYouGotIt: Localized,
+    val whatToDo: Localized,
+    val phone: String? = null,
+    val verifiedAt: String? = null,
+    val source: Localized? = null,
+)
+
+/**
+ * Canonical form-number key: uppercase, strip everything but letters/digits.
+ * "NA 200" / "na-200" / "NA200" all collapse to "NA200" so detection and lookup
+ * agree regardless of how the OCR rendered the spaces/dashes.
+ */
+fun normalizeFormNumber(raw: String): String =
+    raw.uppercase().filter { it.isLetterOrDigit() }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/decoder/ExplainerCorpusParser.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/decoder/ExplainerCorpusParser.kt
@@ -1,0 +1,16 @@
+package `in`.jphe.storyvox.feature.techempower.decoder
+
+import kotlinx.serialization.json.Json
+
+/**
+ * Issue #1516 — pure JSON → [ExplainerCorpus] decode. No Android, no IO.
+ */
+object ExplainerCorpusParser {
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+    }
+
+    fun parse(raw: String): ExplainerCorpus =
+        json.decodeFromString(ExplainerCorpus.serializer(), raw)
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/decoder/ExplainerFreshness.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/decoder/ExplainerFreshness.kt
@@ -1,0 +1,38 @@
+package `in`.jphe.storyvox.feature.techempower.decoder
+
+import java.time.LocalDate
+import java.time.format.DateTimeParseException
+import java.time.temporal.ChronoUnit
+
+/**
+ * Issue #1516 — pure freshness check for verified explainers.
+ *
+ * Acceptance criterion: "a CI check fails explainers older than the freshness
+ * bar." This is the logic behind that gate — deterministic (caller supplies
+ * `asOf`, no wall-clock here). The time-relative CI gate is enabled against the
+ * TechEmpower-supplied production corpus; the seed sample intentionally does not
+ * fail CI as it ages (it is placeholder content, not verified).
+ */
+object ExplainerFreshness {
+
+    /** True when [verifiedAt] (ISO yyyy-MM-dd) is within [maxAgeDays] of [asOf]. */
+    fun isFresh(verifiedAt: String?, asOf: LocalDate, maxAgeDays: Long): Boolean {
+        val date = parse(verifiedAt) ?: return false // unparseable / missing → not fresh
+        if (date.isAfter(asOf)) return true // stamped in the future → treat as fresh
+        val ageDays = ChronoUnit.DAYS.between(date, asOf)
+        return ageDays <= maxAgeDays
+    }
+
+    /** Explainers in [corpus] that are stale as of [asOf], by the corpus's bar. */
+    fun staleExplainers(corpus: ExplainerCorpus, asOf: LocalDate): List<NoticeExplainer> =
+        corpus.explainers.filter { !isFresh(it.verifiedAt, asOf, corpus.metadata.freshnessMaxAgeDays) }
+
+    private fun parse(value: String?): LocalDate? {
+        if (value.isNullOrBlank()) return null
+        return try {
+            LocalDate.parse(value)
+        } catch (_: DateTimeParseException) {
+            null
+        }
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/decoder/NoticeFormDetector.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/decoder/NoticeFormDetector.kt
@@ -1,0 +1,42 @@
+package `in`.jphe.storyvox.feature.techempower.decoder
+
+/**
+ * Issue #1516 — pure form-number detection over OCR'd (or typed) notice text.
+ *
+ * CA notices carry a form number in a footer or title line — e.g. `NA 200`,
+ * `NA 274`, `MC 355`, `SAR 7`. These are template documents, so a regex for
+ * "2–4 letters + 1–4 digits" reliably surfaces candidate form numbers. We do
+ * NOT interpret the letter's contents; we only find the form-number token and
+ * hand it to the corpus lookup. Detection producing a candidate the corpus does
+ * not know → honest "no verified explainer" fallback, never a guess.
+ */
+object NoticeFormDetector {
+
+    // Prefix (2–4 letters), optional space/dash, then 1–4 digits.
+    private val FORM_PATTERN = Regex("""\b([A-Za-z]{2,4})[ \-]?(\d{1,4})\b""")
+
+    /**
+     * All distinct normalized form-number candidates in [text], in first-seen
+     * order. Empty when nothing looks like a form number.
+     */
+    fun detectCandidates(text: String): List<String> {
+        val seen = LinkedHashSet<String>()
+        for (match in FORM_PATTERN.findAll(text)) {
+            val prefix = match.groupValues[1]
+            val digits = match.groupValues[2]
+            seen.add(normalizeFormNumber("$prefix$digits"))
+        }
+        return seen.toList()
+    }
+
+    /**
+     * The first candidate in [text] that [corpus] has a verified explainer for,
+     * or null. This is the "did we recognize this notice?" answer.
+     */
+    fun firstKnown(text: String, corpus: ExplainerCorpus): NoticeExplainer? {
+        for (candidate in detectCandidates(text)) {
+            corpus.find(candidate)?.let { return it }
+        }
+        return null
+    }
+}

--- a/feature/src/main/res/values-es/strings.xml
+++ b/feature/src/main/res/values-es/strings.xml
@@ -68,4 +68,34 @@
     <!-- Tarjeta de entrada en la cuadrícula de Inicio de TechEmpower. -->
     <string name="screener_card_title">¿Califico?</string>
     <string name="screener_card_body">Responda unas preguntas rápidas para encontrar ayuda local para la que podría ser elegible. Funciona sin conexión.</string>
+
+    <!-- #1516 — Benefits letter decoder -->
+    <string name="decoder_title">Entender una carta</string>
+    <string name="decoder_back">Atrás</string>
+    <string name="decoder_intro">Tome una foto de una carta de beneficios, o escriba su número de formulario, y le explicaremos qué significa y qué hacer.</string>
+    <string name="decoder_offline_note">Funciona sin conexión. El texto de la carta se queda en este dispositivo.</string>
+    <string name="decoder_seed_banner_title">Datos de muestra</string>
+    <string name="decoder_seed_banner_body">Estos explicadores son una vista previa. Los explicadores finales y verificados provienen de TechEmpower.</string>
+    <string name="decoder_input_label">Texto de la carta o número de formulario</string>
+    <string name="decoder_input_placeholder">Por ejemplo: NA 200</string>
+    <string name="decoder_scan">Escanear una carta</string>
+    <string name="decoder_use_last_scan">Usar mi último escaneo</string>
+    <string name="decoder_decode">Explicar esta carta</string>
+    <string name="decoder_start_over">Empezar de nuevo</string>
+    <string name="decoder_section_meaning">Qué significa</string>
+    <string name="decoder_section_why">Por qué la recibió</string>
+    <string name="decoder_section_todo">Qué hacer</string>
+    <string name="decoder_read_aloud">Leer en voz alta</string>
+    <string name="decoder_read_scanned">Leer mi carta en voz alta</string>
+    <string name="decoder_stop">Detener</string>
+    <string name="decoder_call">Llamar</string>
+    <string name="decoder_call_211">Llamar al 211</string>
+    <string name="decoder_learn_more">Más información</string>
+    <!-- %1$s = la fecha de verificación del explicador. -->
+    <string name="decoder_verified_prefix">Explicador verificado: %1$s</string>
+    <string name="decoder_verified_unknown">Este explicador aún no está verificado.</string>
+    <string name="decoder_load_error">No pudimos abrir la biblioteca de explicadores. Actualice la aplicación e inténtelo de nuevo.</string>
+    <!-- Tarjeta de entrada en la cuadrícula de Inicio de TechEmpower. -->
+    <string name="decoder_card_title">Entender una carta</string>
+    <string name="decoder_card_body">Fotografíe un aviso de beneficios confuso; le explicaremos qué significa, en inglés o español. Funciona sin conexión.</string>
 </resources>

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -1306,4 +1306,36 @@
     <!-- Entry card on the TechEmpower Home grid. -->
     <string name="screener_card_title">Do I qualify?</string>
     <string name="screener_card_body">Answer a few quick questions to find local help you may be eligible for. Works offline.</string>
+
+    <!-- #1516 — Benefits letter decoder -->
+    <string name="decoder_title">Understand a letter</string>
+    <string name="decoder_back">Back</string>
+    <string name="decoder_intro">Take a photo of a benefits letter, or type its form number, and we will explain what it means and what to do.</string>
+    <string name="decoder_offline_note">Works offline. The letter\'s text stays on this device.</string>
+    <string name="decoder_seed_banner_title">Sample data</string>
+    <string name="decoder_seed_banner_body">These explainers are a preview. Final, verified explainers come from TechEmpower.</string>
+    <string name="decoder_input_label">Letter text or form number</string>
+    <string name="decoder_input_placeholder">For example: NA 200</string>
+    <string name="decoder_scan">Scan a letter</string>
+    <string name="decoder_use_last_scan">Use my last scan</string>
+    <string name="decoder_decode">Explain this letter</string>
+    <string name="decoder_start_over">Start over</string>
+    <string name="decoder_section_meaning">What it means</string>
+    <string name="decoder_section_why">Why you got it</string>
+    <string name="decoder_section_todo">What to do</string>
+    <string name="decoder_read_aloud">Read aloud</string>
+    <string name="decoder_read_scanned">Read my letter aloud</string>
+    <string name="decoder_stop">Stop</string>
+    <string name="decoder_call">Call</string>
+    <string name="decoder_call_211">Call 211</string>
+    <string name="decoder_learn_more">Learn more</string>
+    <string name="decoder_unknown_title">We don\'t have a verified explainer for this yet</string>
+    <string name="decoder_unknown_body">We will not guess what your letter says. You can hear it read aloud, or call 211 for free help understanding it.</string>
+    <!-- %1$s = the explainer\'s verified date. -->
+    <string name="decoder_verified_prefix">Explainer verified: %1$s</string>
+    <string name="decoder_verified_unknown">This explainer is not yet verified.</string>
+    <string name="decoder_load_error">We could not open the explainer library. Please update the app and try again.</string>
+    <!-- Entry card on the TechEmpower Home grid. -->
+    <string name="decoder_card_title">Understand a letter</string>
+    <string name="decoder_card_body">Photograph a confusing benefits notice — we will explain what it means, in English or Spanish. Works offline.</string>
 </resources>

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/techempower/decoder/ExplainerCorpusTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/techempower/decoder/ExplainerCorpusTest.kt
@@ -1,0 +1,85 @@
+package `in`.jphe.storyvox.feature.techempower.decoder
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1516 — pins corpus decode + explainer lookup, including the alias and
+ * unknown-form paths that drive the honest fallback.
+ */
+class ExplainerCorpusTest {
+
+    private val sample = """
+        {
+          "metadata": {
+            "schemaVersion": 1,
+            "provenance": "seed-sample",
+            "verifiedDate": "2026-07-04",
+            "freshnessMaxAgeDays": 365,
+            "source": "seed",
+            "futureUnknownField": "ignored"
+          },
+          "explainers": [
+            {
+              "formNumber": "NA 200",
+              "aliases": ["NA200", "NA-200"],
+              "title": { "en": "Notice of Action (NA 200)", "es": "Aviso (NA 200)" },
+              "whatItMeans": { "en": "means-en", "es": "means-es" },
+              "whyYouGotIt": { "en": "why-en" },
+              "whatToDo": { "en": "todo-en", "es": "todo-es" },
+              "phone": "211",
+              "verifiedAt": "2026-07-04",
+              "source": { "en": "seed" }
+            }
+          ]
+        }
+    """.trimIndent()
+
+    @Test
+    fun parsesMetadataAndExplainers() {
+        val corpus = ExplainerCorpusParser.parse(sample)
+        assertEquals("seed-sample", corpus.metadata.provenance)
+        assertEquals(365L, corpus.metadata.freshnessMaxAgeDays)
+        assertEquals(1, corpus.explainers.size)
+        assertFalse(corpus.metadata.isVerified)
+    }
+
+    @Test
+    fun findResolvesByCanonicalForm() {
+        val corpus = ExplainerCorpusParser.parse(sample)
+        assertNotNull(corpus.find("NA 200"))
+        assertEquals("Notice of Action (NA 200)", corpus.find("NA 200")!!.title.get(spanish = false))
+    }
+
+    @Test
+    fun findResolvesByAliasAndNormalization() {
+        val corpus = ExplainerCorpusParser.parse(sample)
+        assertNotNull(corpus.find("NA200"))
+        assertNotNull(corpus.find("na-200"))
+        assertNotNull(corpus.find("Na 200"))
+    }
+
+    @Test
+    fun findReturnsNullForUnknownForm() {
+        val corpus = ExplainerCorpusParser.parse(sample)
+        assertNull(corpus.find("XX 999"))
+    }
+
+    @Test
+    fun localizedFallsBackToEnglish() {
+        val corpus = ExplainerCorpusParser.parse(sample)
+        val e = corpus.find("NA 200")!!
+        assertEquals("means-es", e.whatItMeans.get(spanish = true))
+        assertEquals("why-en", e.whyYouGotIt.get(spanish = true)) // no es → fallback
+    }
+
+    @Test
+    fun ignoresUnknownKeys() {
+        // futureUnknownField in metadata must not break decode.
+        assertTrue(ExplainerCorpusParser.parse(sample).explainers.isNotEmpty())
+    }
+}

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/techempower/decoder/ExplainerFreshnessTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/techempower/decoder/ExplainerFreshnessTest.kt
@@ -1,0 +1,70 @@
+package `in`.jphe.storyvox.feature.techempower.decoder
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.LocalDate
+
+/**
+ * Issue #1516 — pins the freshness gate logic (acceptance: "a CI check fails
+ * explainers older than the freshness bar"). Deterministic: `asOf` is supplied,
+ * never read from the wall clock.
+ */
+class ExplainerFreshnessTest {
+
+    private val asOf = LocalDate.of(2026, 7, 4)
+
+    @Test
+    fun freshWhenWithinMaxAge() {
+        assertTrue(ExplainerFreshness.isFresh("2026-06-01", asOf, maxAgeDays = 365))
+    }
+
+    @Test
+    fun staleWhenBeyondMaxAge() {
+        assertFalse(ExplainerFreshness.isFresh("2024-01-01", asOf, maxAgeDays = 365))
+    }
+
+    @Test
+    fun exactlyAtBarIsFresh() {
+        // 365 days before asOf, maxAge 365 → still fresh (<=).
+        assertTrue(ExplainerFreshness.isFresh("2025-07-04", asOf, maxAgeDays = 365))
+    }
+
+    @Test
+    fun oneDayPastBarIsStale() {
+        assertFalse(ExplainerFreshness.isFresh("2025-07-03", asOf, maxAgeDays = 365))
+    }
+
+    @Test
+    fun futureDateTreatedAsFresh() {
+        assertTrue(ExplainerFreshness.isFresh("2027-01-01", asOf, maxAgeDays = 365))
+    }
+
+    @Test
+    fun nullOrUnparseableIsNotFresh() {
+        assertFalse(ExplainerFreshness.isFresh(null, asOf, maxAgeDays = 365))
+        assertFalse(ExplainerFreshness.isFresh("", asOf, maxAgeDays = 365))
+        assertFalse(ExplainerFreshness.isFresh("not-a-date", asOf, maxAgeDays = 365))
+    }
+
+    @Test
+    fun staleExplainersFiltersCorrectly() {
+        fun e(form: String, at: String?) = NoticeExplainer(
+            formNumber = form,
+            title = Localized("t"), whatItMeans = Localized("m"),
+            whyYouGotIt = Localized("w"), whatToDo = Localized("d"),
+            verifiedAt = at,
+        )
+        val corpus = ExplainerCorpus(
+            metadata = DecoderMetadata(freshnessMaxAgeDays = 365),
+            explainers = listOf(
+                e("FRESH", "2026-06-01"),
+                e("STALE", "2020-01-01"),
+                e("MISSING", null),
+            ),
+        )
+        val stale = ExplainerFreshness.staleExplainers(corpus, asOf).map { it.formNumber }.toSet()
+        assertEquals(setOf("STALE", "MISSING"), stale)
+    }
+}

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/techempower/decoder/NoticeFormDetectorTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/techempower/decoder/NoticeFormDetectorTest.kt
@@ -1,0 +1,83 @@
+package `in`.jphe.storyvox.feature.techempower.decoder
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1516 — pins form-number detection + lookup. Pure JVM, no OCR/Android.
+ */
+class NoticeFormDetectorTest {
+
+    private fun explainer(form: String, vararg aliases: String) = NoticeExplainer(
+        formNumber = form,
+        aliases = aliases.toList(),
+        title = Localized("t"),
+        whatItMeans = Localized("m"),
+        whyYouGotIt = Localized("w"),
+        whatToDo = Localized("d"),
+        verifiedAt = "2026-07-04",
+    )
+
+    private val corpus = ExplainerCorpus(
+        metadata = DecoderMetadata(),
+        explainers = listOf(
+            explainer("NA 200", "NA200", "NA-200"),
+            explainer("SAR 7", "SAR7"),
+        ),
+    )
+
+    @Test
+    fun detectsFormNumberInProse() {
+        val text = "Condado de ... this is your Notice of Action NA 200 dated 07/01."
+        assertEquals(listOf("NA200"), NoticeFormDetector.detectCandidates(text))
+    }
+
+    @Test
+    fun normalizesSpacingAndDashes() {
+        assertEquals("NA200", normalizeFormNumber("NA 200"))
+        assertEquals("NA200", normalizeFormNumber("na-200"))
+        assertEquals("NA200", normalizeFormNumber("NA200"))
+        assertEquals("SAR7", normalizeFormNumber("SAR 7"))
+    }
+
+    @Test
+    fun collectsMultipleCandidatesInOrderDeduped() {
+        val text = "See NA 200 and also MC 355. Reminder: NA 200 again."
+        assertEquals(listOf("NA200", "MC355"), NoticeFormDetector.detectCandidates(text))
+    }
+
+    @Test
+    fun firstKnownResolvesKnownForm() {
+        val hit = NoticeFormDetector.firstKnown("Your NA 200 notice", corpus)
+        assertNotNull(hit)
+        assertEquals("NA 200", hit!!.formNumber)
+    }
+
+    @Test
+    fun firstKnownMatchesViaAlias() {
+        val hit = NoticeFormDetector.firstKnown("footer: NA200", corpus)
+        assertNotNull(hit)
+        assertEquals("NA 200", hit!!.formNumber)
+    }
+
+    @Test
+    fun firstKnownSkipsUnknownToFindKnown() {
+        // XX 999 is unknown; NA 200 is known and comes later — still resolves.
+        val hit = NoticeFormDetector.firstKnown("XX 999 ... NA 200", corpus)
+        assertNotNull(hit)
+        assertEquals("NA 200", hit!!.formNumber)
+    }
+
+    @Test
+    fun unknownFormReturnsNull() {
+        assertNull(NoticeFormDetector.firstKnown("Form XX 999 only", corpus))
+    }
+
+    @Test
+    fun emptyTextHasNoCandidates() {
+        assertTrue(NoticeFormDetector.detectCandidates("no form numbers here").isEmpty())
+    }
+}


### PR DESCRIPTION
## Benefits letter decoder — "Understand a letter" (#1516)

Photograph a Notice of Action (or type its form number) → detect the form number → show a **hand-written, verified** plain-language explainer of what that notice type means, why you got it, and exactly what to do — EN/ES, listenable via TTS. The scariest mail a household gets, decoded.

### ⚠️ Corpus provenance (verified-or-silent, invariant 3)
Editorial discipline is the differentiator here. This PR ships the **surface + form-number detection + a corpus reader**. The bundled `feature/src/main/assets/techempower/notice_explainers.json` is a **SMALL, clearly-marked SEED SAMPLE** (`provenance = "seed-sample"`; a persistent in-app **"Sample data"** banner). The explainer *text* is placeholder — only the form numbers (NA 200 / SAR 7 / MC 355) and the fact that these are template CA notices come from the epic.

**The production corpus is TechEmpower-supplied** from the same adversarial fact-check pipeline as the show and screener (v1 = top ~10 CA notice types, EN/ES, each explainer carrying `verifiedAt` + `source`). It replaces the asset wholesale; set `provenance` to `techempower-verified` and the banner disappears.

**There is NO generative summarization of the user's letter** — an unknown form number gets an honest fallback ("we don't have a verified explainer for this yet"): read-aloud of the scanned text + call 211 + techempower.org routing. Never a guess, never an LLM paraphrase of a real notice.

### What's in it
- **Detection:** pure regex over OCR'd/typed text for form-number tokens, normalized for spacing/dashes; corpus lookup by canonical form + aliases.
- **Reuse (epic #1520):** OCR text via the existing `OcrConfig` scan store ("Use my last scan"), and "Scan a letter" routes to the existing OCR capture surface. Read-aloud via the app-level `PlaybackControllerUi.speakText` seam — `core-playback` untouched.
- **Freshness gate:** `ExplainerFreshness` logic with deterministic tests (acceptance: "a CI check fails explainers older than the freshness bar"). Wired to run against the verified corpus; the seed intentionally does not rot CI as it ages.
- **On-device only:** the only IO is a bundled asset + the local OCR store — the letter's text never leaves the device.
- **EN/ES (invariant 2):** chrome via `res/values` + `res/values-es`; explainer content carries its own `en`/`es`.
- **Accessibility (invariant 4):** plain scrolling form (no spatial UI), TalkBack headings + labels, read-aloud on every surface.
- **Tests:** pure JVM — detector, corpus/lookup (known/alias/unknown), freshness.

### Acceptance criteria
- [x] NA 200 → correct explainer, EN and ES, listenable via TTS (detection + lookup + read-aloud; seed NA 200 entry present)
- [x] Unknown notice → fallback flow, no invented explanation anywhere (honest `DecodeResult.Unknown`: read-aloud + 211, never a guess)
- [x] Each explainer displays its verified-date; freshness-bar check logic ships + tested (time-relative CI gate enabled with the verified corpus so the seed doesn't fail CI)

### Notes for the wave
- Adds the **kotlinx-serialization plugin** to `feature/build.gradle.kts` (branch is off fresh `main`; dedupes with #1517's identical add at merge).
- Appends to `feature/.../res/values/strings.xml` and creates `res/values-es/strings.xml` (clearly-commented `#1516` block) — mechanical merge with #1517's strings.
- Ships a small verified-date seed sample; **production corpus is TechEmpower-supplied**.

Closes #1516
