### PR TITLE
dx(sources): enforce + document the fiction-id "<pluginId>:<localId>" prefix (#1564)

### DIFF
--- a/core-data/build.gradle.kts
+++ b/core-data/build.gradle.kts
@@ -47,6 +47,12 @@ android {
             // Robolectric needs Android resources on the unit-test classpath
             // so MigrationTestHelper can spin up a real SQLiteOpenHelper.
             isIncludeAndroidResources = true
+            // #1564 — FictionSourceIdResolver logs LOUD (android.util.Log.w)
+            // when it hits a colon-less non-numeric id. Its plain-JVM test
+            // exercises that path, so let the android stubs return defaults
+            // instead of throwing "not mocked". (No effect on Robolectric
+            // tests, which supply real android impls.)
+            isReturnDefaultValues = true
         }
     }
 }

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/source/FictionSourceIdResolver.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/source/FictionSourceIdResolver.kt
@@ -1,5 +1,7 @@
 package `in`.jphe.storyvox.data.source
 
+import android.util.Log
+
 /**
  * Issue #981 — resolves a stored fiction id to the `sourceId` (the
  * `Map<String, FictionSource>` key) that can actually hydrate it.
@@ -73,7 +75,9 @@ object FictionSourceIdResolver {
             return null
         }
 
-        // No colon → bare Royal Road numeric id.
+        // No colon → bare Royal Road numeric id (or a source that forgot
+        // its prefix — #1564 warns loudly on the latter).
+        warnIfMissingSourcePrefix(id)
         if (SourceIds.ROYAL_ROAD in boundSourceIds) return SourceIds.ROYAL_ROAD
         return null
     }
@@ -95,6 +99,43 @@ object FictionSourceIdResolver {
      * the authoritative self-heal; this just stops the most common shape
      * (bare RR ids) from ever being written wrong.
      */
-    fun resolveByShape(id: String): String =
-        if (id.contains(':')) id.substringBefore(':') else SourceIds.ROYAL_ROAD
+    fun resolveByShape(id: String): String {
+        if (id.contains(':')) return id.substringBefore(':')
+        warnIfMissingSourcePrefix(id)
+        return SourceIds.ROYAL_ROAD
+    }
+
+    /**
+     * Issue #1564 — a colon-less id that is NOT a bare number is almost
+     * certainly a source that forgot the required `"<pluginId>:<localId>"`
+     * prefix. Royal Road (the only bare-id source) uses numeric ids, radio
+     * ids carry a colon, and every other source prefixes — so a colon-less
+     * NON-numeric id is a routing bug: it silently defaults to Royal Road
+     * (above), and its fiction's detail/reader never open.
+     *
+     * Pure (no Android types) so it is unit-testable without a logger.
+     */
+    internal fun looksLikeMissingSourcePrefix(id: String): Boolean =
+        !id.contains(':') && id.toLongOrNull() == null
+
+    /**
+     * Log LOUD (not gated behind verbose logging, and not a throw — a
+     * bad id from one source must not crash sync/back-fill for the rest)
+     * when [id] looks like a missing-prefix routing bug (#1564). The
+     * contract kit ([FictionSourceContractTest]) is the fail-fast,
+     * test-time counterpart.
+     */
+    private fun warnIfMissingSourcePrefix(id: String) {
+        if (looksLikeMissingSourcePrefix(id)) {
+            Log.w(
+                TAG,
+                "Fiction id '$id' has no '<pluginId>:' prefix — routing it to " +
+                    "Royal Road by default. A non-Royal-Road source returning bare " +
+                    "ids will misroute (detail/reader won't open). Fiction ids must " +
+                    "be \"<pluginId>:<localId>\" — see docs/CONTRIBUTING-SOURCES.md.",
+            )
+        }
+    }
+
+    private const val TAG = "FictionSrcIdResolver"
 }

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/source/FictionSourceIdResolverTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/source/FictionSourceIdResolverTest.kt
@@ -1,7 +1,9 @@
 package `in`.jphe.storyvox.data.source
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -63,6 +65,31 @@ class FictionSourceIdResolverTest {
         assertEquals("royalroad", FictionSourceIdResolver.resolveByShape("8894"))
         assertEquals("gutenberg", FictionSourceIdResolver.resolveByShape("gutenberg:84"))
         assertEquals("somafm-groove-salad", FictionSourceIdResolver.resolveByShape("somafm-groove-salad:live"))
+    }
+
+    @Test fun `issue 1564 - colon-less non-numeric id is flagged as a missing prefix`() {
+        // The trap: a source that returns bare ids (e.g. "candela-handbook")
+        // instead of "<pluginId>:<localId>". A bare NUMBER is a legit Royal
+        // Road id and must NOT be flagged.
+        assertTrue(FictionSourceIdResolver.looksLikeMissingSourcePrefix("candela-handbook"))
+        assertTrue(FictionSourceIdResolver.looksLikeMissingSourcePrefix("guides"))
+        // legit shapes are not flagged:
+        assertFalse(FictionSourceIdResolver.looksLikeMissingSourcePrefix("8894")) // bare RR number
+        assertFalse(FictionSourceIdResolver.looksLikeMissingSourcePrefix("146000"))
+        assertFalse(FictionSourceIdResolver.looksLikeMissingSourcePrefix("notion:guides")) // has prefix
+        assertFalse(FictionSourceIdResolver.looksLikeMissingSourcePrefix("somafm-groove-salad:live"))
+    }
+
+    @Test fun `issue 1564 - colon-less non-numeric id still defaults to royalroad (with a loud warning)`() {
+        // The routing behaviour is unchanged (defaults to Royal Road); #1564
+        // only ADDS a loud Log.w so the misroute is diagnosable. This asserts
+        // the return value; the warning is a side effect (safe here because
+        // core-data unit tests return default values for android.util.Log).
+        assertEquals("royalroad", FictionSourceIdResolver.resolveByShape("candela-handbook"))
+        assertEquals(
+            "royalroad",
+            FictionSourceIdResolver.resolve("candela-handbook", bound, storedSourceId = null),
+        )
     }
 
     @Test fun `issue 988 - placeholder-creation stamps royalroad not the whole number`() {

--- a/core-source-testkit/src/main/kotlin/in/jphe/storyvox/testkit/source/FictionSourceContractTest.kt
+++ b/core-source-testkit/src/main/kotlin/in/jphe/storyvox/testkit/source/FictionSourceContractTest.kt
@@ -2,6 +2,8 @@ package `in`.jphe.storyvox.testkit.source
 
 import `in`.jphe.storyvox.data.source.FictionSource
 import `in`.jphe.storyvox.data.source.model.FictionResult
+import `in`.jphe.storyvox.data.source.model.FictionSummary
+import `in`.jphe.storyvox.data.source.model.ListPage
 import `in`.jphe.storyvox.data.source.model.SearchQuery
 import kotlinx.coroutines.runBlocking
 import okhttp3.OkHttpClient
@@ -148,6 +150,30 @@ abstract class FictionSourceContractTest {
                 "through to the 404 arm). Point listPathFragment() at a substring your " +
                 "popular()/search() endpoint actually requests (#1523).",
             paths.any { it.contains(fragment) },
+        )
+    }
+
+    @Test fun `returned fiction ids carry the source's own id prefix`() {
+        // #1564 — a FictionSource MUST return ids shaped "<pluginId>:<localId>".
+        // FictionSourceIdResolver routes a fiction to its owning source by the
+        // id's colon prefix and DEFAULTS a colon-less id to Royal Road — so a
+        // source returning bare ids has its fictions silently misrouted (their
+        // detail/reader never open). Compiles clean, breaks only at runtime;
+        // this makes it fail honestly in the kit (matching the #1523 philosophy).
+        val src = source()
+        val result = runBlocking { exerciseList(src) }
+        val page = (result as? FictionResult.Success<*>)?.value as? ListPage<*>
+        // The happy-body-served + parsed guarantees live in the checks above;
+        // here we only assert the SHAPE of whatever ids came back.
+        val ids = page?.items?.filterIsInstance<FictionSummary>()?.map { it.id }.orEmpty()
+        val prefix = "${src.id}:"
+        val offenders = ids.filterNot { it.startsWith(prefix) }
+        assertTrue(
+            "FictionSummary ids must be \"<pluginId>:<localId>\" — this source's id is " +
+                "\"${src.id}\", so every returned id must start with \"$prefix\". A colon-less " +
+                "or wrong-prefix id silently routes to Royal Road at runtime " +
+                "(FictionSourceIdResolver), so detail/reader never open (#1564). Offenders: $offenders",
+            offenders.isEmpty(),
         )
     }
 

--- a/docs/CONTRIBUTING-SOURCES.md
+++ b/docs/CONTRIBUTING-SOURCES.md
@@ -126,6 +126,30 @@ Use `FictionResult.map { … }` to transform a `Success` while passing failures
 through unchanged. `source-hackernews` (`toSummary()` / `toDetail()`) is the
 canonical mapping example.
 
+### Id scheme — the `<pluginId>:<localId>` rule (required)
+
+Every `FictionSummary.id` (and the `fictionId` in `FictionDetail`) **must** be
+shaped `"<pluginId>:<localId>"`, where `<pluginId>` is your source's `@SourcePlugin`
+id (the same string as `FictionSource.id`). Example: a Gutenberg book `84` becomes
+`"gutenberg:84"`; a Notion page becomes `"notion:guides"`.
+
+**Why it's not optional.** `FictionSourceIdResolver` (#981) routes a stored fiction
+back to its owning source by the id's colon prefix (`id.substringBefore(':')`), and
+**defaults a colon-less id to Royal Road**. So a source that returns a bare id (e.g.
+`"my-doc"`) has its fictions silently misrouted to Royal Road — detail and reader
+never open. It compiles clean and passes green tests; it breaks only at runtime.
+As of #1564:
+
+- The contract kit (`FictionSourceContractTest`) asserts every id returned by
+  `popular()`/`search()` starts with `"<yourId>:"` — a bare id **fails the test**.
+- `FictionSourceIdResolver` logs a loud warning when it routes a colon-less,
+  non-numeric id to Royal Road (bare *numeric* ids are the one legitimate
+  colon-less shape — they're Royal Road's).
+
+**Chapter ids are composite too.** A `Chapter.id` must be globally unique across
+fictions — build it as `"$fictionId::<localChapterId>"` (note the `::`), so joins on
+chapter id stay 1:1 (#1261). `source-hackernews` shows both conventions.
+
 ## 4. Turn the contract test green
 
 Open `<Name>ContractTest.kt` and set the two fixture hooks:

--- a/scripts/new-source.sh
+++ b/scripts/new-source.sh
@@ -895,9 +895,12 @@ class __PASCAL__SourceTest {
     fun `popular surfaces every local item as a fiction`() = runTest {
         val source = __PASCAL__Source(
             FakeReader(
+                // #1564 — ids are "<pluginId>:<localId>". A colon-less id
+                // silently misroutes to Royal Road (FictionSourceIdResolver),
+                // so your FictionSummary ids MUST keep the "__ID__:" prefix.
                 listOf(
-                    __PASCAL__Item(id = "1", title = "First", body = "Body one"),
-                    __PASCAL__Item(id = "2", title = "Second", body = "Body two"),
+                    __PASCAL__Item(id = "__ID__:1", title = "First", body = "Body one"),
+                    __PASCAL__Item(id = "__ID__:2", title = "Second", body = "Body two"),
                 ),
             ),
         )


### PR DESCRIPTION
## What

Enforce + document the **`"<pluginId>:<localId>"` fiction-id prefix**. Colon-less ids silently route to Royal Road (the default in `FictionSourceIdResolver`), so a source returning bare ids has its fictions misrouted — detail/reader never open. It **compiles clean and passes green tests; it breaks only at runtime** (surfaced building `source-handbook` #1544, caught in review not CI).

## Three-layer fix

1. **Contract kit (primary enforcement).** `FictionSourceContractTest` now asserts every id returned by `popular()`/`search()` starts with `"<sourceUnderTest.id>:"` — a bare/wrong-prefix id **fails the test honestly** (matching the #1523 "kit must FAIL honestly" philosophy). Inherited by every HTTP/auth/xml source's contract test.
2. **Loud runtime check.** `FictionSourceIdResolver` logs a **LOUD** `Log.w` when it routes a colon-less **non-numeric** id to Royal Road. (Bare *numeric* ids are the one legitimate colon-less shape — they're Royal Road's — so they're never flagged.) The detection is a pure `internal fun looksLikeMissingSourcePrefix()` (unit-testable without a logger). It's a **warning, not a throw** — one malformed id from a buggy source must not crash sync/back-fill for every other fiction. Enabled `isReturnDefaultValues` in core-data test options so the resolver's plain-JVM test tolerates `android.util.Log`.
3. **Docs + scaffold.** `CONTRIBUTING-SOURCES.md` gains an **"Id scheme"** section (the rule, the Royal-Road-default gotcha, and the composite `"$fictionId::<chapter>"` chapter-id rule). `new-source.sh`'s `--local` test seed now models `"$ID:1"` / `"$ID:2"` instead of bare `"1"` / `"2"`, so the first consumer copies the **right** shape.

## Notes

- **dx/tooling only** — no user-facing strings, so no EN/ES.
- The contract-kit assertion runs at test-execution time (like the kit's other checks); the PR gate (`compileDebugUnitTestKotlin` / `assembleRelease`) compiles it. Existing sources all follow the convention, so none regress.
- `isReturnDefaultValues` affects only non-Robolectric core-data JVM tests (Robolectric supplies real android impls); it makes `android.util.Log` stubs return defaults instead of throwing.

## Files

- `core-data/.../FictionSourceIdResolver.kt` — loud check + pure detector
- `core-data/build.gradle.kts` — `isReturnDefaultValues = true`
- `core-data/.../FictionSourceIdResolverTest.kt` — detector + default-routing tests
- `core-source-testkit/.../FictionSourceContractTest.kt` — id-prefix assertion
- `docs/CONTRIBUTING-SOURCES.md` — "Id scheme" section
- `scripts/new-source.sh` — `--local` seed ids now prefixed

Companion to #1562 (completes the `--local` dogfood round). Refs #981, #1523, #1526.

Closes #1564

🤖 Generated with [Claude Code](https://claude.com/claude-code)
