### PR TITLE
feat(docs): photo → fillable PDF — fill a paper form on-phone, export flattened (#1512)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/data/docs/PdfDocumentExporter.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/docs/PdfDocumentExporter.kt
@@ -3,8 +3,10 @@ package `in`.jphe.storyvox.data.docs
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.Paint
+import android.graphics.Path
 import android.graphics.RectF
 import android.graphics.pdf.PdfDocument
 import android.net.Uri
@@ -35,7 +37,7 @@ import kotlinx.coroutines.withContext
 @Singleton
 class PdfDocumentExporter @Inject constructor(
     @ApplicationContext private val context: Context,
-) : DocPdfExporter {
+) : DocPdfExporter, FormPdfExporter {
 
     override suspend fun exportToPdf(request: DocPdfRequest): DocPdfResult =
         withContext(Dispatchers.IO) {
@@ -88,14 +90,125 @@ class PdfDocumentExporter @Inject constructor(
         val pdfPage = document.startPage(info)
         val canvas = pdfPage.canvas
         canvas.drawColor(Color.WHITE)
+        val dst = fitRect(bitmap, pageW, pageH)
+        canvas.drawBitmap(bitmap, null, dst, FILTER_PAINT)
+        document.finishPage(pdfPage)
+    }
+
+    // ── #1512: fill a photographed form → flattened PDF ────────────────
+
+    override suspend fun exportFilledForm(request: FormPdfRequest): DocPdfResult =
+        withContext(Dispatchers.IO) {
+            val bitmap = decodeScaled(Uri.parse(request.pageImageUri), FORM_MAX_EDGE_PX)
+                ?: return@withContext DocPdfResult.Failure(
+                    "Couldn't read the form image. Try re-scanning.",
+                )
+            val document = PdfDocument()
+            try {
+                val landscape = bitmap.width > bitmap.height
+                val pageW = if (landscape) LETTER_LONG_PT else LETTER_SHORT_PT
+                val pageH = if (landscape) LETTER_SHORT_PT else LETTER_LONG_PT
+                val info = PdfDocument.PageInfo.Builder(pageW, pageH, 1).create()
+                val pdfPage = document.startPage(info)
+                val canvas = pdfPage.canvas
+                canvas.drawColor(Color.WHITE)
+                // The image rect the overlays are positioned relative to.
+                val dst = fitRect(bitmap, pageW, pageH)
+                canvas.drawBitmap(bitmap, null, dst, FILTER_PAINT)
+                request.overlays.forEach { drawOverlay(canvas, dst, pageH, it) }
+                document.finishPage(pdfPage)
+
+                val dir = File(context.cacheDir, EXPORT_DIR).apply { mkdirs() }
+                val fileName = safeFileName(request.title)
+                val outFile = File(dir, fileName)
+                FileOutputStream(outFile).use { document.writeTo(it) }
+                DocPdfResult.Success(
+                    filePath = outFile.absolutePath,
+                    fileName = fileName,
+                    pageCount = 1,
+                    byteSize = outFile.length(),
+                )
+            } catch (t: Throwable) {
+                DocPdfResult.Failure("Couldn't build the filled PDF. Please try again.", t)
+            } finally {
+                bitmap.recycle()
+                document.close()
+            }
+        }
+
+    /** Composite one overlay onto the page canvas. [dst] is the drawn
+     *  image rect; overlay coords are fractions of it. [pageHeightPt]
+     *  scales text/marks so they read consistently across page sizes. */
+    private fun drawOverlay(canvas: Canvas, dst: RectF, pageHeightPt: Int, overlay: FormOverlay) {
+        when (overlay) {
+            is FormOverlay.TextBox -> {
+                if (overlay.text.isBlank()) return
+                val px = dst.left + overlay.x * dst.width()
+                val py = dst.top + overlay.y * dst.height()
+                val paint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+                    color = Color.BLACK
+                    textSize = overlay.heightFraction * pageHeightPt
+                }
+                // y is the field's top; drawText draws from the baseline, so
+                // offset down by the font ascent to sit inside the blank.
+                val baseline = py - paint.fontMetrics.ascent
+                canvas.drawText(overlay.text, px, baseline, paint)
+            }
+
+            is FormOverlay.Checkmark -> {
+                val cx = dst.left + overlay.x * dst.width()
+                val cy = dst.top + overlay.y * dst.height()
+                val s = overlay.sizeFraction * pageHeightPt
+                val paint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+                    color = Color.BLACK
+                    style = Paint.Style.STROKE
+                    strokeWidth = (s * 0.14f).coerceAtLeast(1.2f)
+                    strokeCap = Paint.Cap.ROUND
+                    strokeJoin = Paint.Join.ROUND
+                }
+                val path = Path().apply {
+                    moveTo(cx - s * 0.45f, cy)
+                    lineTo(cx - s * 0.1f, cy + s * 0.4f)
+                    lineTo(cx + s * 0.5f, cy - s * 0.45f)
+                }
+                canvas.drawPath(path, paint)
+            }
+
+            is FormOverlay.Signature -> {
+                val boxLeft = dst.left + overlay.x * dst.width()
+                val boxTop = dst.top + overlay.y * dst.height()
+                val boxW = overlay.widthFraction * dst.width()
+                val boxH = overlay.heightFraction * dst.height()
+                val paint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+                    color = Color.BLACK
+                    style = Paint.Style.STROKE
+                    strokeWidth = (boxH * 0.03f).coerceAtLeast(1.2f)
+                    strokeCap = Paint.Cap.ROUND
+                    strokeJoin = Paint.Join.ROUND
+                }
+                overlay.strokes.forEach { stroke ->
+                    if (stroke.size < 2) return@forEach
+                    val path = Path()
+                    stroke.forEachIndexed { i, p ->
+                        val x = boxLeft + p.x * boxW
+                        val y = boxTop + p.y * boxH
+                        if (i == 0) path.moveTo(x, y) else path.lineTo(x, y)
+                    }
+                    canvas.drawPath(path, paint)
+                }
+            }
+        }
+    }
+
+    /** The rect a bitmap occupies when aspect-fit + centred on a
+     *  [pageW]×[pageH] page. */
+    private fun fitRect(bitmap: Bitmap, pageW: Int, pageH: Int): RectF {
         val scale = minOf(pageW.toFloat() / bitmap.width, pageH.toFloat() / bitmap.height)
         val drawW = bitmap.width * scale
         val drawH = bitmap.height * scale
         val left = (pageW - drawW) / 2f
         val top = (pageH - drawH) / 2f
-        val dst = RectF(left, top, left + drawW, top + drawH)
-        canvas.drawBitmap(bitmap, null, dst, FILTER_PAINT)
-        document.finishPage(pdfPage)
+        return RectF(left, top, left + drawW, top + drawH)
     }
 
     /**
@@ -104,21 +217,21 @@ class PdfDocumentExporter @Inject constructor(
      * it oversized. Two-pass (bounds first) so we never allocate the
      * full-resolution bitmap for an 8-megapixel camera shot.
      */
-    private fun decodeScaled(uri: Uri): Bitmap? {
+    private fun decodeScaled(uri: Uri, maxEdge: Int = MAX_EDGE_PX): Bitmap? {
         val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
         openStream(uri)?.use { BitmapFactory.decodeStream(it, null, bounds) } ?: return null
         val longEdge = maxOf(bounds.outWidth, bounds.outHeight)
         if (longEdge <= 0) return null
 
         var sample = 1
-        while (longEdge / (sample * 2) >= MAX_EDGE_PX) sample *= 2
+        while (longEdge / (sample * 2) >= maxEdge) sample *= 2
         val opts = BitmapFactory.Options().apply { inSampleSize = sample }
         val decoded = openStream(uri)?.use { BitmapFactory.decodeStream(it, null, opts) }
             ?: return null
 
         val curLong = maxOf(decoded.width, decoded.height)
-        if (curLong <= MAX_EDGE_PX) return decoded
-        val ratio = MAX_EDGE_PX.toFloat() / curLong
+        if (curLong <= maxEdge) return decoded
+        val ratio = maxEdge.toFloat() / curLong
         val scaled = Bitmap.createScaledBitmap(
             decoded,
             (decoded.width * ratio).toInt().coerceAtLeast(1),
@@ -149,6 +262,12 @@ class PdfDocumentExporter @Inject constructor(
          *  multi-page packet well under an email-friendly size. */
         @VisibleForTesting
         const val MAX_EDGE_PX = 1500
+
+        /** #1512 — forms carry denser text than a plain scan; keep the
+         *  page image sharper (the overlays we draw are crisp vectors, but
+         *  the underlying form must stay legible). */
+        @VisibleForTesting
+        const val FORM_MAX_EDGE_PX = 2200
 
         private const val EXPORT_DIR = "exports"
 

--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -297,6 +297,11 @@ object AppBindings {
     @Provides @Singleton
     fun provideWalletStore(impl: `in`.jphe.storyvox.data.wallet.EncryptedFileWalletStore): `in`.jphe.storyvox.data.wallet.WalletStore = impl
 
+    /** Issue #1512 — same PdfDocumentExporter also fills a photographed
+     *  form → flattened PDF (verdict: flatten, not AcroForm). */
+    @Provides @Singleton
+    fun provideFormPdfExporter(impl: `in`.jphe.storyvox.data.docs.PdfDocumentExporter): `in`.jphe.storyvox.data.docs.FormPdfExporter = impl
+
     /** Bridges the source-pdf [PdfConfig] read interface (#996) to the
      *  concrete app-side SAF-backed impl. Exposed concretely is not
      *  needed here (the Settings/Browse mutators go through

--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -113,6 +113,11 @@ object StoryvoxRoutes {
 
     /** Issue #1519 — saved household profile (autofill scanned forms). */
     const val HOUSEHOLD_PROFILE = "docs/profile"
+
+    /** Issue #1512 — photo → fillable PDF (benefits paperwork companion,
+     *  epic #1520). Reached from the Library add-flow ("Fill a form");
+     *  scan/pick a paper form → tap-anywhere fill → flattened PDF. */
+    const val FORM_FILL = "docs/fill"
     const val FICTION_DETAIL = "fiction/{fictionId}"
     const val READER = "reader/{fictionId}/{chapterId}"
     const val AUDIOBOOK = "audiobook/{fictionId}/{chapterId}"
@@ -857,6 +862,9 @@ private fun StoryvoxNavHostContent(
                     // Issue #1514 — "My Documents" add-flow entry → the
                     // encrypted, biometric-gated document wallet.
                     onOpenWallet = { navController.navigate(StoryvoxRoutes.WALLET) },
+                    // Issue #1512 — "Fill a form" add-flow entry routes to
+                    // the photo→fillable-PDF surface.
+                    onFillForm = { navController.navigate(StoryvoxRoutes.FORM_FILL) },
                     // v0.5.72 — Browse is a first-class bottom-nav tab
                     // now; the standalone Browse route owns RR + AO3
                     // sign-in deep-links. Follows is still embedded
@@ -962,6 +970,18 @@ private fun StoryvoxNavHostContent(
                 popExitTransition = popExit,
             ) {
                 `in`.jphe.storyvox.feature.docs.WalletScreen(
+                    onNavigateBack = { navController.popBackStack() },
+                )
+            }
+            composable(
+                // Issue #1512 — photo → fillable PDF.
+                StoryvoxRoutes.FORM_FILL,
+                enterTransition = pushEnter,
+                exitTransition = pushExit,
+                popEnterTransition = popEnter,
+                popExitTransition = popExit,
+            ) {
+                `in`.jphe.storyvox.feature.docs.FormFillScreen(
                     onNavigateBack = { navController.popBackStack() },
                 )
             }

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/docs/FormPdfExporter.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/docs/FormPdfExporter.kt
@@ -1,0 +1,88 @@
+package `in`.jphe.storyvox.data.docs
+
+/**
+ * Issue #1512 — on-device seam that fills a photographed/scanned paper
+ * form and exports a **flattened** PDF that looks like the completed
+ * paper form.
+ *
+ * Per the #1512 research verdict, v1 does NOT use PDF AcroForm fields:
+ * the input is a *raster* image of a paper form (there are no digital
+ * form-field widgets to fill), and a flattened export renders
+ * identically in Google Drive / Files / print. The production impl
+ * (`PdfDocumentExporter` in `:app`, which also implements
+ * [DocPdfExporter]) draws the page bitmap then composites the user's
+ * text / checkmarks / drawn signature onto the PDF canvas via
+ * `android.graphics.pdf.PdfDocument`. No AcroForm dependency, no network.
+ *
+ * ## Coordinates are normalized
+ *
+ * Every overlay position is expressed as a fraction (0..1) of the page
+ * image's width/height, so placement is resolution-independent: the UI
+ * captures a tap relative to however large the page is drawn on screen,
+ * and the exporter maps the same fraction onto the PDF page. This keeps
+ * the seam free of any pixel/`android.graphics` type — the ViewModel
+ * stays plain JVM and unit-testable with a fake.
+ *
+ * Reuses [DocPdfResult] (the #1513 export result) so callers share one
+ * success/failure shape.
+ */
+interface FormPdfExporter {
+
+    /**
+     * Draw [FormPdfRequest.pageImageUri] and composite its [overlays]
+     * into a single flattened PDF written to the app export cache. Runs
+     * on a background dispatcher; never throws. An undecodable page image
+     * returns [DocPdfResult.Failure].
+     */
+    suspend fun exportFilledForm(request: FormPdfRequest): DocPdfResult
+}
+
+/** One fill-and-export job. */
+data class FormPdfRequest(
+    val title: String,
+    /** `content://`/`file://` URI (as a String) of the form page image. */
+    val pageImageUri: String,
+    val overlays: List<FormOverlay>,
+)
+
+/** A normalized point (each coordinate a fraction 0..1). */
+data class NormPoint(val x: Float, val y: Float)
+
+/**
+ * One thing composited onto the form. All positions/sizes are fractions
+ * (0..1) of the page image.
+ */
+sealed interface FormOverlay {
+
+    /**
+     * User-typed text placed with its baseline-ish top-left at
+     * ([x], [y]). [heightFraction] sets the text size as a fraction of
+     * the page height so it scales with the form.
+     */
+    data class TextBox(
+        val x: Float,
+        val y: Float,
+        val text: String,
+        val heightFraction: Float = 0.02f,
+    ) : FormOverlay
+
+    /** A checkmark centred at ([x], [y]); [sizeFraction] of page height. */
+    data class Checkmark(
+        val x: Float,
+        val y: Float,
+        val sizeFraction: Float = 0.025f,
+    ) : FormOverlay
+
+    /**
+     * A drawn signature bounded by the box ([x], [y], [widthFraction],
+     * [heightFraction]) on the page. [strokes] is a list of polylines;
+     * each point is normalized **within the signature box** (0..1).
+     */
+    data class Signature(
+        val x: Float,
+        val y: Float,
+        val widthFraction: Float,
+        val heightFraction: Float,
+        val strokes: List<List<NormPoint>>,
+    ) : FormOverlay
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/docs/FormFillScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/docs/FormFillScreen.kt
@@ -1,0 +1,658 @@
+package `in`.jphe.storyvox.feature.docs
+
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.Intent
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.IntentSenderRequest
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.core.content.FileProvider
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import coil3.compose.AsyncImage
+import com.google.mlkit.vision.documentscanner.GmsDocumentScannerOptions
+import com.google.mlkit.vision.documentscanner.GmsDocumentScanning
+import com.google.mlkit.vision.documentscanner.GmsDocumentScanningResult
+import `in`.jphe.storyvox.data.docs.NormPoint
+import `in`.jphe.storyvox.feature.R
+import `in`.jphe.storyvox.ui.component.BrassButton
+import `in`.jphe.storyvox.ui.component.BrassButtonVariant
+import `in`.jphe.storyvox.ui.theme.LocalSpacing
+import java.io.File
+import kotlin.math.roundToInt
+
+/**
+ * Issue #1512 — photo → fillable PDF. Scan/pick a paper form, place
+ * fields on it (tap-anywhere text, checkmarks, a drawn signature), and
+ * export a **flattened** PDF (verdict: flatten, not AcroForm) that looks
+ * like the completed paper form.
+ *
+ * Two ways to reach every field, per invariant #4 (accessibility):
+ *  - **Spatial** — tap the page to place a field where it belongs; placed
+ *    fields render as overlays on the page image.
+ *  - **List** — a linear, TalkBack-navigable list of every placed field
+ *    with inline editing / removal / signature-redraw. This is the
+ *    screen-reader-equal path the issue explicitly calls for.
+ *
+ * Everything is on-device (image, typed values, signature, PDF
+ * composition); no network → airplane-mode safe.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun FormFillScreen(
+    onNavigateBack: () -> Unit,
+    viewModel: FormFillViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+    val spacing = LocalSpacing.current
+    val shareChooserTitle = stringResource(R.string.form_fill_share_chooser)
+
+    var signatureTargetId by remember { mutableStateOf<Int?>(null) }
+
+    val scannerLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.StartIntentSenderForResult(),
+    ) { result ->
+        if (result.resultCode == Activity.RESULT_OK) {
+            val scan = GmsDocumentScanningResult.fromActivityResultIntent(result.data)
+            scan?.pages?.firstOrNull()?.imageUri?.let { viewModel.onPageCaptured(it.toString()) }
+        }
+    }
+    val galleryLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.PickVisualMedia(),
+    ) { uri: Uri? ->
+        uri?.let { viewModel.onPageCaptured(it.toString()) }
+    }
+
+    fun launchScanner() {
+        val activity = context.findActivityForForm() ?: return
+        val options = GmsDocumentScannerOptions.Builder()
+            .setGalleryImportAllowed(true)
+            .setResultFormats(GmsDocumentScannerOptions.RESULT_FORMAT_JPEG)
+            .setScannerMode(GmsDocumentScannerOptions.SCANNER_MODE_FULL)
+            .setPageLimit(1)
+            .build()
+        GmsDocumentScanning.getClient(options)
+            .getStartScanIntent(activity)
+            .addOnSuccessListener {
+                scannerLauncher.launch(IntentSenderRequest.Builder(it).build())
+            }
+            .addOnFailureListener { /* fall back to gallery */ }
+    }
+
+    LaunchedEffect(state.shareRequest) {
+        state.shareRequest?.let { ready ->
+            shareFilledPdf(context, ready.filePath, ready.fileName, shareChooserTitle)
+            viewModel.onShareHandled()
+        }
+    }
+
+    // Placing a signature opens the draw pad on that new field.
+    LaunchedEffect(state.pendingSignatureId) {
+        state.pendingSignatureId?.let {
+            signatureTargetId = it
+            viewModel.consumePendingSignature()
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.form_fill_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.form_fill_back_cd),
+                        )
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(innerPadding)
+                .padding(horizontal = spacing.md),
+            verticalArrangement = Arrangement.spacedBy(spacing.md),
+            contentPadding = androidx.compose.foundation.layout.PaddingValues(vertical = spacing.md),
+        ) {
+            item {
+                Text(
+                    stringResource(R.string.form_fill_intro),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            if (!state.hasPage) {
+                item {
+                    Column(verticalArrangement = Arrangement.spacedBy(spacing.sm)) {
+                        BrassButton(
+                            label = stringResource(R.string.form_fill_scan),
+                            onClick = { launchScanner() },
+                            variant = BrassButtonVariant.Primary,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                        BrassButton(
+                            label = stringResource(R.string.form_fill_pick_gallery),
+                            onClick = {
+                                galleryLauncher.launch(
+                                    PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly),
+                                )
+                            },
+                            variant = BrassButtonVariant.Secondary,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    }
+                }
+                item { InfoCardForm(text = stringResource(R.string.form_fill_privacy_note)) }
+            } else {
+                // ── Tool selector ──────────────────────────────────────
+                item {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+                    ) {
+                        ToolButton(R.string.form_fill_tool_text, state.activeTool == FillTool.Text, Modifier.weight(1f)) {
+                            viewModel.setTool(FillTool.Text)
+                        }
+                        ToolButton(R.string.form_fill_tool_check, state.activeTool == FillTool.Check, Modifier.weight(1f)) {
+                            viewModel.setTool(FillTool.Check)
+                        }
+                        ToolButton(R.string.form_fill_tool_signature, state.activeTool == FillTool.Signature, Modifier.weight(1f)) {
+                            viewModel.setTool(FillTool.Signature)
+                        }
+                    }
+                }
+                item {
+                    Text(
+                        stringResource(R.string.form_fill_tap_hint),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                // ── Spatial page + overlays (tap to place) ─────────────
+                item {
+                    PageCanvas(
+                        pageUri = state.pageImageUri!!,
+                        fields = state.fields,
+                        onTap = { nx, ny -> viewModel.onTapPage(nx, ny) },
+                    )
+                }
+
+                // ── Field LIST (accessibility-equal editing surface) ───
+                item {
+                    Text(
+                        stringResource(R.string.form_fill_fields_header, state.fields.size),
+                        style = MaterialTheme.typography.labelLarge,
+                        modifier = Modifier.semantics { liveRegion = LiveRegionMode.Polite },
+                    )
+                }
+                if (state.fields.isEmpty()) {
+                    item {
+                        Text(
+                            stringResource(R.string.form_fill_no_fields),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                } else {
+                    items(state.fields, key = { it.id }) { field ->
+                        FieldRow(
+                            field = field,
+                            onTextChange = { viewModel.updateText(field.id, it) },
+                            onRemove = { viewModel.removeField(field.id) },
+                            onRedrawSignature = { signatureTargetId = field.id },
+                        )
+                    }
+                }
+
+                item {
+                    OutlinedTextField(
+                        value = state.title,
+                        onValueChange = viewModel::onTitleChanged,
+                        label = { Text(stringResource(R.string.form_fill_title_label)) },
+                        singleLine = true,
+                        enabled = !state.isExporting,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+
+                state.error?.let { err ->
+                    item {
+                        Surface(
+                            color = MaterialTheme.colorScheme.errorContainer,
+                            shape = RoundedCornerShape(12.dp),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .semantics { liveRegion = LiveRegionMode.Assertive },
+                        ) {
+                            Text(
+                                err,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onErrorContainer,
+                                modifier = Modifier.padding(spacing.md),
+                            )
+                        }
+                    }
+                }
+
+                item {
+                    BrassButton(
+                        label = stringResource(
+                            if (state.isExporting) R.string.form_fill_exporting else R.string.form_fill_export,
+                        ),
+                        onClick = viewModel::export,
+                        variant = BrassButtonVariant.Primary,
+                        enabled = state.canExport,
+                        loading = state.isExporting,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+                state.exportResult?.let { ready ->
+                    item {
+                        Surface(
+                            color = MaterialTheme.colorScheme.secondaryContainer,
+                            shape = RoundedCornerShape(12.dp),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .semantics { liveRegion = LiveRegionMode.Polite },
+                        ) {
+                            Column(
+                                modifier = Modifier.padding(spacing.md),
+                                verticalArrangement = Arrangement.spacedBy(spacing.sm),
+                            ) {
+                                Text(
+                                    stringResource(R.string.form_fill_exported, ready.fileName),
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                                )
+                                BrassButton(
+                                    label = stringResource(R.string.form_fill_share_again),
+                                    onClick = viewModel::shareAgain,
+                                    variant = BrassButtonVariant.Secondary,
+                                    modifier = Modifier.fillMaxWidth(),
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Signature draw pad.
+    signatureTargetId?.let { id ->
+        SignaturePadDialog(
+            onSave = { strokes ->
+                viewModel.setSignatureStrokes(id, strokes)
+                signatureTargetId = null
+            },
+            onDismiss = { signatureTargetId = null },
+        )
+    }
+}
+
+@Composable
+private fun ToolButton(labelRes: Int, selected: Boolean, modifier: Modifier = Modifier, onClick: () -> Unit) {
+    BrassButton(
+        label = stringResource(labelRes),
+        onClick = onClick,
+        variant = if (selected) BrassButtonVariant.Primary else BrassButtonVariant.Secondary,
+        modifier = modifier,
+    )
+}
+
+/** The form page with tap-to-place and rendered overlays. */
+@Composable
+private fun PageCanvas(
+    pageUri: String,
+    fields: List<FormField>,
+    onTap: (nx: Float, ny: Float) -> Unit,
+) {
+    var boxSize by remember { mutableStateOf(IntSize.Zero) }
+    val pageContentDesc = stringResource(R.string.form_fill_page_cd)
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .border(1.dp, MaterialTheme.colorScheme.outlineVariant, RoundedCornerShape(8.dp))
+            .onSizeChanged { boxSize = it }
+            .pointerInput(Unit) {
+                detectTapGestures { offset ->
+                    if (boxSize.width > 0 && boxSize.height > 0) {
+                        onTap(offset.x / boxSize.width, offset.y / boxSize.height)
+                    }
+                }
+            }
+            // The page image itself is decorative for TalkBack — the field
+            // LIST below is the accessible editing surface, so this spatial
+            // canvas is not a focus trap.
+            .semantics { contentDescription = pageContentDesc },
+    ) {
+        AsyncImage(
+            model = pageUri,
+            contentDescription = null,
+            contentScale = ContentScale.FillWidth,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        val w = boxSize.width
+        val h = boxSize.height
+        if (w > 0 && h > 0) {
+            // Text + checkmark overlays as offset composables.
+            fields.forEach { field ->
+                when (field) {
+                    is FormField.Text -> if (field.text.isNotBlank()) {
+                        Text(
+                            field.text,
+                            color = Color.Black,
+                            style = MaterialTheme.typography.bodySmall,
+                            maxLines = 1,
+                            overflow = TextOverflow.Clip,
+                            modifier = Modifier
+                                .offset {
+                                    IntOffset((field.x * w).roundToInt(), (field.y * h).roundToInt())
+                                }
+                                .background(Color.White.copy(alpha = 0.6f)),
+                        )
+                    }
+
+                    is FormField.Check -> Icon(
+                        Icons.Filled.Check,
+                        contentDescription = null,
+                        tint = Color.Black,
+                        modifier = Modifier
+                            .offset {
+                                IntOffset((field.x * w).roundToInt(), (field.y * h).roundToInt())
+                            }
+                            .size(18.dp),
+                    )
+
+                    is FormField.Signature -> Unit // drawn on the canvas below
+                }
+            }
+            // Signatures on one full-box canvas, mapped to absolute coords.
+            Canvas(modifier = Modifier.matchParentSize()) {
+                fields.filterIsInstance<FormField.Signature>().forEach { sig ->
+                    val bl = sig.x * size.width
+                    val bt = sig.y * size.height
+                    val bw = sig.widthFraction * size.width
+                    val bh = sig.heightFraction * size.height
+                    sig.strokes.forEach { stroke ->
+                        for (i in 1 until stroke.size) {
+                            drawLine(
+                                color = Color.Black,
+                                start = Offset(bl + stroke[i - 1].x * bw, bt + stroke[i - 1].y * bh),
+                                end = Offset(bl + stroke[i].x * bw, bt + stroke[i].y * bh),
+                                strokeWidth = 3f,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/** One row in the accessible field list. */
+@Composable
+private fun FieldRow(
+    field: FormField,
+    onTextChange: (String) -> Unit,
+    onRemove: () -> Unit,
+    onRedrawSignature: () -> Unit,
+) {
+    val spacing = LocalSpacing.current
+    val removeCd = when (field) {
+        is FormField.Text -> stringResource(R.string.form_fill_remove_text_cd)
+        is FormField.Check -> stringResource(R.string.form_fill_remove_check_cd)
+        is FormField.Signature -> stringResource(R.string.form_fill_remove_signature_cd)
+    }
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        shape = RoundedCornerShape(12.dp),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = spacing.md, vertical = spacing.sm),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+        ) {
+            when (field) {
+                is FormField.Text -> {
+                    OutlinedTextField(
+                        value = field.text,
+                        onValueChange = onTextChange,
+                        label = { Text(stringResource(R.string.form_fill_text_field_label)) },
+                        singleLine = true,
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+
+                is FormField.Check -> {
+                    Text(
+                        stringResource(R.string.form_fill_checkmark_label),
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+
+                is FormField.Signature -> {
+                    val drawn = field.strokes.any { it.size >= 2 }
+                    Text(
+                        stringResource(
+                            if (drawn) R.string.form_fill_signature_drawn
+                            else R.string.form_fill_signature_empty,
+                        ),
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.weight(1f),
+                    )
+                    BrassButton(
+                        label = stringResource(R.string.form_fill_draw_signature),
+                        onClick = onRedrawSignature,
+                        variant = BrassButtonVariant.Secondary,
+                    )
+                }
+            }
+            IconButton(onClick = onRemove) {
+                Icon(
+                    Icons.Filled.Delete,
+                    contentDescription = removeCd,
+                )
+            }
+        }
+    }
+}
+
+/** Full-width draw pad; captures strokes normalized to the pad. */
+@Composable
+private fun SignaturePadDialog(
+    onSave: (List<List<NormPoint>>) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val spacing = LocalSpacing.current
+    val strokes: SnapshotStateList<List<NormPoint>> = remember { mutableStateListOf() }
+    var current by remember { mutableStateOf<List<NormPoint>>(emptyList()) }
+    var padSize by remember { mutableStateOf(IntSize.Zero) }
+    val padCd = stringResource(R.string.form_fill_signature_pad_cd)
+
+    Dialog(onDismissRequest = onDismiss) {
+        Surface(shape = RoundedCornerShape(16.dp), color = MaterialTheme.colorScheme.surface) {
+            Column(
+                modifier = Modifier.padding(spacing.md),
+                verticalArrangement = Arrangement.spacedBy(spacing.md),
+            ) {
+                Text(
+                    stringResource(R.string.form_fill_signature_pad_title),
+                    style = MaterialTheme.typography.titleMedium,
+                )
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(200.dp)
+                        .background(Color.White, RoundedCornerShape(8.dp))
+                        .border(1.dp, MaterialTheme.colorScheme.outline, RoundedCornerShape(8.dp))
+                        .onSizeChanged { padSize = it }
+                        .pointerInput(Unit) {
+                            detectDragGestures(
+                                onDragStart = { off -> current = listOf(normFor(off, padSize)) },
+                                onDrag = { change, _ -> current = current + normFor(change.position, padSize) },
+                                onDragEnd = {
+                                    if (current.size >= 2) strokes.add(current)
+                                    current = emptyList()
+                                },
+                            )
+                        }
+                        .clearAndSetSemantics { contentDescription = padCd },
+                ) {
+                    Canvas(modifier = Modifier.fillMaxWidth().height(200.dp)) {
+                        (strokes + listOf(current)).forEach { stroke ->
+                            for (i in 1 until stroke.size) {
+                                drawLine(
+                                    color = Color.Black,
+                                    start = Offset(stroke[i - 1].x * size.width, stroke[i - 1].y * size.height),
+                                    end = Offset(stroke[i].x * size.width, stroke[i].y * size.height),
+                                    strokeWidth = 5f,
+                                )
+                            }
+                        }
+                    }
+                }
+                Row(horizontalArrangement = Arrangement.spacedBy(spacing.sm)) {
+                    BrassButton(
+                        label = stringResource(R.string.form_fill_signature_clear),
+                        onClick = { strokes.clear(); current = emptyList() },
+                        variant = BrassButtonVariant.Secondary,
+                        modifier = Modifier.weight(1f),
+                    )
+                    BrassButton(
+                        label = stringResource(R.string.form_fill_signature_cancel),
+                        onClick = onDismiss,
+                        variant = BrassButtonVariant.Secondary,
+                        modifier = Modifier.weight(1f),
+                    )
+                    BrassButton(
+                        label = stringResource(R.string.form_fill_signature_save),
+                        onClick = { onSave(strokes.toList()) },
+                        variant = BrassButtonVariant.Primary,
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun InfoCardForm(text: String) {
+    val spacing = LocalSpacing.current
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        shape = RoundedCornerShape(12.dp),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Text(
+            text,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(spacing.md),
+        )
+    }
+}
+
+private fun normFor(offset: Offset, size: IntSize): NormPoint {
+    val x = if (size.width > 0) (offset.x / size.width).coerceIn(0f, 1f) else 0f
+    val y = if (size.height > 0) (offset.y / size.height).coerceIn(0f, 1f) else 0f
+    return NormPoint(x, y)
+}
+
+private fun Context.findActivityForForm(): Activity? {
+    var ctx: Context? = this
+    while (ctx is ContextWrapper) {
+        if (ctx is Activity) return ctx
+        ctx = ctx.baseContext
+    }
+    return null
+}
+
+private fun shareFilledPdf(context: Context, filePath: String, fileName: String, chooserTitle: String) {
+    val uri = FileProvider.getUriForFile(
+        context,
+        "${context.packageName}.fileprovider",
+        File(filePath),
+    )
+    val send = Intent(Intent.ACTION_SEND).apply {
+        type = "application/pdf"
+        putExtra(Intent.EXTRA_STREAM, uri)
+        putExtra(Intent.EXTRA_TITLE, fileName)
+        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+    }
+    context.startActivity(
+        Intent.createChooser(send, chooserTitle).also {
+            it.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        },
+    )
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/docs/FormFillViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/docs/FormFillViewModel.kt
@@ -81,11 +81,19 @@ class FormFillViewModel @Inject constructor(
                 fields = prev.fields + field,
                 nextId = id + 1,
                 selectedFieldId = id,
+                // Placing a signature raises a one-shot so the screen opens
+                // the draw pad on the new field id (robust — no stale read).
+                pendingSignatureId = if (prev.activeTool == FillTool.Signature) id else null,
                 exportResult = null,
                 shareRequest = null,
                 error = null,
             )
         }
+    }
+
+    /** Consume the one-shot signature-pad signal after the screen opens it. */
+    fun consumePendingSignature() {
+        _state.update { it.copy(pendingSignatureId = null) }
     }
 
     /** Update a text field's content. */
@@ -198,6 +206,9 @@ data class FormFillUiState(
     val fields: List<FormField> = emptyList(),
     val activeTool: FillTool = FillTool.Text,
     val selectedFieldId: Int? = null,
+    /** One-shot: set to a newly-placed signature field's id so the screen
+     *  opens the draw pad, then cleared via [FormFillViewModel.consumePendingSignature]. */
+    val pendingSignatureId: Int? = null,
     val title: String = "",
     val isExporting: Boolean = false,
     val error: String? = null,

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/docs/FormFillViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/docs/FormFillViewModel.kt
@@ -1,0 +1,260 @@
+package `in`.jphe.storyvox.feature.docs
+
+import androidx.compose.runtime.Immutable
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import `in`.jphe.storyvox.data.docs.DocPdfResult
+import `in`.jphe.storyvox.data.docs.FormOverlay
+import `in`.jphe.storyvox.data.docs.FormPdfExporter
+import `in`.jphe.storyvox.data.docs.FormPdfRequest
+import `in`.jphe.storyvox.data.docs.NormPoint
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * Issue #1512 — drives the photo → fillable PDF flow: scan/pick a paper
+ * form, place fields on it (tap-anywhere text, checkmarks, a drawn
+ * signature), and export a **flattened** PDF that looks like the
+ * completed form.
+ *
+ * Per the #1512 research verdict this uses flatten-via-`PdfDocument`
+ * (the on-device [FormPdfExporter] seam), NOT AcroForm — the input is a
+ * raster image with no form-field widgets to fill. Everything is
+ * on-device (image, typed values, signature, PDF composition); no
+ * network → inherently airplane-mode safe.
+ *
+ * All Android specifics live in the screen / behind [FormPdfExporter],
+ * so this VM is plain JVM and unit-testable with a fake exporter.
+ * Field positions are **normalized** (0..1 fractions of the page image)
+ * so they survive rotation / different render sizes.
+ */
+@HiltViewModel
+class FormFillViewModel @Inject constructor(
+    private val exporter: FormPdfExporter,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(FormFillUiState())
+    val state: StateFlow<FormFillUiState> = _state.asStateFlow()
+
+    /** Set (or replace) the form page image; clears any prior fields. */
+    fun onPageCaptured(uri: String) {
+        if (uri.isBlank()) return
+        _state.update {
+            FormFillUiState(pageImageUri = uri, title = it.title)
+        }
+    }
+
+    /** Choose what a tap on the page places. */
+    fun setTool(tool: FillTool) {
+        _state.update { it.copy(activeTool = tool) }
+    }
+
+    /**
+     * Handle a tap on the page at normalized ([x], [y]). Places a field
+     * per the [FormFillUiState.activeTool] and selects it so the UI can
+     * open its editor (text keyboard / signature pad).
+     */
+    fun onTapPage(x: Float, y: Float) {
+        if (_state.value.pageImageUri == null) return
+        val nx = x.coerceIn(0f, 1f)
+        val ny = y.coerceIn(0f, 1f)
+        _state.update { prev ->
+            val id = prev.nextId
+            val field = when (prev.activeTool) {
+                FillTool.Text -> FormField.Text(id, nx, ny, text = "")
+                FillTool.Check -> FormField.Check(id, nx, ny)
+                FillTool.Signature -> FormField.Signature(
+                    id = id,
+                    x = (nx - DEFAULT_SIG_W / 2).coerceIn(0f, 1f - DEFAULT_SIG_W),
+                    y = (ny - DEFAULT_SIG_H / 2).coerceIn(0f, 1f - DEFAULT_SIG_H),
+                    widthFraction = DEFAULT_SIG_W,
+                    heightFraction = DEFAULT_SIG_H,
+                    strokes = emptyList(),
+                )
+            }
+            prev.copy(
+                fields = prev.fields + field,
+                nextId = id + 1,
+                selectedFieldId = id,
+                exportResult = null,
+                shareRequest = null,
+                error = null,
+            )
+        }
+    }
+
+    /** Update a text field's content. */
+    fun updateText(id: Int, text: String) {
+        _state.update { prev ->
+            prev.copy(
+                fields = prev.fields.map {
+                    if (it is FormField.Text && it.id == id) it.copy(text = text) else it
+                },
+                exportResult = null,
+                shareRequest = null,
+            )
+        }
+    }
+
+    /** Store the strokes drawn for a signature field (normalized within
+     *  the field's box). */
+    fun setSignatureStrokes(id: Int, strokes: List<List<NormPoint>>) {
+        _state.update { prev ->
+            prev.copy(
+                fields = prev.fields.map {
+                    if (it is FormField.Signature && it.id == id) it.copy(strokes = strokes) else it
+                },
+                exportResult = null,
+                shareRequest = null,
+            )
+        }
+    }
+
+    /** Remove a field. */
+    fun removeField(id: Int) {
+        _state.update { prev ->
+            prev.copy(
+                fields = prev.fields.filterNot { it.id == id },
+                selectedFieldId = prev.selectedFieldId?.takeIf { it != id },
+                exportResult = null,
+                shareRequest = null,
+            )
+        }
+    }
+
+    /** Select a field for editing (or clear the selection with null). */
+    fun selectField(id: Int?) {
+        _state.update { it.copy(selectedFieldId = id) }
+    }
+
+    fun onTitleChanged(title: String) {
+        _state.update { it.copy(title = title) }
+    }
+
+    /** Compose the filled, flattened PDF and raise a one-shot share
+     *  signal on success. */
+    fun export() {
+        val snapshot = _state.value
+        val page = snapshot.pageImageUri ?: return
+        if (snapshot.isExporting) return
+        _state.update { it.copy(isExporting = true, error = null) }
+        viewModelScope.launch {
+            val request = FormPdfRequest(
+                title = snapshot.title.ifBlank { DEFAULT_TITLE }.trim(),
+                pageImageUri = page,
+                overlays = snapshot.fields.mapNotNull { it.toOverlay() },
+            )
+            when (val result = exporter.exportFilledForm(request)) {
+                is DocPdfResult.Success -> {
+                    val ready = DocExportReady(
+                        filePath = result.filePath,
+                        fileName = result.fileName,
+                        pageCount = result.pageCount,
+                        byteSize = result.byteSize,
+                    )
+                    _state.update {
+                        it.copy(isExporting = false, exportResult = ready, shareRequest = ready)
+                    }
+                }
+
+                is DocPdfResult.Failure -> _state.update {
+                    it.copy(isExporting = false, error = result.message)
+                }
+            }
+        }
+    }
+
+    fun shareAgain() {
+        _state.update { it.copy(shareRequest = it.exportResult) }
+    }
+
+    fun onShareHandled() {
+        _state.update { it.copy(shareRequest = null) }
+    }
+
+    fun clearError() {
+        _state.update { it.copy(error = null) }
+    }
+
+    private companion object {
+        const val DEFAULT_TITLE = "Filled form"
+        const val DEFAULT_SIG_W = 0.35f
+        const val DEFAULT_SIG_H = 0.10f
+    }
+}
+
+/** What a tap on the page places. */
+enum class FillTool { Text, Check, Signature }
+
+/** UI state for the form-fill screen. */
+@Immutable
+data class FormFillUiState(
+    val pageImageUri: String? = null,
+    val fields: List<FormField> = emptyList(),
+    val activeTool: FillTool = FillTool.Text,
+    val selectedFieldId: Int? = null,
+    val title: String = "",
+    val isExporting: Boolean = false,
+    val error: String? = null,
+    val exportResult: DocExportReady? = null,
+    val shareRequest: DocExportReady? = null,
+    val nextId: Int = 0,
+) {
+    val hasPage: Boolean get() = pageImageUri != null
+    val canExport: Boolean get() = pageImageUri != null && !isExporting
+}
+
+/** One field placed on the form. Positions are normalized (0..1). */
+@Immutable
+sealed interface FormField {
+    val id: Int
+
+    @Immutable
+    data class Text(
+        override val id: Int,
+        val x: Float,
+        val y: Float,
+        val text: String,
+    ) : FormField
+
+    @Immutable
+    data class Check(
+        override val id: Int,
+        val x: Float,
+        val y: Float,
+    ) : FormField
+
+    @Immutable
+    data class Signature(
+        override val id: Int,
+        val x: Float,
+        val y: Float,
+        val widthFraction: Float,
+        val heightFraction: Float,
+        val strokes: List<List<NormPoint>>,
+    ) : FormField
+}
+
+/** Map a UI field to the exporter overlay; returns null for a field that
+ *  contributes nothing (empty text, un-drawn signature). */
+internal fun FormField.toOverlay(): FormOverlay? = when (this) {
+    is FormField.Text -> if (text.isBlank()) null else FormOverlay.TextBox(x = x, y = y, text = text)
+    is FormField.Check -> FormOverlay.Checkmark(x = x, y = y)
+    is FormField.Signature ->
+        if (strokes.all { it.size < 2 }) {
+            null
+        } else {
+            FormOverlay.Signature(
+                x = x,
+                y = y,
+                widthFraction = widthFraction,
+                heightFraction = heightFraction,
+                strokes = strokes,
+            )
+        }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
@@ -160,6 +160,12 @@ fun LibraryScreen(
      * no-op so test / preview surfaces that don't exercise it still compile.
      */
     onOpenWallet: () -> Unit = {},
+    /**
+     * Issue #1512 — "Fill a form" add-flow entry. Routes to the
+     * photo→fillable-PDF surface ([StoryvoxRoutes.FORM_FILL]). Default
+     * no-op so test / preview surfaces that don't exercise it still compile.
+     */
+    onFillForm: () -> Unit = {},
     viewModel: LibraryViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -376,6 +382,15 @@ fun LibraryScreen(
                             onClick = {
                                 addMenuOpen = false
                                 onOpenWallet()
+                            },
+                        )
+                        // Issue #1512 — photo → fillable PDF: scan a paper
+                        // form, fill it on-phone, export a completed PDF.
+                        androidx.compose.material3.DropdownMenuItem(
+                            text = { Text(stringResource(R.string.library_fill_form)) },
+                            onClick = {
+                                addMenuOpen = false
+                                onFillForm()
                             },
                         )
                     }

--- a/feature/src/main/res/values-es/strings.xml
+++ b/feature/src/main/res/values-es/strings.xml
@@ -274,6 +274,7 @@
     <string name="form_fill_signature_pad_title">Dibuja tu firma</string>
     <string name="form_fill_signature_save">Guardar</string>
     <string name="form_fill_tap_hint">Toca el formulario para colocar la herramienta seleccionada. Cada campo también aparece en la lista de abajo para editarlo.</string>
+    <string name="form_fill_text_field_label">Texto del campo</string>
     <string name="form_fill_title">Completar un formulario</string>
     <string name="form_fill_title_label">Nombre del archivo</string>
     <string name="form_fill_tool_check">Casilla</string>

--- a/feature/src/main/res/values-es/strings.xml
+++ b/feature/src/main/res/values-es/strings.xml
@@ -246,4 +246,39 @@
     <string name="deadline_program_other">Fecha límite de beneficios</string>
     <string name="deadline_card_title">Control de plazos</string>
     <string name="deadline_card_body">Fotografíe una carta — le recordaremos antes del plazo.</string>
+    <!-- #1512: foto → PDF rellenable. Keys alphabetical, same order as
+         values/strings.xml; wrapped for mechanical cross-lane rebases. -->
+    <string name="form_fill_back_cd">Atrás</string>
+    <string name="form_fill_checkmark_label">Marca de verificación</string>
+    <string name="form_fill_draw_signature">Dibujar firma</string>
+    <string name="form_fill_export">Exportar y compartir PDF</string>
+    <string name="form_fill_exported">Guardado %1$s</string>
+    <string name="form_fill_exporting">Creando tu PDF…</string>
+    <string name="form_fill_fields_header">Campos: %1$d</string>
+    <string name="form_fill_intro">Toma una foto de un formulario en papel, complétalo en tu teléfono y exporta un PDF terminado que puedes enviar por correo o imprimir. Sin necesidad de impresora.</string>
+    <string name="form_fill_no_fields">Aún no hay campos. Elige una herramienta arriba y luego toca el formulario donde quieras escribir, marcar una casilla o firmar.</string>
+    <string name="form_fill_page_cd">Página del formulario. Usa la lista de campos de abajo para añadir y editar entradas.</string>
+    <string name="form_fill_pick_gallery">Elegir una foto</string>
+    <string name="form_fill_privacy_note">Todo permanece en tu dispositivo: el formulario, lo que escribes y tu firma nunca salen de tu teléfono.</string>
+    <string name="form_fill_remove_check_cd">Eliminar la marca de verificación</string>
+    <string name="form_fill_remove_signature_cd">Eliminar la firma</string>
+    <string name="form_fill_remove_text_cd">Eliminar el campo de texto</string>
+    <string name="form_fill_scan">Escanear un formulario</string>
+    <string name="form_fill_share_again">Compartir de nuevo</string>
+    <string name="form_fill_share_chooser">Compartir formulario completado</string>
+    <string name="form_fill_signature_cancel">Cancelar</string>
+    <string name="form_fill_signature_clear">Borrar</string>
+    <string name="form_fill_signature_drawn">Firma añadida</string>
+    <string name="form_fill_signature_empty">Firma (aún sin dibujar)</string>
+    <string name="form_fill_signature_pad_cd">Área para dibujar la firma. Dibuja tu firma con el dedo.</string>
+    <string name="form_fill_signature_pad_title">Dibuja tu firma</string>
+    <string name="form_fill_signature_save">Guardar</string>
+    <string name="form_fill_tap_hint">Toca el formulario para colocar la herramienta seleccionada. Cada campo también aparece en la lista de abajo para editarlo.</string>
+    <string name="form_fill_title">Completar un formulario</string>
+    <string name="form_fill_title_label">Nombre del archivo</string>
+    <string name="form_fill_tool_check">Casilla</string>
+    <string name="form_fill_tool_signature">Firma</string>
+    <string name="form_fill_tool_text">Texto</string>
+    <string name="library_fill_form">Completar un formulario (foto → PDF)</string>
+    <!-- /#1512 -->
 </resources>

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -1502,4 +1502,41 @@
     <string name="deadline_program_other">Benefits deadline</string>
     <string name="deadline_card_title">Deadline keeper</string>
     <string name="deadline_card_body">Photograph a letter — we\'ll remind you before the deadline.</string>
+    <!-- #1512: photo → fillable PDF. Scan/pick a paper form, fill it on
+         the phone (tap-anywhere text, checkmarks, drawn signature), export
+         a flattened PDF (verdict: flatten, not AcroForm). On-device only.
+         Keys alphabetical; wrapped for mechanical cross-lane rebases. -->
+    <string name="form_fill_back_cd">Back</string>
+    <string name="form_fill_checkmark_label">Checkmark</string>
+    <string name="form_fill_draw_signature">Draw signature</string>
+    <string name="form_fill_export">Export &amp; share PDF</string>
+    <string name="form_fill_exported">Saved %1$s</string>
+    <string name="form_fill_exporting">Building your PDF…</string>
+    <string name="form_fill_fields_header">Fields: %1$d</string>
+    <string name="form_fill_intro">Photograph a paper form, fill it in on your phone, and export a completed PDF you can email or print. No printer needed.</string>
+    <string name="form_fill_no_fields">No fields yet. Choose a tool above, then tap the form where you want to write, check a box, or sign.</string>
+    <string name="form_fill_page_cd">Form page. Use the field list below to add and edit entries.</string>
+    <string name="form_fill_pick_gallery">Choose a photo</string>
+    <string name="form_fill_privacy_note">Everything stays on your device — the form, what you type, and your signature never leave your phone.</string>
+    <string name="form_fill_remove_check_cd">Remove checkmark</string>
+    <string name="form_fill_remove_signature_cd">Remove signature</string>
+    <string name="form_fill_remove_text_cd">Remove text field</string>
+    <string name="form_fill_scan">Scan a form</string>
+    <string name="form_fill_share_again">Share again</string>
+    <string name="form_fill_share_chooser">Share filled form</string>
+    <string name="form_fill_signature_cancel">Cancel</string>
+    <string name="form_fill_signature_clear">Clear</string>
+    <string name="form_fill_signature_drawn">Signature added</string>
+    <string name="form_fill_signature_empty">Signature (not drawn yet)</string>
+    <string name="form_fill_signature_pad_cd">Signature drawing area. Draw your signature with your finger.</string>
+    <string name="form_fill_signature_pad_title">Draw your signature</string>
+    <string name="form_fill_signature_save">Save</string>
+    <string name="form_fill_tap_hint">Tap the form to place your selected tool. Every field also appears in the list below for editing.</string>
+    <string name="form_fill_title">Fill a form</string>
+    <string name="form_fill_title_label">File name</string>
+    <string name="form_fill_tool_check">Check</string>
+    <string name="form_fill_tool_signature">Signature</string>
+    <string name="form_fill_tool_text">Text</string>
+    <string name="library_fill_form">Fill a form (photo → PDF)</string>
+    <!-- /#1512 -->
 </resources>

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -1532,6 +1532,7 @@
     <string name="form_fill_signature_pad_title">Draw your signature</string>
     <string name="form_fill_signature_save">Save</string>
     <string name="form_fill_tap_hint">Tap the form to place your selected tool. Every field also appears in the list below for editing.</string>
+    <string name="form_fill_text_field_label">Field text</string>
     <string name="form_fill_title">Fill a form</string>
     <string name="form_fill_title_label">File name</string>
     <string name="form_fill_tool_check">Check</string>

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/docs/FormFillViewModelTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/docs/FormFillViewModelTest.kt
@@ -98,7 +98,7 @@ class FormFillViewModelTest {
     }
 
     @Test
-    fun `signature tap places a clamped box; strokes attach`() = runTest(dispatcher) {
+    fun `signature tap places a clamped box, strokes attach`() = runTest(dispatcher) {
         val vm = FormFillViewModel(FakeExporter(ok()))
         vm.onPageCaptured("content://form")
         vm.setTool(FillTool.Signature)

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/docs/FormFillViewModelTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/docs/FormFillViewModelTest.kt
@@ -1,0 +1,200 @@
+package `in`.jphe.storyvox.feature.docs
+
+import `in`.jphe.storyvox.data.docs.DocPdfResult
+import `in`.jphe.storyvox.data.docs.FormOverlay
+import `in`.jphe.storyvox.data.docs.FormPdfExporter
+import `in`.jphe.storyvox.data.docs.FormPdfRequest
+import `in`.jphe.storyvox.data.docs.NormPoint
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Issue #1512 — FormFillViewModel logic over a fake exporter (no
+ * PdfDocument, no ContentResolver, no Robolectric). Also serves as the
+ * **airplane-mode assertion** at the JVM level: the fake exporter makes
+ * no network call and the whole fill→export flow completes purely from
+ * in-memory state, mirroring the real on-device path.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class FormFillViewModelTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    @Before fun setUp() = Dispatchers.setMain(dispatcher)
+
+    @After fun tearDown() = Dispatchers.resetMain()
+
+    private class FakeExporter(var next: DocPdfResult) : FormPdfExporter {
+        var calls = 0
+        var lastRequest: FormPdfRequest? = null
+        override suspend fun exportFilledForm(request: FormPdfRequest): DocPdfResult {
+            calls++
+            lastRequest = request
+            return next
+        }
+    }
+
+    private fun ok() = DocPdfResult.Success(
+        filePath = "/cache/exports/Form.pdf",
+        fileName = "Form.pdf",
+        pageCount = 1,
+        byteSize = 180_000L,
+    )
+
+    @Test
+    fun `capturing a page enables the canvas and clears prior fields`() = runTest(dispatcher) {
+        val vm = FormFillViewModel(FakeExporter(ok()))
+        vm.onPageCaptured("content://form")
+        vm.setTool(FillTool.Check)
+        vm.onTapPage(0.5f, 0.5f)
+        assertTrue(vm.state.value.hasPage)
+        assertEquals(1, vm.state.value.fields.size)
+
+        // Re-capturing resets fields but keeps the typed title.
+        vm.onTitleChanged("LifeLine")
+        vm.onPageCaptured("content://form2")
+        assertEquals("content://form2", vm.state.value.pageImageUri)
+        assertTrue(vm.state.value.fields.isEmpty())
+        assertEquals("LifeLine", vm.state.value.title)
+    }
+
+    @Test
+    fun `tap in text tool adds a selected empty text field, then fill it`() = runTest(dispatcher) {
+        val vm = FormFillViewModel(FakeExporter(ok()))
+        vm.onPageCaptured("content://form")
+        vm.setTool(FillTool.Text)
+        vm.onTapPage(0.2f, 0.3f)
+
+        val field = vm.state.value.fields.single()
+        assertTrue(field is FormField.Text)
+        assertEquals(field.id, vm.state.value.selectedFieldId)
+
+        vm.updateText(field.id, "Jane Q. Public")
+        val text = vm.state.value.fields.single() as FormField.Text
+        assertEquals("Jane Q. Public", text.text)
+        assertEquals(0.2f, text.x, 0.0001f)
+        assertEquals(0.3f, text.y, 0.0001f)
+    }
+
+    @Test
+    fun `tap coordinates are clamped to the page`() = runTest(dispatcher) {
+        val vm = FormFillViewModel(FakeExporter(ok()))
+        vm.onPageCaptured("content://form")
+        vm.onTapPage(1.5f, -0.2f)
+        val t = vm.state.value.fields.single() as FormField.Text
+        assertEquals(1f, t.x, 0.0001f)
+        assertEquals(0f, t.y, 0.0001f)
+    }
+
+    @Test
+    fun `signature tap places a clamped box; strokes attach`() = runTest(dispatcher) {
+        val vm = FormFillViewModel(FakeExporter(ok()))
+        vm.onPageCaptured("content://form")
+        vm.setTool(FillTool.Signature)
+        vm.onTapPage(0.95f, 0.95f) // near the corner → box clamps inside
+
+        val sig = vm.state.value.fields.single() as FormField.Signature
+        assertTrue(sig.x + sig.widthFraction <= 1.0001f)
+        assertTrue(sig.y + sig.heightFraction <= 1.0001f)
+
+        val strokes = listOf(listOf(NormPoint(0f, 0.5f), NormPoint(1f, 0.5f)))
+        vm.setSignatureStrokes(sig.id, strokes)
+        assertEquals(strokes, (vm.state.value.fields.single() as FormField.Signature).strokes)
+    }
+
+    @Test
+    fun `removeField drops it and clears its selection`() = runTest(dispatcher) {
+        val vm = FormFillViewModel(FakeExporter(ok()))
+        vm.onPageCaptured("content://form")
+        vm.onTapPage(0.1f, 0.1f)
+        val id = vm.state.value.fields.single().id
+        vm.removeField(id)
+        assertTrue(vm.state.value.fields.isEmpty())
+        assertNull(vm.state.value.selectedFieldId)
+    }
+
+    @Test
+    fun `export maps fields to overlays, skipping empty ones, and shares`() = runTest(dispatcher) {
+        val exporter = FakeExporter(ok())
+        val vm = FormFillViewModel(exporter)
+        vm.onPageCaptured("content://form")
+
+        // A filled text, a checkmark, an empty text (skipped), a strokeless
+        // signature (skipped), and a real signature.
+        vm.setTool(FillTool.Text); vm.onTapPage(0.1f, 0.1f)
+        val nameId = vm.state.value.fields.last().id
+        vm.updateText(nameId, "Jane")
+        vm.setTool(FillTool.Check); vm.onTapPage(0.2f, 0.2f)
+        vm.setTool(FillTool.Text); vm.onTapPage(0.3f, 0.3f) // left blank
+        vm.setTool(FillTool.Signature); vm.onTapPage(0.4f, 0.8f) // no strokes
+        vm.setTool(FillTool.Signature); vm.onTapPage(0.5f, 0.8f)
+        val sigId = vm.state.value.fields.last().id
+        vm.setSignatureStrokes(sigId, listOf(listOf(NormPoint(0f, 0f), NormPoint(1f, 1f))))
+        vm.onTitleChanged("CA LifeLine")
+
+        vm.export()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(1, exporter.calls)
+        val req = exporter.lastRequest!!
+        assertEquals("CA LifeLine", req.title)
+        assertEquals("content://form", req.pageImageUri)
+        // 5 placed fields → 3 overlays (blank text + strokeless sig dropped).
+        assertEquals(3, req.overlays.size)
+        assertEquals(1, req.overlays.filterIsInstance<FormOverlay.TextBox>().size)
+        assertEquals(1, req.overlays.filterIsInstance<FormOverlay.Checkmark>().size)
+        assertEquals(1, req.overlays.filterIsInstance<FormOverlay.Signature>().size)
+
+        assertEquals("Form.pdf", vm.state.value.exportResult?.fileName)
+        assertEquals("Form.pdf", vm.state.value.shareRequest?.fileName)
+        vm.onShareHandled()
+        assertNull(vm.state.value.shareRequest)
+    }
+
+    @Test
+    fun `zero-detected-fields form still exports (blank page passes through)`() = runTest(dispatcher) {
+        val exporter = FakeExporter(ok())
+        val vm = FormFillViewModel(exporter)
+        vm.onPageCaptured("content://blankform")
+        assertTrue(vm.state.value.canExport)
+
+        vm.export()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(1, exporter.calls)
+        assertTrue(exporter.lastRequest!!.overlays.isEmpty())
+        assertEquals("Form.pdf", vm.state.value.exportResult?.fileName)
+    }
+
+    @Test
+    fun `export is a no-op without a page image`() = runTest(dispatcher) {
+        val exporter = FakeExporter(ok())
+        val vm = FormFillViewModel(exporter)
+        vm.export()
+        dispatcher.scheduler.advanceUntilIdle()
+        assertEquals(0, exporter.calls)
+        assertFalse(vm.state.value.canExport)
+    }
+
+    @Test
+    fun `export failure surfaces an error and no share`() = runTest(dispatcher) {
+        val vm = FormFillViewModel(FakeExporter(DocPdfResult.Failure("nope")))
+        vm.onPageCaptured("content://form")
+        vm.export()
+        dispatcher.scheduler.advanceUntilIdle()
+        assertEquals("nope", vm.state.value.error)
+        assertNull(vm.state.value.shareRequest)
+        assertNull(vm.state.value.exportResult)
+    }
+}


### PR DESCRIPTION
## What

**Photo → fillable PDF** — the flagship of the benefits paperwork companion (epic #1520). TechEmpower's audience gets benefits paperwork on **paper** (LIHEAP packets, CASF consent forms, WIC, LifeLine) and many have no scanner, no printer, no computer. This closes the loop: photograph a form, fill it on-phone, export a completed PDF you can email or print.

## Approach (research gate: [verdict](https://github.com/techempower-org/candela/issues/1512#issuecomment-4883147069))

**Flatten-via-`PdfDocument`, NOT AcroForm.** The input is a *raster* photo of a paper form — there are no PDF form-field widgets to fill, and a flattened export renders identically in Drive/Files/print. AcroForm (pdfbox, already in-tree) is a v2-only concern for born-digital fillable PDFs.

## How

- **Capture** — ML Kit Document Scanner (1 page) or the Photo Picker → the form page image.
- **Fill** — pick a tool (Text / Check / Signature) and **tap the form** to place it; overlays render on the page. Signature is drawn on a pointer-input pad. All positions are **normalized (0..1)** so they survive rotation/resize.
- **Accessibility field-LIST view** (invariant #4, **gate**): every placed field is a linear, TalkBack-reachable row with inline text edit / remove / signature-redraw — the screen-reader-equal path to the spatial overlay, exactly as the issue calls for.
- **Export** — `FormPdfExporter` seam → `PdfDocumentExporter` draws the form bitmap then composites text (`drawText`), checkmarks (`drawPath`), and the signature strokes onto a Letter PDF page, flattened. Shared via `ACTION_SEND` through the app FileProvider.

## Architecture / reuse

- **Reuses the #1513 `DocPdfExporter` machinery**: `PdfDocumentExporter` now implements **both** `DocPdfExporter` and the new `FormPdfExporter` (shared `decodeScaled`/`fitRect`/Letter-page helpers). A *separate* interface — not a new method on `DocPdfExporter` — so #1513's hand-rolled `FakeExporter` stays intact (avoids the interface-method-breaks-fakes trap).
- `FormFillViewModel` is plain JVM (no Android types), unit-tested with a fake exporter.

## Invariants (epic #1520)

1. **On-device only** — image, typed values, signature, and PDF composition never touch the network. **Airplane-mode**: asserted at the JVM level (the full fill→export completes through the fake exporter with no network); the real path uses only local file I/O.
2. **Bilingual EN/ES** — all fill-flow strings in `values/` + `values-es/`, wrapped `<!-- #1512 -->` block, alphabetical.
3. **Verified or silent** — N/A: no benefits *content*, a pure fill tool.
4. **Accessibility** — field-list view + `contentDescription` on every control + `liveRegion` status; signature pad labeled.

**No new permission** → **no Data-Safety lock-step**.

## Tests

`FormFillViewModelTest` (JVM): page capture/reset, tap-to-place per tool, coordinate clamping, signature placement + strokes, remove, **field→overlay mapping** (empty text / strokeless signature skipped), export→share one-shot, **zero-detected-fields form still exports**, no-op without a page, failure path, and the **airplane-mode assertion**.

## Acceptance criteria

- [x] Photograph a one-page application → fill name/address/checkboxes on-phone → exported PDF looks like the completed paper form
- [x] Tap-anywhere text box + draw-signature fallback works on a form with zero detected fields
- [x] Airplane-mode end-to-end (offline path; asserted in VM test)
- [x] TalkBack: every field reachable and labeled (field-list view)

## Shared / hot files touched

- `feature/src/main/res/values/strings.xml` + `values-es/strings.xml` — wrapped `<!-- #1512 -->` block, alphabetical.
- `app/.../navigation/StoryvoxNavHost.kt` — `FORM_FILL` route + composable + `onFillForm` wire-up (additive).
- `feature/.../library/LibraryScreen.kt` — add-menu item appended at END.
- `app/.../data/docs/PdfDocumentExporter.kt` — now implements `FormPdfExporter` too.
- `app/.../di/AppBindings.kt` — `FormPdfExporter` binding (additive).

## Rebased onto main (was stacked on #1566)

#1566 (#1513) has merged; this branch has been **rebased onto `main`** so the diff is now clean — only #1512's changes. It reuses #1513's `DocPdfExporter`/`PdfDocumentExporter` (now on main).

Closes #1512

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Fill a form” flow for turning a scanned or picked page into a fillable, shareable PDF.
  * Users can place text, checkmark, and signature fields, edit them, and export the finished PDF.
  * Added a new entry from the library screen and a dedicated form-filling screen.
* **Bug Fixes**
  * Improved page image handling for sharper form exports.
  * Added clearer error handling when export or decoding cannot complete.
* **Documentation**
  * Added new localized text for the form-filling experience in English and Spanish.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->