### PR TITLE
fix(notion): auto-refresh Browse on connect — key paginator on config (#1556)

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseViewModel.kt
@@ -237,6 +237,21 @@ class BrowseViewModel @Inject constructor(
         .distinctUntilChanged()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), true)
 
+    /**
+     * Issue #1556 — fingerprint of the Notion config that changes what the
+     * Browse → Notion chip should show (token connected? which database?).
+     * Folded into the [paginator] key so connecting Notion — or editing the
+     * token / database id — rebuilds the paginator and auto-fetches with the
+     * new config, with NO manual pull-to-refresh. Closes the
+     * config-just-saved race (follow-up to #1511): before this, the
+     * paginator keyed only on source/tab/filter, so page 1 (fetched empty,
+     * pre-token) was never re-run until the user pulled to refresh.
+     */
+    private val notionConfigKey: StateFlow<String> = settings.settings
+        .map { "${it.notionTokenConfigured}|${it.notionDatabaseId}" }
+        .distinctUntilChanged()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), "")
+
     private val hasGitHubRepoScope: kotlinx.coroutines.flow.Flow<Boolean> =
         settings.settings
             .map { s ->
@@ -333,7 +348,7 @@ class BrowseViewModel @Inject constructor(
         val authForResolve = combine(githubSignedIn, royalRoadSignedIn, ao3SignedIn) { gh, rr, ao3 ->
             Triple(gh, rr, ao3)
         }
-        combine(baseTuple, _palaceFilter, authForResolve) { tup, pf, auth ->
+        combine(baseTuple, _palaceFilter, authForResolve, notionConfigKey) { tup, pf, auth, notionKey ->
             resolveSource(
                 sourceId = tup.sourceId,
                 tab = tup.tab,
@@ -343,10 +358,17 @@ class BrowseViewModel @Inject constructor(
                 githubSignedIn = auth.first,
                 royalRoadSignedIn = auth.second,
                 ao3SignedIn = auth.third,
-            )?.let { source -> source to tup.sourceId }
+            )?.let { source ->
+                // #1556 — fold the Notion config fingerprint into the key
+                // ONLY for the Notion source, so connecting / editing Notion
+                // rebuilds the paginator (→ auto-fetch via the init
+                // collectLatest { loadNext() }) without recreating any other
+                // source's paginator on unrelated settings emissions.
+                Triple(source, tup.sourceId, notionPaginatorRefreshKey(tup.sourceId, notionKey))
+            }
         }
             .distinctUntilChanged()
-            .map { pair -> pair?.let { (source, sourceId) -> repo.paginator(source, sourceId) } }
+            .map { triple -> triple?.let { (source, sourceId, _) -> repo.paginator(source, sourceId) } }
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
     }
 
@@ -727,6 +749,18 @@ data class NotionConnectionUi(
     val workspaceName: String = "",
     val databaseId: String = "",
 )
+
+/**
+ * Issue #1556 — the extra component folded into the Browse paginator's
+ * distinct key that makes it rebuild (and thus auto-fetch) when the Notion
+ * config changes. Returns [notionConfigKey] for the Notion source and an
+ * empty string for every other source — so a Notion connect/edit refreshes
+ * the Notion chip without disturbing any other source's paginator (which
+ * would otherwise reset its scroll/pagination on unrelated settings
+ * changes). Pure so it's unit-testable without the full ViewModel.
+ */
+internal fun notionPaginatorRefreshKey(sourceId: String, notionConfigKey: String): String =
+    if (sourceId == SourceIds.NOTION_PAT) notionConfigKey else ""
 
 private val AUTH_ONLY_GH_TABS: Set<BrowseTab> = setOf(BrowseTab.MyRepos, BrowseTab.Starred, BrowseTab.Gists)
 

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/browse/NotionPaginatorRefreshKeyTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/browse/NotionPaginatorRefreshKeyTest.kt
@@ -1,0 +1,46 @@
+package `in`.jphe.storyvox.feature.browse
+
+import `in`.jphe.storyvox.data.source.SourceIds
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+/**
+ * Issue #1556 — pins the "Notion-only paginator keying" invariant behind
+ * the auto-refresh-on-connect fix. The Notion config fingerprint must feed
+ * the paginator key ONLY for the Notion source, so:
+ *  - connecting / editing Notion rebuilds the Notion paginator (auto-fetch),
+ *  - and NO other source's paginator rebuilds on unrelated settings changes
+ *    (which would reset its scroll/pagination).
+ * Pure function, no ViewModel/Hilt needed — same posture as the favorites
+ * ordering test in this package.
+ */
+class NotionPaginatorRefreshKeyTest {
+
+    @Test fun `notion source carries the config fingerprint`() {
+        assertEquals("true|db123", notionPaginatorRefreshKey(SourceIds.NOTION_PAT, "true|db123"))
+    }
+
+    @Test fun `non-notion sources never carry the fingerprint`() {
+        for (id in listOf("rr", "github", "ao3", "gutenberg", SourceIds.ROYAL_ROAD)) {
+            assertEquals("", notionPaginatorRefreshKey(id, "true|db123"))
+        }
+    }
+
+    @Test fun `connect transition changes the notion key`() {
+        // unconfigured → configured must produce a different key so the
+        // paginator's distinctUntilChanged rebuilds it (→ auto-fetch).
+        val before = notionPaginatorRefreshKey(SourceIds.NOTION_PAT, "false|")
+        val after = notionPaginatorRefreshKey(SourceIds.NOTION_PAT, "true|db123")
+        assertNotEquals(before, after)
+    }
+
+    @Test fun `unrelated settings change does not move a non-notion key`() {
+        // Even if the Notion fingerprint flips, a non-Notion source's key
+        // stays "" → its paginator is NOT rebuilt.
+        val a = notionPaginatorRefreshKey("rr", "false|")
+        val b = notionPaginatorRefreshKey("rr", "true|db123")
+        assertEquals(a, b)
+        assertEquals("", a)
+    }
+}


### PR DESCRIPTION
## The race (follow-up to #1511)

`BrowseViewModel`'s paginator was keyed on **source / tab / filter** — but not the Notion config. So connecting Notion (or editing the token/db id) while the Notion chip was open didn't re-fetch: page 1 was already fetched (empty, pre-token), and only a manual pull-to-refresh re-ran it with the now-configured token. This is the "empty on first fetch, populates on second refresh" symptom.

## Fix — issue's approach (a): key the paginator on the config

- New `notionConfigKey` flow = a fingerprint of `notionTokenConfigured` + `notionDatabaseId` (own `distinctUntilChanged`).
- Folded into the paginator's `combine`/`distinctUntilChanged` key **only for the Notion source** (`notionPaginatorRefreshKey()`), so a Notion connect/edit produces a new distinct key → a fresh `RealBrowsePaginator` → the existing `init { paginator.collectLatest { p -> p?.loadNext() } }` **auto-fetches** with the new token. No user action.
- **Scoped to Notion**: every other source's refresh key is `""`, so unrelated settings emissions never rebuild their paginators (no scroll/pagination reset — the naive-`LaunchedEffect` failure mode the issue called out is avoided).
- Robust across entry points (Browse manage-sheet save, Settings, OAuth callback) because it keys off the persisted settings, not a single call site.

`RealBrowsePaginator` is constructed fresh per `repo.paginator()` call (no caching), so recreation genuinely re-fetches. The #1511 `NotionConnectedEmptyState` stays as a graceful fallback for the brief fetch window / genuinely-empty DBs.

## Acceptance

- [x] Connecting Notion while the Notion chip is open auto-populates without a manual refresh.
- [x] No re-fetch/scroll-reset on every entry to the chip (rebuild only on actual config change).
- [x] Other sources unaffected by Notion (or unrelated) settings changes.

## Tests

`NotionPaginatorRefreshKeyTest` — pure-function coverage of the Notion-only keying invariant (notion carries fingerprint; connect transition changes the key; non-notion sources always `""`). Matches this package's pure-logic test posture (no ViewModel/Hilt host).

No user-facing strings added → no EN/ES change needed.

Closes #1556