### PR TITLE
feat(techempower): "make the call" — guided phone scripts + tap-to-dial + capture (#1518)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -70,6 +70,7 @@ import `in`.jphe.storyvox.feature.settings.VoiceAndPlaybackSettingsScreen
 import `in`.jphe.storyvox.feature.settings.pronunciation.PronunciationDictScreen
 import `in`.jphe.storyvox.feature.techempower.TechEmpowerAboutScreen
 import `in`.jphe.storyvox.feature.techempower.TechEmpowerHomeScreen
+import `in`.jphe.storyvox.feature.techempower.calls.CallCardsScreen
 import `in`.jphe.storyvox.feature.techempower.decoder.DecoderScreen
 import `in`.jphe.storyvox.feature.techempower.screener.ScreenerScreen
 import `in`.jphe.storyvox.feature.voicelibrary.VoiceLibraryScreen
@@ -262,6 +263,12 @@ object StoryvoxRoutes {
      * TechEmpower Home.
      */
     const val TECHEMPOWER_DECODER = "techempower/decoder"
+
+    /**
+     * Issue #1518 — "make the call" guided phone scripts. Per-program call
+     * cards with tap-to-dial + answer capture. Drill-down from TechEmpower Home.
+     */
+    const val TECHEMPOWER_CALLS = "techempower/calls"
     /** Q&A chat about a fiction (#81 follow-up). One chat history per
      *  fictionId; the screen pulls fiction title + current chapter
      *  context internally for the system prompt.
@@ -1689,6 +1696,9 @@ private fun StoryvoxNavHostContent(
                     onOpenDecoder = {
                         navController.navigate(StoryvoxRoutes.TECHEMPOWER_DECODER)
                     },
+                    onOpenCalls = {
+                        navController.navigate(StoryvoxRoutes.TECHEMPOWER_CALLS)
+                    },
                     onOpenFiction = { fictionId ->
                         navController.navigate(StoryvoxRoutes.fictionDetail(fictionId))
                     },
@@ -1718,6 +1728,18 @@ private fun StoryvoxNavHostContent(
                 DecoderScreen(
                     onBack = { navController.popBackStack() },
                     onScan = { navController.navigate(StoryvoxRoutes.OCR_CAPTURE) },
+                )
+            }
+            // Issue #1518 — "make the call" guided phone scripts drill-down.
+            composable(
+                StoryvoxRoutes.TECHEMPOWER_CALLS,
+                enterTransition = pushEnter,
+                exitTransition = pushExit,
+                popEnterTransition = popEnter,
+                popExitTransition = popExit,
+            ) {
+                CallCardsScreen(
+                    onBack = { navController.popBackStack() },
                 )
             }
             composable(

--- a/feature/src/main/assets/techempower/call_cards.json
+++ b/feature/src/main/assets/techempower/call_cards.json
@@ -1,0 +1,130 @@
+{
+  "metadata": {
+    "schemaVersion": 1,
+    "provenance": "seed-sample",
+    "verifiedDate": "2026-07-04",
+    "source": "SEED SAMPLE — authored for surface development (issue #1518). NOT the production corpus.",
+    "note": "Placeholder call cards used to build and test the make-the-call surface. Program NAMES and org mappings come from epic #1520; the scripts, checklists, and best-time-to-call notes are GENERIC call-coaching placeholders, NOT verified content. NO phone number is asserted here beyond the public 211 line — the direct program lines come from the TechEmpower-supplied corpus + SEASON-OPS phone book, each carrying verifiedAt. Cards without a verified number route the user through 211. The production corpus replaces this file wholesale; set provenance to \"techempower-verified\" and the seed banner disappears."
+  },
+  "cards": [
+    {
+      "id": "liheap",
+      "org": "Project GO",
+      "title": { "en": "Energy bill help (LIHEAP)", "es": "Ayuda con la factura de energía (LIHEAP)" },
+      "bestTimeToCall": {
+        "en": "Lines are busiest midday — try calling first thing in the morning.",
+        "es": "Las líneas están más ocupadas al mediodía; intente llamar a primera hora de la mañana."
+      },
+      "phone": null,
+      "whatToSay": [
+        { "en": "Hi, my name is ___. I am calling to ask about energy bill help.", "es": "Hola, me llamo ___. Llamo para preguntar sobre ayuda con la factura de energía." },
+        { "en": "I think I might qualify. Can you tell me what I need to apply?", "es": "Creo que podría calificar. ¿Me puede decir qué necesito para solicitar?" },
+        { "en": "What is the best next step, and is there a deadline?", "es": "¿Cuál es el mejor siguiente paso y hay una fecha límite?" }
+      ],
+      "whatToAsk": [
+        { "en": "Are funds still available?", "es": "¿Todavía hay fondos disponibles?" },
+        { "en": "What documents do I need to bring?", "es": "¿Qué documentos necesito llevar?" },
+        { "en": "Is there an appointment or a deadline?", "es": "¿Hay una cita o una fecha límite?" },
+        { "en": "Who should I ask for if I call back?", "es": "¿Por quién debo preguntar si vuelvo a llamar?" }
+      ],
+      "captureFields": [
+        { "id": "funds_available", "label": { "en": "Funds available?", "es": "¿Fondos disponibles?" } },
+        { "id": "appointment", "label": { "en": "Appointment date / time", "es": "Fecha / hora de la cita" } },
+        { "id": "reference", "label": { "en": "Reference or case number", "es": "Número de referencia o de caso" } },
+        { "id": "notes", "label": { "en": "Other notes", "es": "Otras notas" } }
+      ],
+      "verifiedDate": null,
+      "source": {
+        "en": "Seed placeholder — direct line pending verified corpus; routes via 211 for now.",
+        "es": "Marcador de posición — línea directa pendiente del corpus verificado; se conecta por el 211 por ahora."
+      }
+    },
+    {
+      "id": "nid_water_discount",
+      "org": "NID",
+      "title": { "en": "Lower water bill (NID discount)", "es": "Factura de agua más baja (descuento de NID)" },
+      "bestTimeToCall": {
+        "en": "Call during weekday business hours.",
+        "es": "Llame durante el horario laboral entre semana."
+      },
+      "phone": null,
+      "whatToSay": [
+        { "en": "Hi, my name is ___. I am asking about the reduced water rate.", "es": "Hola, me llamo ___. Pregunto sobre la tarifa de agua reducida." },
+        { "en": "I have a limited income. How do I apply for the discount?", "es": "Tengo ingresos limitados. ¿Cómo solicito el descuento?" },
+        { "en": "What do you need from me to get started?", "es": "¿Qué necesita de mí para comenzar?" }
+      ],
+      "whatToAsk": [
+        { "en": "What proof of income do you need?", "es": "¿Qué comprobante de ingresos necesita?" },
+        { "en": "How long does approval take?", "es": "¿Cuánto tarda la aprobación?" },
+        { "en": "Will the discount show on my next bill?", "es": "¿Aparecerá el descuento en mi próxima factura?" }
+      ],
+      "captureFields": [
+        { "id": "documents", "label": { "en": "Documents needed", "es": "Documentos necesarios" } },
+        { "id": "timeline", "label": { "en": "How long approval takes", "es": "Cuánto tarda la aprobación" } },
+        { "id": "notes", "label": { "en": "Other notes", "es": "Otras notas" } }
+      ],
+      "verifiedDate": null,
+      "source": {
+        "en": "Seed placeholder — direct line pending verified corpus; routes via 211 for now.",
+        "es": "Marcador de posición — línea directa pendiente del corpus verificado; se conecta por el 211 por ahora."
+      }
+    },
+    {
+      "id": "freed_battery_backup",
+      "org": "FREED",
+      "title": { "en": "Medical battery backup (FREED)", "es": "Batería de respaldo médica (FREED)" },
+      "bestTimeToCall": {
+        "en": "Call during weekday business hours; have your equipment details ready.",
+        "es": "Llame durante el horario laboral entre semana; tenga listos los detalles de su equipo."
+      },
+      "phone": null,
+      "whatToSay": [
+        { "en": "Hi, my name is ___. Someone in my home uses electric medical equipment.", "es": "Hola, me llamo ___. Alguien en mi hogar usa equipo médico eléctrico." },
+        { "en": "I am asking about a battery backup for power outages.", "es": "Pregunto sobre una batería de respaldo para los apagones." },
+        { "en": "How do I find out if we qualify?", "es": "¿Cómo averiguo si calificamos?" }
+      ],
+      "whatToAsk": [
+        { "en": "What equipment qualifies?", "es": "¿Qué equipo califica?" },
+        { "en": "Is there a waitlist?", "es": "¿Hay una lista de espera?" },
+        { "en": "What is the next step?", "es": "¿Cuál es el siguiente paso?" }
+      ],
+      "captureFields": [
+        { "id": "qualifies", "label": { "en": "Do we qualify?", "es": "¿Calificamos?" } },
+        { "id": "waitlist", "label": { "en": "Waitlist?", "es": "¿Lista de espera?" } },
+        { "id": "notes", "label": { "en": "Other notes", "es": "Otras notas" } }
+      ],
+      "verifiedDate": null,
+      "source": {
+        "en": "Seed placeholder — direct line pending verified corpus; routes via 211 for now.",
+        "es": "Marcador de posición — línea directa pendiente del corpus verificado; se conecta por el 211 por ahora."
+      }
+    },
+    {
+      "id": "help_211",
+      "org": "United Way 211",
+      "title": { "en": "Free local help line (211)", "es": "Línea de ayuda local gratuita (211)" },
+      "bestTimeToCall": {
+        "en": "Available any time, day or night.",
+        "es": "Disponible en cualquier momento, de día o de noche."
+      },
+      "phone": "211",
+      "whatToSay": [
+        { "en": "Hi, I am looking for help with ___ (housing, food, utilities).", "es": "Hola, busco ayuda con ___ (vivienda, comida, servicios públicos)." },
+        { "en": "I live in ___ . What is available near me?", "es": "Vivo en ___ . ¿Qué hay disponible cerca de mí?" }
+      ],
+      "whatToAsk": [
+        { "en": "What programs am I eligible for?", "es": "¿Para qué programas soy elegible?" },
+        { "en": "Can you connect me directly?", "es": "¿Me puede conectar directamente?" }
+      ],
+      "captureFields": [
+        { "id": "programs", "label": { "en": "Programs they mentioned", "es": "Programas que mencionaron" } },
+        { "id": "notes", "label": { "en": "Other notes", "es": "Otras notas" } }
+      ],
+      "verifiedDate": "2026-07-04",
+      "source": {
+        "en": "211 is the public United Way social-services line.",
+        "es": "211 es la línea pública de servicios sociales de United Way."
+      }
+    }
+  ]
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/TechEmpowerHomeScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/TechEmpowerHomeScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.material.icons.filled.Forum
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Mail
 import androidx.compose.material.icons.filled.Phone
+import androidx.compose.material.icons.filled.SupportAgent
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -100,6 +101,7 @@ fun TechEmpowerHomeScreen(
     onOpenAbout: () -> Unit,
     onOpenScreener: () -> Unit,
     onOpenDecoder: () -> Unit,
+    onOpenCalls: () -> Unit,
     onOpenFiction: (String) -> Unit,
 ) {
     val spacing = LocalSpacing.current
@@ -187,6 +189,16 @@ fun TechEmpowerHomeScreen(
                     body = "Join our Discord community. Real people, no scripts.",
                     icon = Icons.Filled.Forum,
                     onClick = { launchDiscord(context) },
+                )
+            }
+            // Issue #1518 — "Make the call" guided phone scripts. Bilingual copy
+            // via string resources.
+            item {
+                TechEmpowerCard(
+                    title = stringResource(FeatureR.string.calls_card_title),
+                    body = stringResource(FeatureR.string.calls_card_body),
+                    icon = Icons.Filled.SupportAgent,
+                    onClick = onOpenCalls,
                 )
             }
             // Issue #546 — surface a "no-telephony" fallback dialog if

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/calls/CallCards.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/calls/CallCards.kt
@@ -1,0 +1,74 @@
+package `in`.jphe.storyvox.feature.techempower.calls
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Issue #1518 — data model for the **"make the call"** corpus.
+ *
+ * Per-program call cards: the number (tap-to-dial), best time to call, a short
+ * script of what to say, a checklist of what to ask, and a capture form for the
+ * answers. Cards are listenable (rehearse the call in the car).
+ *
+ * VERIFIED-OR-SILENT (epic #1520 invariant 3): ships the SURFACE + a corpus
+ * READER. The bundled `call_cards.json` is a SMALL, clearly-marked SEED SAMPLE
+ * ([CallCardsMetadata.provenance] == `"seed-sample"`); scripts/checklists are
+ * generic call-coaching placeholders. The only asserted number is the public
+ * 211 line — the direct program lines come from the TechEmpower-supplied corpus
+ * + SEASON-OPS phone book (each carrying verifiedAt). A card with no verified
+ * [CallCard.phone] routes the caller through 211. We never invent a number.
+ */
+@Serializable
+data class CallCardsCorpus(
+    val metadata: CallCardsMetadata,
+    val cards: List<CallCard> = emptyList(),
+)
+
+@Serializable
+data class CallCardsMetadata(
+    val schemaVersion: Int = 1,
+    val provenance: String = PROVENANCE_SEED,
+    val verifiedDate: String? = null,
+    val source: String? = null,
+    val note: String? = null,
+) {
+    val isVerified: Boolean get() = provenance == PROVENANCE_VERIFIED
+
+    companion object {
+        const val PROVENANCE_SEED = "seed-sample"
+        const val PROVENANCE_VERIFIED = "techempower-verified"
+    }
+}
+
+/** A bilingual string; [get] picks the language, falling back to EN. */
+@Serializable
+data class Localized(
+    val en: String,
+    val es: String? = null,
+) {
+    fun get(spanish: Boolean): String = if (spanish) (es ?: en) else en
+}
+
+@Serializable
+data class CallCard(
+    val id: String,
+    val org: String? = null,
+    val title: Localized,
+    val bestTimeToCall: Localized? = null,
+    /** Verified direct number, or null → route through 211 (never invented). */
+    val phone: String? = null,
+    val whatToSay: List<Localized> = emptyList(),
+    val whatToAsk: List<Localized> = emptyList(),
+    val captureFields: List<CaptureField> = emptyList(),
+    val verifiedDate: String? = null,
+    val source: Localized? = null,
+) {
+    /** The number the dial affordance uses: the verified line, or 211. */
+    fun dialNumber(fallback: String = "211"): String = phone ?: fallback
+}
+
+/** One field in a card's post-call answer-capture form. */
+@Serializable
+data class CaptureField(
+    val id: String,
+    val label: Localized,
+)

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/calls/CallCardsParser.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/calls/CallCardsParser.kt
@@ -1,0 +1,14 @@
+package `in`.jphe.storyvox.feature.techempower.calls
+
+import kotlinx.serialization.json.Json
+
+/** Issue #1518 — pure JSON → [CallCardsCorpus] decode. No Android, no IO. */
+object CallCardsParser {
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+    }
+
+    fun parse(raw: String): CallCardsCorpus =
+        json.decodeFromString(CallCardsCorpus.serializer(), raw)
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/calls/CallCardsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/calls/CallCardsScreen.kt
@@ -1,0 +1,417 @@
+package `in`.jphe.storyvox.feature.techempower.calls
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Phone
+import androidx.compose.material.icons.filled.VolumeUp
+import androidx.compose.material3.Button
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
+import `in`.jphe.storyvox.data.TechEmpowerLinks
+import `in`.jphe.storyvox.feature.R
+import `in`.jphe.storyvox.ui.theme.LocalSpacing
+
+/**
+ * Issue #1518 — the "make the call" surface.
+ *
+ * Per-program call cards: tap-to-dial (`ACTION_DIAL`, no CALL_PHONE permission,
+ * no call log), best time to call, a short script of what to say, a checklist
+ * of what to ask, and a post-call answer-capture sheet. Cards are listenable —
+ * rehearse the call in the car (invariant 4). A card with no verified number
+ * routes through 211 (we never invent a number).
+ *
+ * On returning to the app after a dial, the capture sheet is offered — detected
+ * via ON_RESUME, with NO call-log access. Chrome is bilingual via `res/values`
+ * + `res/values-es`; card content carries its own EN/ES and follows the locale.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CallCardsScreen(
+    onBack: () -> Unit,
+    viewModel: CallCardsViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsState()
+    val spanish = LocalConfiguration.current.locales[0].language == "es"
+
+    // Foreground-return → offer the capture sheet (no call-log access).
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) { viewModel.onReturnedToForeground() }
+
+    val selected = state.selectedCard
+
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = {
+                    Text(
+                        selected?.title?.get(spanish) ?: stringResource(R.string.calls_title),
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = { if (selected != null) viewModel.backToList() else onBack() }) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.calls_back),
+                        )
+                    }
+                },
+            )
+        },
+    ) { pad ->
+        when {
+            state.isLoading -> Centered(Modifier.padding(pad)) { CircularProgressIndicator() }
+            state.loadError -> Centered(Modifier.padding(pad)) {
+                Text(
+                    stringResource(R.string.calls_load_error),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            selected != null -> CardDetail(
+                card = selected,
+                spanish = spanish,
+                onDialInitiated = viewModel::onDialInitiated,
+                onOpenCapture = viewModel::openCapture,
+                onReadAloud = viewModel::readAloud,
+                onStop = viewModel::stopReadAloud,
+                modifier = Modifier.padding(pad),
+            )
+            else -> CardList(
+                corpus = state.corpus,
+                spanish = spanish,
+                onSelect = viewModel::select,
+                modifier = Modifier.padding(pad),
+            )
+        }
+    }
+
+    if (state.showCapture && selected != null) {
+        CaptureSheet(
+            card = selected,
+            spanish = spanish,
+            values = state.captureByCard[selected.id].orEmpty(),
+            onValueChange = { fieldId, value -> viewModel.updateCapture(selected.id, fieldId, value) },
+            onDismiss = viewModel::dismissCapture,
+        )
+    }
+}
+
+@Composable
+private fun Centered(modifier: Modifier = Modifier, content: @Composable () -> Unit) {
+    Box(modifier.fillMaxSize(), contentAlignment = Alignment.Center) { content() }
+}
+
+@Composable
+private fun CardList(
+    corpus: CallCardsCorpus?,
+    spanish: Boolean,
+    onSelect: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    corpus ?: return
+    val spacing = LocalSpacing.current
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(spacing.md),
+        verticalArrangement = Arrangement.spacedBy(spacing.md),
+    ) {
+        item {
+            Text(
+                stringResource(R.string.calls_intro),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+        if (!corpus.metadata.isVerified) item { SampleDataBanner() }
+        items(corpus.cards, key = { it.id }) { card ->
+            CallCardRow(card = card, spanish = spanish, onClick = { onSelect(card.id) })
+        }
+    }
+}
+
+@Composable
+private fun CallCardRow(card: CallCard, spanish: Boolean, onClick: () -> Unit) {
+    val spacing = LocalSpacing.current
+    val brass = MaterialTheme.colorScheme.primary
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(MaterialTheme.shapes.large)
+            .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+            .border(1.5.dp, brass.copy(alpha = 0.55f), MaterialTheme.shapes.large)
+            .clickable(onClick = onClick)
+            .padding(spacing.md),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+    ) {
+        Icon(Icons.Filled.Phone, contentDescription = null, tint = brass, modifier = Modifier.size(24.dp))
+        Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(spacing.xs)) {
+            Text(
+                card.title.get(spanish),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                fontWeight = FontWeight.SemiBold,
+            )
+            card.org?.let {
+                Text(it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+        }
+        Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, contentDescription = null, tint = brass)
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun CardDetail(
+    card: CallCard,
+    spanish: Boolean,
+    onDialInitiated: () -> Unit,
+    onOpenCapture: () -> Unit,
+    onReadAloud: (String) -> Unit,
+    onStop: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val spacing = LocalSpacing.current
+    val context = LocalContext.current
+    val brass = MaterialTheme.colorScheme.primary
+    val number = card.dialNumber()
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(spacing.md),
+        verticalArrangement = Arrangement.spacedBy(spacing.md),
+    ) {
+        card.bestTimeToCall?.let {
+            Section(stringResource(R.string.calls_best_time), it.get(spanish))
+        }
+
+        // What to say — the script.
+        if (card.whatToSay.isNotEmpty()) {
+            Column(verticalArrangement = Arrangement.spacedBy(spacing.xs)) {
+                SectionHeading(stringResource(R.string.calls_what_to_say))
+                card.whatToSay.forEach { line ->
+                    Text("• ${line.get(spanish)}", style = MaterialTheme.typography.bodyMedium)
+                }
+            }
+        }
+
+        // What to ask — the checklist.
+        if (card.whatToAsk.isNotEmpty()) {
+            Column(verticalArrangement = Arrangement.spacedBy(spacing.xs)) {
+                SectionHeading(stringResource(R.string.calls_what_to_ask))
+                card.whatToAsk.forEach { item ->
+                    Text("☐ ${item.get(spanish)}", style = MaterialTheme.typography.bodyMedium)
+                }
+            }
+        }
+
+        // Actions.
+        Button(
+            onClick = {
+                dial(context, number)
+                onDialInitiated()
+            },
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Icon(Icons.Filled.Phone, contentDescription = null, modifier = Modifier.size(18.dp))
+            Spacer(Modifier.width(spacing.xs))
+            Text(
+                if (card.phone != null) {
+                    stringResource(R.string.calls_call) + "  " + number
+                } else {
+                    stringResource(R.string.calls_call_via_211)
+                },
+            )
+        }
+        FlowRow(horizontalArrangement = Arrangement.spacedBy(spacing.sm)) {
+            OutlinedButton(onClick = { onReadAloud(cardAsSpeech(card, spanish)) }) {
+                Icon(Icons.Filled.VolumeUp, contentDescription = null, modifier = Modifier.size(18.dp))
+                Spacer(Modifier.width(spacing.xs))
+                Text(stringResource(R.string.calls_read_aloud))
+            }
+            TextButton(onClick = onStop) { Text(stringResource(R.string.calls_stop)) }
+            TextButton(onClick = onOpenCapture) { Text(stringResource(R.string.calls_add_notes)) }
+        }
+
+        // Verified-date.
+        val date = card.verifiedDate
+        Text(
+            if (date != null) stringResource(R.string.calls_verified_prefix, date)
+            else stringResource(R.string.calls_verified_unknown),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun CaptureSheet(
+    card: CallCard,
+    spanish: Boolean,
+    values: Map<String, String>,
+    onValueChange: (String, String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val spacing = LocalSpacing.current
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = spacing.md)
+                .padding(bottom = spacing.lg),
+            verticalArrangement = Arrangement.spacedBy(spacing.sm),
+        ) {
+            Text(
+                stringResource(R.string.calls_capture_title),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.primary,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.semantics { heading() },
+            )
+            Text(
+                stringResource(R.string.calls_capture_note),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            card.captureFields.forEach { field ->
+                OutlinedTextField(
+                    value = values[field.id].orEmpty(),
+                    onValueChange = { onValueChange(field.id, it) },
+                    label = { Text(field.label.get(spanish)) },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = field.id != "notes",
+                )
+            }
+            Button(onClick = onDismiss, modifier = Modifier.fillMaxWidth()) {
+                Text(stringResource(R.string.calls_capture_save))
+            }
+        }
+    }
+}
+
+@Composable
+private fun Section(label: String, body: String) {
+    val spacing = LocalSpacing.current
+    Column(verticalArrangement = Arrangement.spacedBy(spacing.xs)) {
+        SectionHeading(label)
+        Text(body, style = MaterialTheme.typography.bodyMedium)
+    }
+}
+
+@Composable
+private fun SectionHeading(label: String) {
+    Text(
+        label,
+        style = MaterialTheme.typography.labelLarge,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = Modifier.semantics { heading() },
+    )
+}
+
+@Composable
+private fun SampleDataBanner() {
+    val spacing = LocalSpacing.current
+    val accent = MaterialTheme.colorScheme.tertiary
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(MaterialTheme.shapes.medium)
+            .background(accent.copy(alpha = 0.12f))
+            .border(1.dp, accent.copy(alpha = 0.5f), MaterialTheme.shapes.medium)
+            .padding(spacing.md),
+        horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+    ) {
+        Icon(Icons.Filled.Info, contentDescription = null, tint = accent, modifier = Modifier.size(20.dp))
+        Column(verticalArrangement = Arrangement.spacedBy(spacing.xs)) {
+            Text(
+                stringResource(R.string.calls_seed_banner_title),
+                style = MaterialTheme.typography.labelLarge,
+                color = accent,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Text(
+                stringResource(R.string.calls_seed_banner_body),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+// ─── Speech + intents ──────────────────────────────────────────────────────
+
+private fun cardAsSpeech(card: CallCard, spanish: Boolean): String = buildString {
+    append(card.title.get(spanish)); append(". ")
+    card.bestTimeToCall?.let { append(it.get(spanish)); append(" ") }
+    if (card.whatToSay.isNotEmpty()) {
+        card.whatToSay.forEach { append(it.get(spanish)); append(" ") }
+    }
+    if (card.whatToAsk.isNotEmpty()) {
+        card.whatToAsk.forEach { append(it.get(spanish)); append(" ") }
+    }
+}
+
+private fun dial(context: Context, number: String) {
+    runCatching {
+        context.startActivity(
+            Intent(Intent.ACTION_DIAL, Uri.parse(TechEmpowerLinks.telUri(number)))
+                .apply { addFlags(Intent.FLAG_ACTIVITY_NEW_TASK) },
+        )
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/calls/CallCardsViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/calls/CallCardsViewModel.kt
@@ -1,0 +1,142 @@
+package `in`.jphe.storyvox.feature.techempower.calls
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import `in`.jphe.storyvox.feature.api.PlaybackControllerUi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+/**
+ * Issue #1518 — "make the call" ViewModel.
+ *
+ * Holds the call-card corpus, the selected card, per-card captured answers, and
+ * the post-call capture flow. Dialing is `Intent.ACTION_DIAL` (no CALL_PHONE
+ * permission, no call log). When the user returns to the app after a dial we
+ * offer the capture sheet — detected via a foreground-return signal from the
+ * screen ([onReturnedToForeground]); NO call-log access.
+ *
+ * Answer capture is on-device, in this session's state only. Durable, encrypted
+ * persistence is deferred to the wallet storage seam:
+ *   // TODO(#1514): persist captured call answers via the encrypted wallet seam
+ *   // once it lands, instead of session-only memory. Do not add a parallel
+ *   // sensitive store (epic #1520 cross-lane guidance).
+ *
+ * Read-aloud goes through the app-level [PlaybackControllerUi] seam.
+ * `core-playback` is untouched.
+ */
+@HiltViewModel
+class CallCardsViewModel @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val playback: PlaybackControllerUi,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(CallCardsUiState())
+    val state: StateFlow<CallCardsUiState> = _state.asStateFlow()
+
+    init {
+        load()
+    }
+
+    private fun load() {
+        viewModelScope.launch {
+            val result = runCatching {
+                val raw = withContext(Dispatchers.IO) {
+                    context.assets.open(CORPUS_ASSET).use { it.readBytes().decodeToString() }
+                }
+                CallCardsParser.parse(raw)
+            }
+            // `st` names the outer state param explicitly — inside fold, the
+            // onFailure lambda's implicit `it` is the Throwable, not the state,
+            // so `it.copy(...)` would not resolve.
+            _state.update { st ->
+                result.fold(
+                    onSuccess = { corpus -> st.copy(corpus = corpus, loadError = false) },
+                    onFailure = { st.copy(corpus = null, loadError = true) },
+                )
+            }
+        }
+    }
+
+    fun select(cardId: String) {
+        _state.update { it.copy(selectedCardId = cardId, dialInitiated = false, showCapture = false) }
+    }
+
+    fun backToList() {
+        stopReadAloud()
+        _state.update { it.copy(selectedCardId = null, dialInitiated = false, showCapture = false) }
+    }
+
+    /** The screen fires the dial intent; this arms the return-to-capture flow. */
+    fun onDialInitiated() {
+        _state.update { it.copy(dialInitiated = true) }
+    }
+
+    /**
+     * Called on the screen's ON_RESUME. If a dial was just initiated, offer the
+     * capture sheet exactly once.
+     */
+    fun onReturnedToForeground() {
+        _state.update { current ->
+            if (current.dialInitiated && current.selectedCardId != null && !current.showCapture) {
+                current.copy(showCapture = true, dialInitiated = false)
+            } else {
+                current
+            }
+        }
+    }
+
+    /** Manually open the capture sheet (e.g. "I already made the call"). */
+    fun openCapture() {
+        _state.update { if (it.selectedCardId != null) it.copy(showCapture = true) else it }
+    }
+
+    fun dismissCapture() {
+        _state.update { it.copy(showCapture = false) }
+    }
+
+    fun updateCapture(cardId: String, fieldId: String, value: String) {
+        _state.update { current ->
+            val forCard = current.captureByCard[cardId].orEmpty() + (fieldId to value)
+            current.copy(captureByCard = current.captureByCard + (cardId to forCard))
+        }
+    }
+
+    fun readAloud(text: String) {
+        if (text.isBlank()) return
+        viewModelScope.launch { playback.speakText(text) }
+    }
+
+    fun stopReadAloud() {
+        playback.stopSpeaking()
+    }
+
+    override fun onCleared() {
+        stopReadAloud()
+        super.onCleared()
+    }
+
+    companion object {
+        const val CORPUS_ASSET = "techempower/call_cards.json"
+    }
+}
+
+data class CallCardsUiState(
+    val corpus: CallCardsCorpus? = null,
+    val loadError: Boolean = false,
+    val selectedCardId: String? = null,
+    val captureByCard: Map<String, Map<String, String>> = emptyMap(),
+    val dialInitiated: Boolean = false,
+    val showCapture: Boolean = false,
+) {
+    val isLoading: Boolean get() = corpus == null && !loadError
+    val selectedCard: CallCard? get() = corpus?.cards?.firstOrNull { it.id == selectedCardId }
+}

--- a/feature/src/main/res/values-es/strings.xml
+++ b/feature/src/main/res/values-es/strings.xml
@@ -98,4 +98,29 @@
     <!-- Tarjeta de entrada en la cuadrícula de Inicio de TechEmpower. -->
     <string name="decoder_card_title">Entender una carta</string>
     <string name="decoder_card_body">Fotografíe un aviso de beneficios confuso; le explicaremos qué significa, en inglés o español. Funciona sin conexión.</string>
+
+    <!-- #1518 — "Hacer la llamada" guiones telefónicos guiados -->
+    <string name="calls_title">Hacer la llamada</string>
+    <string name="calls_back">Atrás</string>
+    <string name="calls_intro">Algo de ayuda está a solo una llamada de distancia. Elija un programa; le daremos el número, qué decir y un lugar para anotar las respuestas.</string>
+    <string name="calls_seed_banner_title">Datos de muestra</string>
+    <string name="calls_seed_banner_body">Estos guiones de llamada son una vista previa. Los números y detalles verificados provienen de TechEmpower.</string>
+    <string name="calls_best_time">Mejor hora para llamar</string>
+    <string name="calls_what_to_say">Qué decir</string>
+    <string name="calls_what_to_ask">Qué preguntar</string>
+    <string name="calls_call">Llamar</string>
+    <string name="calls_call_via_211">Llamar al 211 para conectar</string>
+    <string name="calls_read_aloud">Leer esto en voz alta</string>
+    <string name="calls_stop">Detener</string>
+    <string name="calls_add_notes">Añadir mis notas</string>
+    <string name="calls_capture_title">Después de su llamada</string>
+    <string name="calls_capture_note">Las notas se guardan en este dispositivo.</string>
+    <string name="calls_capture_save">Guardar</string>
+    <!-- %1$s = la fecha de verificación de la tarjeta. -->
+    <string name="calls_verified_prefix">Detalles verificados: %1$s</string>
+    <string name="calls_verified_unknown">Número aún no verificado; le conecta a través del 211.</string>
+    <string name="calls_load_error">No pudimos abrir las tarjetas de llamada. Actualice la aplicación e inténtelo de nuevo.</string>
+    <!-- Tarjeta de entrada en la cuadrícula de Inicio de TechEmpower. -->
+    <string name="calls_card_title">Hacer la llamada</string>
+    <string name="calls_card_body">Números de teléfono de los programas, qué decir y una lista de verificación, con ayuda para vencer la ansiedad de llamar. Funciona sin conexión.</string>
 </resources>

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -1338,4 +1338,29 @@
     <!-- Entry card on the TechEmpower Home grid. -->
     <string name="decoder_card_title">Understand a letter</string>
     <string name="decoder_card_body">Photograph a confusing benefits notice — we will explain what it means, in English or Spanish. Works offline.</string>
+
+    <!-- #1518 — "Make the call" guided phone scripts -->
+    <string name="calls_title">Make the call</string>
+    <string name="calls_back">Back</string>
+    <string name="calls_intro">Some help is just one phone call away. Pick a program — we will give you the number, what to say, and a place to jot down the answers.</string>
+    <string name="calls_seed_banner_title">Sample data</string>
+    <string name="calls_seed_banner_body">These call scripts are a preview. Verified numbers and details come from TechEmpower.</string>
+    <string name="calls_best_time">Best time to call</string>
+    <string name="calls_what_to_say">What to say</string>
+    <string name="calls_what_to_ask">What to ask</string>
+    <string name="calls_call">Call</string>
+    <string name="calls_call_via_211">Call 211 to connect</string>
+    <string name="calls_read_aloud">Read this aloud</string>
+    <string name="calls_stop">Stop</string>
+    <string name="calls_add_notes">Add my notes</string>
+    <string name="calls_capture_title">After your call</string>
+    <string name="calls_capture_note">Notes are kept on this device.</string>
+    <string name="calls_capture_save">Save</string>
+    <!-- %1$s = the card\'s verified date. -->
+    <string name="calls_verified_prefix">Details verified: %1$s</string>
+    <string name="calls_verified_unknown">Number not yet verified — connects you through 211.</string>
+    <string name="calls_load_error">We could not open the call cards. Please update the app and try again.</string>
+    <!-- Entry card on the TechEmpower Home grid. -->
+    <string name="calls_card_title">Make the call</string>
+    <string name="calls_card_body">Program phone numbers, what to say, and a checklist — with help beating call anxiety. Works offline.</string>
 </resources>

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/techempower/calls/CallCardsParserTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/techempower/calls/CallCardsParserTest.kt
@@ -1,0 +1,88 @@
+package `in`.jphe.storyvox.feature.techempower.calls
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1518 — pins the call-cards decode contract + the never-invent-a-number
+ * dial fallback. Pure JVM.
+ */
+class CallCardsParserTest {
+
+    private val sample = """
+        {
+          "metadata": {
+            "schemaVersion": 1,
+            "provenance": "seed-sample",
+            "verifiedDate": "2026-07-04",
+            "futureField": "ignored"
+          },
+          "cards": [
+            {
+              "id": "liheap", "org": "Project GO",
+              "title": { "en": "Energy help", "es": "Ayuda de energía" },
+              "bestTimeToCall": { "en": "Morning", "es": "Por la mañana" },
+              "phone": null,
+              "whatToSay": [ { "en": "Hi", "es": "Hola" } ],
+              "whatToAsk": [ { "en": "Funds?", "es": "¿Fondos?" } ],
+              "captureFields": [ { "id": "notes", "label": { "en": "Notes", "es": "Notas" } } ],
+              "verifiedDate": null
+            },
+            {
+              "id": "help_211", "org": "211",
+              "title": { "en": "211" }, "phone": "211",
+              "whatToSay": [], "whatToAsk": [], "captureFields": [],
+              "verifiedDate": "2026-07-04"
+            }
+          ]
+        }
+    """.trimIndent()
+
+    @Test
+    fun parsesMetadataAndCards() {
+        val corpus = CallCardsParser.parse(sample)
+        assertEquals("seed-sample", corpus.metadata.provenance)
+        assertFalse(corpus.metadata.isVerified)
+        assertEquals(2, corpus.cards.size)
+    }
+
+    @Test
+    fun ignoresUnknownKeys() {
+        assertTrue(CallCardsParser.parse(sample).cards.isNotEmpty())
+    }
+
+    @Test
+    fun dialNumberFallsBackTo211WhenNoVerifiedNumber() {
+        val corpus = CallCardsParser.parse(sample)
+        val liheap = corpus.cards.first { it.id == "liheap" }
+        // No verified number → never invents one; routes through 211.
+        assertEquals("211", liheap.dialNumber())
+    }
+
+    @Test
+    fun dialNumberUsesVerifiedNumberWhenPresent() {
+        val corpus = CallCardsParser.parse(sample)
+        val help = corpus.cards.first { it.id == "help_211" }
+        assertEquals("211", help.dialNumber())
+        assertEquals("211", help.phone)
+    }
+
+    @Test
+    fun localizedContentFollowsLanguage() {
+        val corpus = CallCardsParser.parse(sample)
+        val liheap = corpus.cards.first { it.id == "liheap" }
+        assertEquals("Ayuda de energía", liheap.title.get(spanish = true))
+        assertEquals("Energy help", liheap.title.get(spanish = false))
+        assertEquals("Por la mañana", liheap.bestTimeToCall!!.get(spanish = true))
+    }
+
+    @Test
+    fun cardsCarryScriptChecklistAndCaptureFields() {
+        val liheap = CallCardsParser.parse(sample).cards.first { it.id == "liheap" }
+        assertEquals(1, liheap.whatToSay.size)
+        assertEquals(1, liheap.whatToAsk.size)
+        assertEquals("notes", liheap.captureFields.single().id)
+    }
+}


### PR DESCRIPTION
## "Make the call" — guided phone scripts (#1518)

Half the benefits in our corpus unlock with one phone call, and call anxiety is a documented barrier for exactly our audience. This surface holds their hand live: per-program **call cards** with tap-to-dial, best time to call, a short script of what to say, a checklist of what to ask, and a post-call **answer-capture** sheet. Cards are listenable — rehearse the call in the car.

### ⚠️ Corpus provenance (verified-or-silent, invariant 3)
Ships the **surface + a corpus reader**. The bundled `feature/src/main/assets/techempower/call_cards.json` is a **SMALL, clearly-marked SEED SAMPLE** (`provenance = "seed-sample"`; persistent in-app **"Sample data"** banner). Scripts/checklists are generic call-coaching placeholders.

**NO phone number is asserted here beyond the public 211 line.** The direct program lines come from the TechEmpower-supplied corpus + SEASON-OPS phone book (each carrying `verifiedAt`). A card with **no verified number routes the caller through 211** — we never invent a number. The production corpus replaces the asset wholesale; set `provenance` to `techempower-verified` and the banner disappears.

### Privacy / on-device (invariant 1)
- Tap-to-dial is `Intent.ACTION_DIAL` — **no `CALL_PHONE` permission, no call log, no recording**.
- Returning to the app after a dial offers the capture sheet, detected via `ON_RESUME` (`LifecycleEventEffect`) — **no call-log access**.
- Captured answers live on-device in session state. Durable **encrypted** persistence is deferred to the #1514 wallet storage seam (`// TODO(#1514)`), per the wave's cross-lane guidance — no parallel sensitive store, and this keeps the PR out of the Data-Safety serialization files.

### Scope notes
- **Reminder/callback scheduling is intentionally NOT built here** — that belongs to the deadline-keeper lane (#1515). Building it would add a new permission (`SCHEDULE_EXACT_ALARM`/`POST_NOTIFICATIONS`) + a Data-Safety serialization point and overlap #1515. Left as a hand-off.
- **Teleprompter (#1367) reuse:** the teleprompter is a recording-mode auto-scroll overlay — the wrong fit for a no-recording call surface. The "what to say" script instead renders as listenable text (same rehearse-out-loud intent).
- Read-aloud via the app-level `PlaybackControllerUi.speakText` seam — `core-playback` untouched.

### What's in it
- EN/ES (invariant 2): chrome via `res/values` + `res/values-es`; card content carries its own `en`/`es`.
- Accessibility (invariant 4): list + detail (no spatial UI), TalkBack headings/labels, read-aloud on every card.
- Pure JVM test: parser + the never-invent-a-number dial fallback.

### Acceptance criteria
- [x] LIHEAP card: dial sheet opens with the number; returning to the app offers the capture sheet (LIHEAP has no *verified* direct line yet → dial sheet opens with **211**, the honest number we have; capture sheet fires on `ON_RESUME`)
- [x] Cards render EN/ES and read aloud
- [x] Every card shows its verified-date (211 = verified; seed cards show "not yet verified — connects via 211")

### Notes for the wave
- Adds the **kotlinx-serialization plugin** to `feature/build.gradle.kts` (branch off fresh `main`; dedupes with #1517/#1516's identical add at merge).
- Appends to `res/values/strings.xml` + `res/values-es/strings.xml` (both already exist on main from #1513 — this is a clean append, `#1518` block).
- Ships a small verified-date seed sample; **production corpus + verified numbers are TechEmpower-supplied**.

Closes #1518
