### PR TITLE
feat(docs): saved household profile — autofill scanned forms (#1519)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/data/EncryptedHouseholdProfileStore.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/EncryptedHouseholdProfileStore.kt
@@ -1,0 +1,86 @@
+package `in`.jphe.storyvox.data
+
+import android.content.SharedPreferences
+import `in`.jphe.storyvox.feature.docs.profile.HouseholdProfile
+import `in`.jphe.storyvox.feature.docs.profile.HouseholdProfileStore
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+/**
+ * Issue #1519 — production [HouseholdProfileStore]. Persists the profile
+ * as a JSON blob under a single key in the app's existing
+ * `EncryptedSharedPreferences` bag (`storyvox.secrets`), the same
+ * encrypted store the source tokens use. That store is already **excluded
+ * from cloud backup and device transfer** (`backup_rules.xml` /
+ * `data_extraction_rules.xml`, #951), so the profile is encrypted at rest
+ * and never leaves the device — no new backup rules or storage needed.
+ *
+ * TODO(#1514): migrate to the "My Documents" wallet's shared encrypted
+ * storage seam once that lane lands (it's the benefits suite's canonical
+ * encrypted store); until then this lane owns its key, per the wave brief.
+ */
+@Singleton
+class EncryptedHouseholdProfileStore @Inject constructor(
+    private val secrets: SharedPreferences,
+) : HouseholdProfileStore {
+
+    private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+    private val _profile = MutableStateFlow(load())
+
+    override fun profile(): Flow<HouseholdProfile> = _profile.asStateFlow()
+
+    override suspend fun save(profile: HouseholdProfile) = withContext(Dispatchers.IO) {
+        secrets.edit().putString(KEY, json.encodeToString(profile.toDto())).apply()
+        _profile.value = profile
+    }
+
+    override suspend fun clear() = withContext(Dispatchers.IO) {
+        secrets.edit().remove(KEY).apply()
+        _profile.value = HouseholdProfile()
+    }
+
+    private fun load(): HouseholdProfile = runCatching {
+        secrets.getString(KEY, null)?.let { json.decodeFromString<Dto>(it).toModel() }
+    }.getOrNull() ?: HouseholdProfile()
+
+    @Serializable
+    private data class Dto(
+        val fullName: String = "",
+        val address: String = "",
+        val householdSize: String = "",
+        val monthlyIncome: String = "",
+        val phone: String = "",
+        val email: String = "",
+    )
+
+    private fun Dto.toModel() = HouseholdProfile(
+        fullName = fullName,
+        address = address,
+        householdSize = householdSize,
+        monthlyIncome = monthlyIncome,
+        phone = phone,
+        email = email,
+    )
+
+    private fun HouseholdProfile.toDto() = Dto(
+        fullName = fullName,
+        address = address,
+        householdSize = householdSize,
+        monthlyIncome = monthlyIncome,
+        phone = phone,
+        email = email,
+    )
+
+    private companion object {
+        const val KEY = "household.profile"
+    }
+}

--- a/app/src/main/kotlin/in/jphe/storyvox/di/ProfileBindingsModule.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/ProfileBindingsModule.kt
@@ -1,0 +1,26 @@
+package `in`.jphe.storyvox.di
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import `in`.jphe.storyvox.data.EncryptedHouseholdProfileStore
+import `in`.jphe.storyvox.feature.docs.profile.HouseholdProfileStore
+import javax.inject.Singleton
+
+/**
+ * Issue #1519 — binds the household-profile store seam (:feature) to its
+ * encrypted :app impl. Lives in :app because the impl needs the
+ * `EncryptedSharedPreferences` handle provided by `:core-data`'s
+ * DataModule.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class ProfileBindingsModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindHouseholdProfileStore(
+        impl: EncryptedHouseholdProfileStore,
+    ): HouseholdProfileStore
+}

--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -110,6 +110,9 @@ object StoryvoxRoutes {
      *  on-device wallet for benefits proofs (epic #1520). Reached from the
      *  Library add-flow ("My Documents"). */
     const val WALLET = "docs/wallet"
+
+    /** Issue #1519 — saved household profile (autofill scanned forms). */
+    const val HOUSEHOLD_PROFILE = "docs/profile"
     const val FICTION_DETAIL = "fiction/{fictionId}"
     const val READER = "reader/{fictionId}/{chapterId}"
     const val AUDIOBOOK = "audiobook/{fictionId}/{chapterId}"
@@ -1717,6 +1720,8 @@ private fun StoryvoxNavHostContent(
                     },
                     onOpenCalls = {
                         navController.navigate(StoryvoxRoutes.TECHEMPOWER_CALLS)
+                    onOpenHouseholdProfile = {
+                        navController.navigate(StoryvoxRoutes.HOUSEHOLD_PROFILE)
                     },
                     onOpenFiction = { fictionId ->
                         navController.navigate(StoryvoxRoutes.fictionDetail(fictionId))
@@ -1726,6 +1731,9 @@ private fun StoryvoxNavHostContent(
             // Issue #1517 — offline benefits screener drill-down.
             composable(
                 StoryvoxRoutes.TECHEMPOWER_SCREENER,
+            // Issue #1519 — saved household profile (drill-down depth).
+            composable(
+                StoryvoxRoutes.HOUSEHOLD_PROFILE,
                 enterTransition = pushEnter,
                 exitTransition = pushExit,
                 popEnterTransition = popEnter,
@@ -1759,6 +1767,8 @@ private fun StoryvoxNavHostContent(
             ) {
                 CallCardsScreen(
                     onBack = { navController.popBackStack() },
+                `in`.jphe.storyvox.feature.docs.profile.HouseholdProfileScreen(
+                    onNavigateBack = { navController.popBackStack() },
                 )
             }
             composable(

--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -1720,6 +1720,7 @@ private fun StoryvoxNavHostContent(
                     },
                     onOpenCalls = {
                         navController.navigate(StoryvoxRoutes.TECHEMPOWER_CALLS)
+                    },
                     onOpenHouseholdProfile = {
                         navController.navigate(StoryvoxRoutes.HOUSEHOLD_PROFILE)
                     },
@@ -1731,6 +1732,15 @@ private fun StoryvoxNavHostContent(
             // Issue #1517 — offline benefits screener drill-down.
             composable(
                 StoryvoxRoutes.TECHEMPOWER_SCREENER,
+                enterTransition = pushEnter,
+                exitTransition = pushExit,
+                popEnterTransition = popEnter,
+                popExitTransition = popExit,
+            ) {
+                ScreenerScreen(
+                    onBack = { navController.popBackStack() },
+                )
+            }
             // Issue #1519 — saved household profile (drill-down depth).
             composable(
                 StoryvoxRoutes.HOUSEHOLD_PROFILE,
@@ -1739,8 +1749,8 @@ private fun StoryvoxNavHostContent(
                 popEnterTransition = popEnter,
                 popExitTransition = popExit,
             ) {
-                ScreenerScreen(
-                    onBack = { navController.popBackStack() },
+                `in`.jphe.storyvox.feature.docs.profile.HouseholdProfileScreen(
+                    onNavigateBack = { navController.popBackStack() },
                 )
             }
             // Issue #1516 — benefits letter decoder drill-down. "Scan a letter"
@@ -1767,8 +1777,6 @@ private fun StoryvoxNavHostContent(
             ) {
                 CallCardsScreen(
                     onBack = { navController.popBackStack() },
-                `in`.jphe.storyvox.feature.docs.profile.HouseholdProfileScreen(
-                    onNavigateBack = { navController.popBackStack() },
                 )
             }
             composable(

--- a/core-sync/src/test/kotlin/in/jphe/storyvox/sync/SecretsSyncerExtensionTest.kt
+++ b/core-sync/src/test/kotlin/in/jphe/storyvox/sync/SecretsSyncerExtensionTest.kt
@@ -337,4 +337,25 @@ class SecretsSyncerExtensionTest {
             "pref_theme_override" in SecretsSyncer.SECRET_KEY_NAMES,
         )
     }
+
+    @Test fun `household profile key is excluded from the secrets sync allowlist`() {
+        // #1519 / #1572 — the Play Data-Safety "Financial info: Not
+        // collected" declaration depends on the saved household profile
+        // (name / address / household size / income / phone / email) NEVER
+        // syncing to the cloud. EncryptedHouseholdProfileStore (:app)
+        // persists it under this key in the SAME `storyvox.secrets`
+        // EncryptedSharedPreferences bag the synced secrets live in — so
+        // SecretsSyncer's allowlist MUST exclude it. This fence fails if a
+        // future allowlist edit (a new name or a broad prefix) silently
+        // starts syncing benefits PII. Mirrors the private `isSecretKey`.
+        val householdProfileKey = "household.profile" // == EncryptedHouseholdProfileStore.KEY
+        assertFalse(
+            "household.profile must NOT be an exact-name synced secret",
+            householdProfileKey in SecretsSyncer.SECRET_KEY_NAMES,
+        )
+        assertFalse(
+            "no SECRET_KEY_PREFIXES entry may match household.profile (would sync income/PII)",
+            SecretsSyncer.SECRET_KEY_PREFIXES.any { householdProfileKey.startsWith(it) },
+        )
+    }
 }

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -203,6 +203,24 @@ Calendar source simply stays empty until you choose to grant it. You can
 revoke the permission anytime in Android Settings. The Calendar source is
 read-only: Candela never creates, edits, or deletes calendar events.
 
+### 2.11 Saved household profile (optional)
+
+Candela can save the facts you re-type on every benefits form — name,
+address, household size, monthly income, phone, email — so it can offer to
+fill them in when you scan a form. This profile is **entirely on-device**:
+it is stored **encrypted at rest** (Android's `EncryptedSharedPreferences`),
+**excluded from cloud backup and device-to-device transfer**, and is
+**never uploaded, collected, transmitted, or shared**. It's optional — the
+app works without it — and you can view, edit, or permanently delete it at
+any time; editing and deleting are protected behind your device lock
+(fingerprint / face / PIN).
+
+**Your Social Security Number is never saved.** It is deliberately not a
+profile field: when a form asks for it you type it directly, and Candela
+neither stores it nor offers to fill it — the app actively warns you on any
+SSN/tax-id field. No network is involved in matching a form field to your
+saved value; it's all local text comparison.
+
 ### 2.13 My Documents wallet (optional, encrypted, device-locked)
 
 Candela can store scans of your benefits paperwork — photo ID, proof of

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/docs/profile/HouseholdProfile.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/docs/profile/HouseholdProfile.kt
@@ -1,0 +1,59 @@
+package `in`.jphe.storyvox.feature.docs.profile
+
+import androidx.compose.runtime.Immutable
+
+/**
+ * Issue #1519 — the saved household profile.
+ *
+ * An optional, on-device set of the facts people re-type into every
+ * benefits form. Stored encrypted-at-rest (see the store impl) and never
+ * synced or backed up. **SSN is deliberately NOT a field** — by policy it
+ * stays type-to-fill only, never persisted (see [ProfileAutofillMatcher.isSensitive]).
+ *
+ * All fields are plain strings so they drop straight into a scanned
+ * form's text field with no parsing (household size and income are typed
+ * as the user would write them on the form).
+ */
+@Immutable
+data class HouseholdProfile(
+    val fullName: String = "",
+    val address: String = "",
+    val householdSize: String = "",
+    val monthlyIncome: String = "",
+    val phone: String = "",
+    val email: String = "",
+) {
+    val isEmpty: Boolean
+        get() = fullName.isBlank() && address.isBlank() && householdSize.isBlank() &&
+            monthlyIncome.isBlank() && phone.isBlank() && email.isBlank()
+
+    /** The stored value for [field] ("" when unset). */
+    fun valueFor(field: ProfileField): String = when (field) {
+        ProfileField.FULL_NAME -> fullName
+        ProfileField.ADDRESS -> address
+        ProfileField.HOUSEHOLD_SIZE -> householdSize
+        ProfileField.MONTHLY_INCOME -> monthlyIncome
+        ProfileField.PHONE -> phone
+        ProfileField.EMAIL -> email
+    }
+
+    /** Copy with [field] set to [value]. */
+    fun with(field: ProfileField, value: String): HouseholdProfile = when (field) {
+        ProfileField.FULL_NAME -> copy(fullName = value)
+        ProfileField.ADDRESS -> copy(address = value)
+        ProfileField.HOUSEHOLD_SIZE -> copy(householdSize = value)
+        ProfileField.MONTHLY_INCOME -> copy(monthlyIncome = value)
+        ProfileField.PHONE -> copy(phone = value)
+        ProfileField.EMAIL -> copy(email = value)
+    }
+}
+
+/** The fillable profile fields. SSN is intentionally absent (never persisted). */
+enum class ProfileField {
+    FULL_NAME,
+    ADDRESS,
+    HOUSEHOLD_SIZE,
+    MONTHLY_INCOME,
+    PHONE,
+    EMAIL,
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/docs/profile/HouseholdProfileScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/docs/profile/HouseholdProfileScreen.kt
@@ -1,0 +1,341 @@
+package `in`.jphe.storyvox.feature.docs.profile
+
+import android.app.Activity
+import android.app.KeyguardManager
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import `in`.jphe.storyvox.feature.R
+import `in`.jphe.storyvox.ui.component.BrassButton
+import `in`.jphe.storyvox.ui.component.BrassButtonVariant
+import `in`.jphe.storyvox.ui.theme.LocalSpacing
+
+/**
+ * Issue #1519 — saved household profile screen.
+ *
+ * An optional, on-device profile (name / address / household size / income
+ * / phone / email) that autofills scanned benefits forms. Edit + delete
+ * are gated behind the device's own lock (biometric or PIN/pattern) via
+ * [KeyguardManager]; the data is encrypted at rest and excluded from
+ * backup/sync. **SSN is never a field here** — it's type-to-fill only.
+ *
+ * Why device-credential rather than androidx BiometricPrompt: the host
+ * `MainActivity` is a `ComponentActivity` (BiometricPrompt needs a
+ * `FragmentActivity`), and the wallet lane (#1514) owns the shared
+ * BiometricPrompt seam. `createConfirmDeviceCredentialIntent` gives the
+ * same "prove it's you (fingerprint / face / PIN)" gate with no new
+ * dependency. TODO(#1514): swap to the wallet's BiometricPrompt gate when
+ * it lands.
+ *
+ * Accessibility (invariant #4): labelled fields, live-region save
+ * confirmation, plain top-to-bottom form (no spatial UI).
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun HouseholdProfileScreen(
+    onNavigateBack: () -> Unit,
+    viewModel: HouseholdProfileViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+    val spacing = LocalSpacing.current
+
+    val keyguard = remember { context.getSystemService(KeyguardManager::class.java) }
+    var unlocked by rememberSaveable { mutableStateOf(false) }
+    var showDeleteConfirm by remember { mutableStateOf(false) }
+    var pendingAction by remember { mutableStateOf<(() -> Unit)?>(null) }
+
+    val authLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.StartActivityForResult(),
+    ) { result ->
+        if (result.resultCode == Activity.RESULT_OK) pendingAction?.invoke()
+        pendingAction = null
+    }
+
+    val authTitle = stringResource(R.string.profile_auth_title)
+    val authDesc = stringResource(R.string.profile_auth_desc)
+
+    // Run [action] only after the user proves it's them. If the device has
+    // no lock set we can't prompt — proceed (the data is still app-private
+    // + encrypted at rest).
+    fun gate(action: () -> Unit) {
+        val km = keyguard
+        if (km != null && km.isDeviceSecure) {
+            pendingAction = action
+            @Suppress("DEPRECATION")
+            val intent = km.createConfirmDeviceCredentialIntent(authTitle, authDesc)
+            if (intent != null) authLauncher.launch(intent) else { pendingAction = null; action() }
+        } else {
+            action()
+        }
+    }
+
+    val savedMsg = stringResource(R.string.profile_saved_announce)
+    LaunchedEffect(state.justSaved) {
+        if (state.justSaved) {
+            Toast.makeText(context, savedMsg, Toast.LENGTH_SHORT).show()
+            viewModel.consumeJustSaved()
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.profile_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.profile_back_cd),
+                        )
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .padding(horizontal = spacing.md)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(spacing.md),
+        ) {
+            Text(
+                stringResource(R.string.profile_intro),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            val locked = state.hasSavedProfile && !unlocked
+            if (locked) {
+                LockedCard(
+                    onUnlock = { gate { unlocked = true } },
+                    onDelete = { gate { showDeleteConfirm = true } },
+                )
+            } else {
+                ProfileForm(
+                    draft = state.draft,
+                    onFieldChange = viewModel::onFieldChange,
+                )
+
+                SsnPolicyNote()
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+                ) {
+                    if (state.hasUnsavedChanges) {
+                        BrassButton(
+                            label = stringResource(R.string.profile_revert),
+                            onClick = viewModel::revert,
+                            variant = BrassButtonVariant.Secondary,
+                            modifier = Modifier.weight(1f),
+                        )
+                    }
+                    BrassButton(
+                        label = stringResource(R.string.profile_save),
+                        onClick = viewModel::save,
+                        variant = BrassButtonVariant.Primary,
+                        enabled = state.hasUnsavedChanges,
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+
+                if (state.hasSavedProfile) {
+                    BrassButton(
+                        label = stringResource(R.string.profile_delete),
+                        onClick = { gate { showDeleteConfirm = true } },
+                        variant = BrassButtonVariant.Secondary,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                    AutofillPreview(profile = state.saved)
+                }
+            }
+        }
+    }
+
+    if (showDeleteConfirm) {
+        AlertDialog(
+            onDismissRequest = { showDeleteConfirm = false },
+            title = { Text(stringResource(R.string.profile_delete_confirm_title)) },
+            text = { Text(stringResource(R.string.profile_delete_confirm_body)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.deleteProfile()
+                    unlocked = false
+                    showDeleteConfirm = false
+                }) { Text(stringResource(R.string.profile_delete)) }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDeleteConfirm = false }) {
+                    Text(stringResource(R.string.profile_cancel))
+                }
+            },
+        )
+    }
+}
+
+@Composable
+private fun LockedCard(onUnlock: () -> Unit, onDelete: () -> Unit) {
+    val spacing = LocalSpacing.current
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        shape = RoundedCornerShape(12.dp),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Column(
+            modifier = Modifier.padding(spacing.md),
+            verticalArrangement = Arrangement.spacedBy(spacing.sm),
+        ) {
+            Row(verticalAlignment = androidx.compose.ui.Alignment.CenterVertically) {
+                Icon(
+                    Icons.Filled.Lock,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+                Text(
+                    stringResource(R.string.profile_locked),
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.padding(start = spacing.sm),
+                )
+            }
+            BrassButton(
+                label = stringResource(R.string.profile_unlock),
+                onClick = onUnlock,
+                variant = BrassButtonVariant.Primary,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            BrassButton(
+                label = stringResource(R.string.profile_delete),
+                onClick = onDelete,
+                variant = BrassButtonVariant.Secondary,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+    }
+}
+
+@Composable
+private fun ProfileForm(
+    draft: HouseholdProfile,
+    onFieldChange: (ProfileField, String) -> Unit,
+) {
+    FIELD_SPECS.forEach { spec ->
+        OutlinedTextField(
+            value = draft.valueFor(spec.field),
+            onValueChange = { onFieldChange(spec.field, it) },
+            label = { Text(stringResource(spec.labelRes)) },
+            singleLine = spec.field != ProfileField.ADDRESS,
+            keyboardOptions = KeyboardOptions(keyboardType = spec.keyboard),
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}
+
+@Composable
+private fun SsnPolicyNote() {
+    val spacing = LocalSpacing.current
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        shape = RoundedCornerShape(12.dp),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Text(
+            stringResource(R.string.profile_ssn_policy),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(spacing.md),
+        )
+    }
+}
+
+/**
+ * Live demonstration of how the saved profile autofills a scanned form —
+ * the same [ProfileAutofillChip] the fillable-PDF screen (#1512) will use,
+ * plus an SSN example proving it warns instead of suggesting.
+ */
+@Composable
+private fun AutofillPreview(profile: HouseholdProfile) {
+    val spacing = LocalSpacing.current
+    val context = LocalContext.current
+    Text(
+        stringResource(R.string.profile_autofill_preview_title),
+        style = MaterialTheme.typography.titleSmall,
+        color = MaterialTheme.colorScheme.primary,
+    )
+    Text(
+        stringResource(R.string.profile_autofill_preview_hint),
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+    Column(verticalArrangement = Arrangement.spacedBy(spacing.xs)) {
+        FIELD_SPECS.forEach { spec ->
+            if (profile.valueFor(spec.field).isNotBlank()) {
+                val sampleLabel = stringResource(spec.labelRes)
+                ProfileAutofillChip(
+                    detectedLabel = sampleLabel,
+                    profile = profile,
+                    onFill = { value ->
+                        Toast.makeText(
+                            context,
+                            context.getString(R.string.profile_preview_filled, value),
+                            Toast.LENGTH_SHORT,
+                        ).show()
+                    },
+                )
+            }
+        }
+        // Always show the SSN guard so it's visible in the demo.
+        SensitiveFieldNote()
+    }
+}
+
+private data class FieldSpec(val field: ProfileField, val labelRes: Int, val keyboard: KeyboardType)
+
+private val FIELD_SPECS = listOf(
+    FieldSpec(ProfileField.FULL_NAME, R.string.profile_field_name, KeyboardType.Text),
+    FieldSpec(ProfileField.ADDRESS, R.string.profile_field_address, KeyboardType.Text),
+    FieldSpec(ProfileField.HOUSEHOLD_SIZE, R.string.profile_field_household_size, KeyboardType.Number),
+    FieldSpec(ProfileField.MONTHLY_INCOME, R.string.profile_field_income, KeyboardType.Number),
+    FieldSpec(ProfileField.PHONE, R.string.profile_field_phone, KeyboardType.Phone),
+    FieldSpec(ProfileField.EMAIL, R.string.profile_field_email, KeyboardType.Email),
+)

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/docs/profile/HouseholdProfileStore.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/docs/profile/HouseholdProfileStore.kt
@@ -1,0 +1,29 @@
+package `in`.jphe.storyvox.feature.docs.profile
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Issue #1519 — on-device, encrypted-at-rest persistence for the saved
+ * household profile.
+ *
+ * The production impl (in :app) stores the profile in the app's existing
+ * `EncryptedSharedPreferences` bag (`storyvox.secrets`) — already
+ * excluded from cloud backup + device transfer (#951) — so the profile is
+ * encrypted at rest and never leaves the device.
+ *
+ * TODO(#1514): once the "My Documents" encrypted wallet lands, migrate
+ * this to the wallet's shared storage seam instead of a private key in the
+ * secrets bag (the wallet is the benefits suite's canonical encrypted
+ * store). Until then this lane owns its storage, per the wave brief.
+ */
+interface HouseholdProfileStore {
+
+    /** Live profile; emits [HouseholdProfile] (empty when nothing saved). */
+    fun profile(): Flow<HouseholdProfile>
+
+    /** Persist [profile] (replaces any previous). */
+    suspend fun save(profile: HouseholdProfile)
+
+    /** Erase the saved profile — also the hook a global "delete all my data" calls. */
+    suspend fun clear()
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/docs/profile/HouseholdProfileViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/docs/profile/HouseholdProfileViewModel.kt
@@ -1,0 +1,78 @@
+package `in`.jphe.storyvox.feature.docs.profile
+
+import androidx.compose.runtime.Immutable
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * Issue #1519 — drives the saved household profile screen.
+ *
+ * Loads the encrypted-at-rest profile, edits an in-memory [ReminderDraft]-
+ * style draft, and persists / clears it via [HouseholdProfileStore]. The
+ * biometric / device-credential gate for edit + delete lives in the screen
+ * (it needs an Activity result launcher); this VM is plain-JVM and
+ * unit-testable with a fake store.
+ */
+@HiltViewModel
+class HouseholdProfileViewModel @Inject constructor(
+    private val store: HouseholdProfileStore,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(HouseholdProfileUiState())
+    val state: StateFlow<HouseholdProfileUiState> = _state.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            store.profile().collect { saved ->
+                _state.update { s ->
+                    // Keep the user's in-progress edits; only re-sync the
+                    // draft from the store when it wasn't diverged.
+                    if (s.draft == s.saved) s.copy(saved = saved, draft = saved)
+                    else s.copy(saved = saved)
+                }
+            }
+        }
+    }
+
+    fun onFieldChange(field: ProfileField, value: String) =
+        _state.update { it.copy(draft = it.draft.with(field, value)) }
+
+    fun save() {
+        val draft = _state.value.draft
+        viewModelScope.launch {
+            store.save(draft)
+            _state.update { it.copy(saved = draft, justSaved = true) }
+        }
+    }
+
+    /** Revert unsaved edits back to what's stored. */
+    fun revert() = _state.update { it.copy(draft = it.saved) }
+
+    fun deleteProfile() {
+        viewModelScope.launch {
+            store.clear()
+            _state.update { it.copy(draft = HouseholdProfile(), saved = HouseholdProfile()) }
+        }
+    }
+
+    fun consumeJustSaved() = _state.update { it.copy(justSaved = false) }
+}
+
+@Immutable
+data class HouseholdProfileUiState(
+    val draft: HouseholdProfile = HouseholdProfile(),
+    val saved: HouseholdProfile = HouseholdProfile(),
+    /** One-shot: a save just completed (drives an a11y / toast confirmation). */
+    val justSaved: Boolean = false,
+) {
+    val hasSavedProfile: Boolean get() = !saved.isEmpty
+    val hasUnsavedChanges: Boolean get() = draft != saved
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/docs/profile/ProfileAutofillChips.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/docs/profile/ProfileAutofillChips.kt
@@ -1,0 +1,65 @@
+package `in`.jphe.storyvox.feature.docs.profile
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import `in`.jphe.storyvox.feature.R
+
+/**
+ * Issue #1519 — the reusable autofill affordance for one detected form
+ * field. This is the drop-in the photo→fillable-PDF screen (#1512, not yet
+ * merged) places next to each detected field: pass the field's OCR'd
+ * label, the saved [HouseholdProfile], and an `onFill` callback.
+ *
+ * Behaviour:
+ *  - Sensitive (SSN / tax-id) label → a **warning**, never a suggestion
+ *    (issue policy: SSN is type-to-fill only, never persisted).
+ *  - A known field with a saved value → a one-tap "use saved …" chip.
+ *  - Otherwise → nothing (no chip, no clutter).
+ *
+ * Pure UI over [ProfileAutofillMatcher]; no VM needed, so #1512 can use it
+ * with just the profile it already holds. TODO(#1512): wire into the
+ * detected-field rows once the fillable-form screen lands.
+ */
+@Composable
+fun ProfileAutofillChip(
+    detectedLabel: String,
+    profile: HouseholdProfile,
+    onFill: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (ProfileAutofillMatcher.isSensitive(detectedLabel)) {
+        SensitiveFieldNote(modifier)
+        return
+    }
+    val field = ProfileAutofillMatcher.match(detectedLabel) ?: return
+    val value = profile.valueFor(field)
+    if (value.isBlank()) return
+
+    val cd = stringResource(R.string.profile_use_saved_cd, value)
+    AssistChip(
+        onClick = { onFill(value) },
+        label = { Text(stringResource(R.string.profile_use_saved, value)) },
+        modifier = modifier.semantics { contentDescription = cd },
+    )
+}
+
+/** Warning shown in place of a suggestion for an SSN / tax-id field. */
+@Composable
+fun SensitiveFieldNote(modifier: Modifier = Modifier) {
+    Row(modifier = modifier.padding(vertical = 4.dp)) {
+        Text(
+            stringResource(R.string.profile_ssn_warning),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.error,
+        )
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/docs/profile/ProfileAutofillMatcher.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/docs/profile/ProfileAutofillMatcher.kt
@@ -1,0 +1,123 @@
+package `in`.jphe.storyvox.feature.docs.profile
+
+/**
+ * Issue #1519 — maps a scanned form's detected field label to a saved
+ * [ProfileField] (or flags it sensitive), bilingually.
+ *
+ * Pure JVM (no Android, no network) so it's fully unit-testable and safe
+ * to run entirely on-device — which is the whole point: form contents
+ * never leave the phone.
+ *
+ * ## Program-awareness
+ *
+ * The dictionary is program-agnostic today (the common EN/ES vocabulary
+ * covers CalFresh, Medi-Cal, LifeLine, LIHEAP forms alike). [match]
+ * accepts an optional `programId` hook so program-specific synonyms can
+ * be layered in later without changing call sites; the seed corpus keys
+ * off the same plain program-id strings the rest of the benefits suite
+ * uses. TODO(#1517): fold in program-specific label synonyms from the
+ * screener corpus when it lands.
+ */
+object ProfileAutofillMatcher {
+
+    /**
+     * Sensitive labels we must NEVER offer a suggestion for and must warn
+     * about — SSN/ITIN/Tax-ID stay type-to-fill only, never persisted
+     * (issue #1519 policy). Accent-free, lowercased.
+     */
+    private val SENSITIVE = listOf(
+        "social security number", "social security", "ssn", "ss number",
+        "itin", "tax id", "taxpayer id", "ein",
+        // Spanish
+        "numero de seguro social", "seguro social", "seguridad social",
+        "numero de identificacion personal del contribuyente",
+    )
+
+    /**
+     * EN + ES synonym lists per field, accent-free + lowercased. Short,
+     * unambiguous forms ("income", "phone") act as the catch-all; longer
+     * forms disambiguate. Ordered most-specific first within each field.
+     */
+    private val SYNONYMS: Map<ProfileField, List<String>> = mapOf(
+        ProfileField.FULL_NAME to listOf(
+            "full name", "first and last name", "applicant name", "your name", "name",
+            "nombre completo", "nombre y apellido", "nombre del solicitante", "nombre",
+        ),
+        ProfileField.ADDRESS to listOf(
+            "mailing address", "home address", "street address", "residential address",
+            "residence", "address",
+            "direccion postal", "domicilio postal", "domicilio", "direccion",
+        ),
+        ProfileField.HOUSEHOLD_SIZE to listOf(
+            "household size", "number in household", "people in household",
+            "household members", "family size", "size of household",
+            "tamano del hogar", "numero de personas en el hogar", "personas en el hogar",
+            "integrantes del hogar", "miembros del hogar", "tamano de la familia",
+        ),
+        ProfileField.MONTHLY_INCOME to listOf(
+            "gross monthly income", "monthly income", "household income",
+            "monthly earnings", "monthly wages", "income",
+            "ingreso mensual bruto", "ingreso mensual", "ingresos del hogar",
+            "ingresos mensuales", "ingresos", "ingreso",
+        ),
+        ProfileField.PHONE to listOf(
+            "phone number", "telephone number", "contact number", "mobile number",
+            "cell phone", "telephone", "phone",
+            "numero de telefono", "telefono de contacto", "telefono celular",
+            "celular", "telefono",
+        ),
+        ProfileField.EMAIL to listOf(
+            "email address", "e mail address", "email", "e mail",
+            "correo electronico", "correo",
+        ),
+    )
+
+    // Pre-normalized for cheap matching.
+    private val NORMALIZED_SENSITIVE = SENSITIVE.map(::normalize)
+    private val NORMALIZED_SYNONYMS: List<Pair<ProfileField, String>> =
+        SYNONYMS.entries.flatMap { (field, syns) -> syns.map { field to normalize(it) } }
+
+    /**
+     * True when [fieldLabel] looks like an SSN / tax-id field. Such fields
+     * must never be autofilled and the UI warns that the value is not
+     * saved.
+     */
+    fun isSensitive(fieldLabel: String): Boolean {
+        val n = normalize(fieldLabel)
+        if (n.isEmpty()) return false
+        return NORMALIZED_SENSITIVE.any { n.contains(it) }
+    }
+
+    /**
+     * The [ProfileField] a detected [fieldLabel] maps to, or null when it
+     * doesn't match anything we hold (or is [isSensitive], which always
+     * returns null — never a suggestion). `programId` is a forward hook
+     * for program-specific synonyms (unused in the seed dictionary).
+     */
+    fun match(fieldLabel: String, programId: String? = null): ProfileField? {
+        val n = normalize(fieldLabel)
+        if (n.isEmpty()) return null
+        if (isSensitive(fieldLabel)) return null
+        // Longest synonym that the label contains wins, so "monthly income"
+        // beats the bare "income" catch-all when both are present.
+        return NORMALIZED_SYNONYMS
+            .filter { (_, syn) -> n.contains(syn) }
+            .maxByOrNull { (_, syn) -> syn.length }
+            ?.first
+    }
+
+    /** lowercase, strip accents, drop punctuation, collapse whitespace. */
+    private fun normalize(s: String): String {
+        val lowered = stripAccents(s.lowercase())
+        val cleaned = buildString(lowered.length) {
+            for (ch in lowered) append(if (ch.isLetterOrDigit()) ch else ' ')
+        }
+        return cleaned.trim().replace(Regex("\\s+"), " ")
+    }
+
+    private fun stripAccents(s: String): String = buildString(s.length) {
+        for (ch in s) {
+            append(java.text.Normalizer.normalize(ch.toString(), java.text.Normalizer.Form.NFD)[0])
+        }
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/TechEmpowerHomeScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/TechEmpowerHomeScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Badge
 import androidx.compose.material.icons.filled.FactCheck
 import androidx.compose.material.icons.filled.Forum
 import androidx.compose.material.icons.filled.Info
@@ -103,6 +104,9 @@ fun TechEmpowerHomeScreen(
     onOpenDecoder: () -> Unit,
     onOpenCalls: () -> Unit,
     onOpenFiction: (String) -> Unit,
+    // Issue #1519 — saved household profile entry point. Defaulted so
+    // other call sites / previews keep compiling.
+    onOpenHouseholdProfile: () -> Unit = {},
 ) {
     val spacing = LocalSpacing.current
     val context = LocalContext.current
@@ -226,6 +230,16 @@ fun TechEmpowerHomeScreen(
             // card above; the crisis affordances can be reinstated as
             // a new card here once the UX review with intervention
             // experts lands.
+            // Issue #1519 — saved household profile. Bilingual (EN/ES) via
+            // stringResource, per the benefits-suite launch invariant.
+            item {
+                TechEmpowerCard(
+                    title = stringResource(FeatureR.string.profile_card_title),
+                    body = stringResource(FeatureR.string.profile_card_body),
+                    icon = Icons.Filled.Badge,
+                    onClick = onOpenHouseholdProfile,
+                )
+            }
             item {
                 TechEmpowerCard(
                     title = "About TechEmpower",

--- a/feature/src/main/res/values-es/strings.xml
+++ b/feature/src/main/res/values-es/strings.xml
@@ -1,14 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    Spanish (es) translations for Candela's :feature module.
-
-    Bootstrapped in #1513 (benefits paperwork companion, epic #1520) — the
-    first Spanish locale in the app. It intentionally contains ONLY the
-    keys that have been translated so far; Android falls back to the
-    default (values/) strings for every untranslated key, so a partial
-    file is correct and does not break the build. Add new keys here in the
-    SAME PR that adds them to values/strings.xml (bilingual-at-launch is a
-    hard invariant for every benefits surface).
+  Spanish (es) translations. Introduced by the benefits-suite wave (epic
+  #1520) — Candela's first localized locale. Each lane appends its own keys
+  under a clearly-commented "#<issue>" block; keep additions grouped so
+  cross-lane rebases stay mechanical.
 -->
 <resources>
 
@@ -167,4 +162,34 @@
     <string name="wallet_what_proves_seed_note">Lista de muestra: la lista verificada de programas la proporciona TechEmpower.</string>
     <string name="wallet_what_proves_title">¿Qué comprueba esto?</string>
     <!-- /#1514 -->
+    <!-- #1519 — saved household profile -->
+    <string name="profile_title">Perfil del hogar</string>
+    <string name="profile_back_cd">Atrás</string>
+    <string name="profile_intro">Guarde una sola vez los datos que escribe en cada formulario. Candela los mantiene cifrados en su dispositivo y ofrece rellenar los campos que coincidan cuando escanea un formulario.</string>
+    <string name="profile_card_title">Perfil del hogar</string>
+    <string name="profile_card_body">Guarde sus datos una vez — Candela rellena los campos que coincidan.</string>
+    <string name="profile_field_name">Nombre completo</string>
+    <string name="profile_field_address">Domicilio</string>
+    <string name="profile_field_household_size">Tamaño del hogar</string>
+    <string name="profile_field_income">Ingreso mensual</string>
+    <string name="profile_field_phone">Número de teléfono</string>
+    <string name="profile_field_email">Correo electrónico</string>
+    <string name="profile_save">Guardar</string>
+    <string name="profile_revert">Deshacer cambios</string>
+    <string name="profile_cancel">Cancelar</string>
+    <string name="profile_delete">Eliminar perfil</string>
+    <string name="profile_delete_confirm_title">¿Eliminar su perfil?</string>
+    <string name="profile_delete_confirm_body">Esto borra sus datos guardados de este dispositivo. No se puede deshacer.</string>
+    <string name="profile_locked">Su perfil está guardado y bloqueado.</string>
+    <string name="profile_unlock">Desbloquear para editar</string>
+    <string name="profile_auth_title">Desbloquee su perfil</string>
+    <string name="profile_auth_desc">Confirme que es usted para ver o cambiar sus datos guardados.</string>
+    <string name="profile_saved_announce">Perfil guardado</string>
+    <string name="profile_ssn_policy">Nunca guarde aquí su Número de Seguro Social. Cuando un formulario lo pida, escríbalo directamente — Candela no lo almacena ni ofrece rellenarlo.</string>
+    <string name="profile_ssn_warning">Número de Seguro Social — escríbalo usted mismo; nunca se guarda.</string>
+    <string name="profile_use_saved">Usar guardado: %1$s</string>
+    <string name="profile_use_saved_cd">Rellenar este campo con su valor guardado: %1$s</string>
+    <string name="profile_autofill_preview_title">Vista previa de autocompletar</string>
+    <string name="profile_autofill_preview_hint">En un formulario escaneado, los campos que coincidan muestran una etiqueta como estas — toque para rellenar.</string>
+    <string name="profile_preview_filled">Rellenado: %1$s</string>
 </resources>

--- a/feature/src/main/res/values-es/strings.xml
+++ b/feature/src/main/res/values-es/strings.xml
@@ -1,9 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  Spanish (es) translations. Introduced by the benefits-suite wave (epic
-  #1520) — Candela's first localized locale. Each lane appends its own keys
-  under a clearly-commented "#<issue>" block; keep additions grouped so
-  cross-lane rebases stay mechanical.
+    Spanish (es) translations for Candela's :feature module.
+
+    Bootstrapped in #1513 (benefits paperwork companion, epic #1520) — the
+    first Spanish locale in the app. It intentionally contains ONLY the
+    keys that have been translated so far; Android falls back to the
+    default (values/) strings for every untranslated key, so a partial
+    file is correct and does not break the build. Add new keys here in the
+    SAME PR that adds them to values/strings.xml (bilingual-at-launch is a
+    hard invariant for every benefits surface).
 -->
 <resources>
 
@@ -192,4 +197,5 @@
     <string name="profile_autofill_preview_title">Vista previa de autocompletar</string>
     <string name="profile_autofill_preview_hint">En un formulario escaneado, los campos que coincidan muestran una etiqueta como estas — toque para rellenar.</string>
     <string name="profile_preview_filled">Rellenado: %1$s</string>
+    <!-- /#1519 -->
 </resources>

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -1425,4 +1425,34 @@
     <string name="wallet_what_proves_seed_note">Sample list — the verified program list is provided by TechEmpower.</string>
     <string name="wallet_what_proves_title">What does this prove?</string>
     <!-- /#1514 -->
+    <!-- #1519 — saved household profile (bilingual EN/ES; see values-es) -->
+    <string name="profile_title">Household profile</string>
+    <string name="profile_back_cd">Back</string>
+    <string name="profile_intro">Save the facts you type on every form once. Candela keeps them encrypted on your device and offers to fill matching fields when you scan a form.</string>
+    <string name="profile_card_title">Household profile</string>
+    <string name="profile_card_body">Save your details once — Candela fills matching form fields for you.</string>
+    <string name="profile_field_name">Full name</string>
+    <string name="profile_field_address">Home address</string>
+    <string name="profile_field_household_size">Household size</string>
+    <string name="profile_field_income">Monthly income</string>
+    <string name="profile_field_phone">Phone number</string>
+    <string name="profile_field_email">Email</string>
+    <string name="profile_save">Save</string>
+    <string name="profile_revert">Undo changes</string>
+    <string name="profile_cancel">Cancel</string>
+    <string name="profile_delete">Delete profile</string>
+    <string name="profile_delete_confirm_title">Delete your profile?</string>
+    <string name="profile_delete_confirm_body">This erases your saved details from this device. It can\'t be undone.</string>
+    <string name="profile_locked">Your profile is saved and locked.</string>
+    <string name="profile_unlock">Unlock to edit</string>
+    <string name="profile_auth_title">Unlock your profile</string>
+    <string name="profile_auth_desc">Confirm it\'s you to view or change your saved details.</string>
+    <string name="profile_saved_announce">Profile saved</string>
+    <string name="profile_ssn_policy">Never save your Social Security Number here. When a form asks for it, type it directly — Candela won\'t store it or offer to fill it.</string>
+    <string name="profile_ssn_warning">Social Security Number — type it yourself; never saved.</string>
+    <string name="profile_use_saved">Use saved: %1$s</string>
+    <string name="profile_use_saved_cd">Fill this field with your saved value: %1$s</string>
+    <string name="profile_autofill_preview_title">Autofill preview</string>
+    <string name="profile_autofill_preview_hint">On a scanned form, matching fields show a chip like these — tap to fill.</string>
+    <string name="profile_preview_filled">Filled: %1$s</string>
 </resources>

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/docs/profile/HouseholdProfileViewModelTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/docs/profile/HouseholdProfileViewModelTest.kt
@@ -1,0 +1,103 @@
+package `in`.jphe.storyvox.feature.docs.profile
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Issue #1519 — household profile VM orchestration with a fake store.
+ * Save / load / edit / revert / delete, all plain-JVM (no Android, no
+ * network; the profile never leaves the device).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class HouseholdProfileViewModelTest {
+
+    private lateinit var store: FakeStore
+
+    @Before
+    fun setUp() = Dispatchers.setMain(UnconfinedTestDispatcher())
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    @Test
+    fun `empty store yields empty draft`() = runTest {
+        store = FakeStore()
+        val vm = HouseholdProfileViewModel(store)
+        assertTrue(vm.state.value.draft.isEmpty)
+        assertFalse(vm.state.value.hasSavedProfile)
+    }
+
+    @Test
+    fun `editing a field marks unsaved changes`() = runTest {
+        store = FakeStore()
+        val vm = HouseholdProfileViewModel(store)
+        vm.onFieldChange(ProfileField.ADDRESS, "123 Main St")
+        assertTrue(vm.state.value.hasUnsavedChanges)
+        assertEquals("123 Main St", vm.state.value.draft.address)
+    }
+
+    @Test
+    fun `save persists to the store and clears unsaved flag`() = runTest {
+        store = FakeStore()
+        val vm = HouseholdProfileViewModel(store)
+        vm.onFieldChange(ProfileField.FULL_NAME, "Ada Lovelace")
+        vm.onFieldChange(ProfileField.HOUSEHOLD_SIZE, "3")
+        vm.save()
+
+        assertEquals("Ada Lovelace", store.current().fullName)
+        assertEquals("3", store.current().householdSize)
+        assertTrue(vm.state.value.hasSavedProfile)
+        assertFalse(vm.state.value.hasUnsavedChanges)
+        assertTrue(vm.state.value.justSaved)
+    }
+
+    @Test
+    fun `existing profile loads into state`() = runTest {
+        store = FakeStore(HouseholdProfile(fullName = "Grace", email = "g@example.org"))
+        val vm = HouseholdProfileViewModel(store)
+        assertTrue(vm.state.value.hasSavedProfile)
+        assertEquals("Grace", vm.state.value.draft.fullName)
+        assertEquals("g@example.org", vm.state.value.draft.email)
+    }
+
+    @Test
+    fun `revert restores the saved values`() = runTest {
+        store = FakeStore(HouseholdProfile(fullName = "Grace"))
+        val vm = HouseholdProfileViewModel(store)
+        vm.onFieldChange(ProfileField.FULL_NAME, "Changed")
+        assertTrue(vm.state.value.hasUnsavedChanges)
+        vm.revert()
+        assertFalse(vm.state.value.hasUnsavedChanges)
+        assertEquals("Grace", vm.state.value.draft.fullName)
+    }
+
+    @Test
+    fun `delete wipes the store and the state`() = runTest {
+        store = FakeStore(HouseholdProfile(fullName = "Grace"))
+        val vm = HouseholdProfileViewModel(store)
+        vm.deleteProfile()
+        assertTrue(store.current().isEmpty)
+        assertFalse(vm.state.value.hasSavedProfile)
+        assertTrue(vm.state.value.draft.isEmpty)
+    }
+
+    private class FakeStore(initial: HouseholdProfile = HouseholdProfile()) : HouseholdProfileStore {
+        private val flow = MutableStateFlow(initial)
+        fun current(): HouseholdProfile = flow.value
+        override fun profile(): Flow<HouseholdProfile> = flow
+        override suspend fun save(profile: HouseholdProfile) { flow.value = profile }
+        override suspend fun clear() { flow.value = HouseholdProfile() }
+    }
+}

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/docs/profile/ProfileAutofillMatcherTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/docs/profile/ProfileAutofillMatcherTest.kt
@@ -1,0 +1,82 @@
+package `in`.jphe.storyvox.feature.docs.profile
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1519 — coverage for the bilingual autofill label matcher. These
+ * ARE the acceptance criteria for the suggestion logic: EN + ES form
+ * vocabulary maps to the right field, and SSN-like fields NEVER map (and
+ * are flagged sensitive). Pure JVM, on-device by construction.
+ */
+class ProfileAutofillMatcherTest {
+
+    @Test
+    fun `english labels map to fields`() {
+        assertEquals(ProfileField.FULL_NAME, ProfileAutofillMatcher.match("Full Name"))
+        assertEquals(ProfileField.ADDRESS, ProfileAutofillMatcher.match("Mailing Address"))
+        assertEquals(ProfileField.HOUSEHOLD_SIZE, ProfileAutofillMatcher.match("Household Size"))
+        assertEquals(ProfileField.MONTHLY_INCOME, ProfileAutofillMatcher.match("Gross Monthly Income"))
+        assertEquals(ProfileField.PHONE, ProfileAutofillMatcher.match("Phone Number"))
+        assertEquals(ProfileField.EMAIL, ProfileAutofillMatcher.match("Email Address"))
+    }
+
+    @Test
+    fun `spanish labels map to fields`() {
+        assertEquals(ProfileField.FULL_NAME, ProfileAutofillMatcher.match("Nombre completo"))
+        assertEquals(ProfileField.ADDRESS, ProfileAutofillMatcher.match("Domicilio"))
+        assertEquals(ProfileField.HOUSEHOLD_SIZE, ProfileAutofillMatcher.match("Número de personas en el hogar"))
+        assertEquals(ProfileField.MONTHLY_INCOME, ProfileAutofillMatcher.match("Ingreso mensual bruto"))
+        assertEquals(ProfileField.PHONE, ProfileAutofillMatcher.match("Teléfono"))
+        assertEquals(ProfileField.EMAIL, ProfileAutofillMatcher.match("Correo electrónico"))
+    }
+
+    @Test
+    fun `bare short labels still map`() {
+        assertEquals(ProfileField.ADDRESS, ProfileAutofillMatcher.match("Address"))
+        assertEquals(ProfileField.MONTHLY_INCOME, ProfileAutofillMatcher.match("Income"))
+        assertEquals(ProfileField.EMAIL, ProfileAutofillMatcher.match("E-mail"))
+    }
+
+    @Test
+    fun `ssn fields are sensitive and never match`() {
+        for (label in listOf(
+            "Social Security Number",
+            "SSN",
+            "Social Security No.",
+            "Número de Seguro Social",
+            "Seguro Social",
+        )) {
+            assertTrue("$label should be sensitive", ProfileAutofillMatcher.isSensitive(label))
+            assertNull("$label must not suggest", ProfileAutofillMatcher.match(label))
+        }
+    }
+
+    @Test
+    fun `non-sensitive fields are not flagged sensitive`() {
+        assertFalse(ProfileAutofillMatcher.isSensitive("Full Name"))
+        assertFalse(ProfileAutofillMatcher.isSensitive("Monthly Income"))
+        assertFalse(ProfileAutofillMatcher.isSensitive(""))
+    }
+
+    @Test
+    fun `unknown labels do not match`() {
+        assertNull(ProfileAutofillMatcher.match("Signature"))
+        assertNull(ProfileAutofillMatcher.match("Date of hearing"))
+        assertNull(ProfileAutofillMatcher.match(""))
+    }
+
+    @Test
+    fun `most specific synonym wins`() {
+        // "Gross monthly household income" contains both "income" and the
+        // more specific income phrases — still resolves to income, not a
+        // spurious household-size hit from the word "household".
+        assertEquals(
+            ProfileField.MONTHLY_INCOME,
+            ProfileAutofillMatcher.match("Gross monthly household income (before taxes)"),
+        )
+    }
+}


### PR DESCRIPTION
## What

An optional, on-device, encrypted household profile (name / address / household size / income / phone / email) that autofills the fields people re-type on every benefits form. Part of the benefits paperwork companion (epic #1520).

## How it works

- **`ProfileAutofillMatcher`** (pure JVM) maps a scanned form's detected label → a saved field, **bilingually** (EN + ES vocabulary: "Address"/"Domicilio", "Gross Monthly Income"/"Ingreso mensual bruto", "Household size"/"Número de personas en el hogar", …). Longest-synonym-wins; **SSN/ITIN/tax-id labels are flagged sensitive and never match**.
- **`ProfileAutofillChip`** — the reusable drop-in for the fillable-PDF screen (#1512): pass a detected label + the profile + an `onFill` callback → get a one-tap "use saved …" chip, or an SSN warning, or nothing. `#1512` isn't merged yet, so this PR ships the matcher + chip + a **live autofill preview** in the profile screen that demonstrates both, and leaves a `TODO(#1512)` for wiring into the detected-field rows.
- **Storage: the app's existing `EncryptedSharedPreferences` (`storyvox.secrets`)** — encrypted at rest and **already excluded from cloud backup + device transfer** (#951). No new store, no Room (dodges the cross-lane `AppDatabase` version collision), no new backup rules. `TODO(#1514)`: migrate to the wallet's encrypted seam when it lands.
- **Edit + delete are gated** behind the device lock (fingerprint / face / PIN) via `KeyguardManager.createConfirmDeviceCredentialIntent`. Why not androidx `BiometricPrompt`: `MainActivity` is a `ComponentActivity` (BiometricPrompt needs a `FragmentActivity`) and the wallet lane (#1514) owns the shared BiometricPrompt seam — `TODO(#1514)` to swap when it lands. No new dependency.

## Invariants (epic #1520)

1. **On-device / airplane-mode.** The profile never leaves the device: encrypted at rest, excluded from backup/sync, and label→value matching is local string comparison (no network).
2. **Bilingual EN/ES.** All new strings in `values/` **and** `values-es/` this PR (values-es kept a **superset** of #1513's doc-scanner keys so it rebases cleanly).
3. **Verified or silent.** No benefits facts authored — this is pure UI + a label dictionary.
4. **Accessibility.** Labelled fields, Toast/save confirmation, plain top-to-bottom form, chip `contentDescription`s.

## Acceptance criteria

- [x] Scan a form → address / household-size fields show suggestion chips → one tap fills — `ProfileAutofillMatcher` + `ProfileAutofillChip` (demonstrated live in the Autofill preview; end-to-end wiring lands with #1512's fillable-form screen — flagged).
- [x] SSN-looking fields never offer a suggestion and warn about persistence — `ProfileAutofillMatcher.isSensitive` (+ `match` returns null), `SensitiveFieldNote`, and an SSN policy note; covered by `ProfileAutofillMatcherTest`.
- [x] Profile edit / delete behind device authentication; wiped by "delete all my data" — `KeyguardManager` gate on edit + delete; `HouseholdProfileStore.clear()` is the hook a global wipe calls (no central local-wipe action exists today — documented). SSN is never persisted.

## Data-Safety

No new permission and no content egress (on-device, encrypted, never transmitted) → Play Data-Safety mapping unchanged. Documented in `privacy.md` §2.11 for honesty (new on-device PII store, SSN never stored). ⚠️ §2.11 also used by #1515 — second-merged renumbers.

## Tests

`ProfileAutofillMatcherTest` (EN/ES mapping, SSN guard, specificity, unknowns) + `HouseholdProfileViewModelTest` (save/load/edit/revert/delete). Pure JVM.

## Cross-lane notes

- `values-es/strings.xml` and `values/strings.xml` are shared with every A-lane — kept append-only + superset of #1513.
- `TechEmpowerHomeScreen.kt` (+entry card) and `StoryvoxNavHost.kt` (+route) touched append-only.

Closes #1519

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a saved household profile screen for viewing, editing, saving, unlocking, and deleting on-device profile details.
  * Added autofill suggestions for supported form fields, with clear warnings for sensitive identifiers.
  * Added navigation entry points from the home screen to access the saved profile flow.
  * Added Spanish translations for the new profile experience.

* **Bug Fixes**
  * Improved profile loading and saving reliability.
  * Ensured sensitive data is never included in autofill or sync behavior.

* **Documentation**
  * Updated privacy guidance to explain on-device encrypted storage and user controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->