### PR TITLE
feat(google-drive): Connect button + empty state in Browse (#1534 item 1)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
@@ -1135,6 +1135,12 @@ class SettingsRepositoryUiImpl(
      *  so the 1.5s debounce resolves in virtual time. */
     private val pushDispatcher: kotlinx.coroutines.CoroutineDispatcher =
         kotlinx.coroutines.Dispatchers.Default,
+    /** Issue #1534 — supplies the Google Drive authorize URL (PKCE + state
+     *  persisted) for [beginGoogleDriveOAuth]. Production wires this to
+     *  [`in`.jphe.storyvox.auth.googledrive.GoogleDriveOAuthManager.beginConnect]
+     *  via a `Lazy` edge in the @Inject constructor; the default returns null so
+     *  test/primary-ctor harnesses don't drag in the OAuth manager. */
+    private val googleDriveOAuthBegin: suspend () -> String? = { null },
 ) : SettingsRepositoryUi,
     PlaybackBufferConfig,
     PlaybackModeConfig,
@@ -1198,6 +1204,11 @@ class SettingsRepositoryUiImpl(
         // `get()` is only called from the debounced push, never at
         // construction.
         coordinator: dagger.Lazy<SyncCoordinator>,
+        // Issue #1534 — Lazy so construction doesn't pull the OAuth manager
+        // into the graph early; `get().beginConnect()` runs only when the user
+        // taps "Connect Google Drive". beginConnect() is non-suspend + returns
+        // null when the build has no client id (button then hidden upstream).
+        googleDriveOAuth: dagger.Lazy<`in`.jphe.storyvox.auth.googledrive.GoogleDriveOAuthManager>,
     ) : this(
         context.settingsDataStore, auth, hydrator,
         palaceConfig, palaceApi, llmCreds, githubAuth, teamsAuth, rssConfig, epubConfig,
@@ -1211,6 +1222,7 @@ class SettingsRepositoryUiImpl(
         bookshareConfig = bookshareConfig,
         sourceConfigContributors = sourceConfigContributors,
         pushSettings = { coordinator.get().requestPush(SETTINGS_PUSH_DOMAIN) },
+        googleDriveOAuthBegin = { googleDriveOAuth.get().beginConnect() },
     )
 
     /**
@@ -1455,6 +1467,10 @@ class SettingsRepositoryUiImpl(
             // Issue #1507 — OAuth surface for the Browse manage sheet.
             notionWorkspaceName = notion.workspaceName,
             notionOAuthAvailable = `in`.jphe.storyvox.auth.notion.NotionOAuthConfig.isAvailable,
+            // Issue #1534 — build-time flag gating the "Connect Google Drive"
+            // empty-state button (false on clean/CI ⇒ button hidden).
+            googleDriveOAuthAvailable =
+                `in`.jphe.storyvox.auth.googledrive.GoogleDriveOAuthConfig.isAvailable,
             sleepShakeToExtendEnabled = prefs[Keys.SLEEP_SHAKE_TO_EXTEND_ENABLED] ?: true,
             showDebugOverlay = prefs[Keys.SHOW_DEBUG_OVERLAY] ?: false,
             debugLogging = prefs[Keys.DEBUG_LOGGING_ENABLED] ?: false,
@@ -2562,6 +2578,15 @@ class SettingsRepositoryUiImpl(
         notionConfig.setOAuthState(nonce)
         return `in`.jphe.storyvox.auth.notion.NotionOAuthConfig.authorizeUrl(nonce)
     }
+
+    /**
+     * Issue #1534 — begin the Google Drive OAuth flow. Delegates to
+     * [`in`.jphe.storyvox.auth.googledrive.GoogleDriveOAuthManager.beginConnect]
+     * (via the injected `Lazy`), which persists the PKCE verifier + CSRF state
+     * (both must survive the Custom Tab evicting the app) and returns the
+     * authorize URL, or null when the build has no OAuth client id.
+     */
+    override suspend fun beginGoogleDriveOAuth(): String? = googleDriveOAuthBegin()
 
     /** #246 — bridge to SuggestedFeedsRegistry. The fallback list
      *  passed in is the baked-in seed; the registry emits it

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -1176,6 +1176,12 @@ data class UiSettings(
      *  "Connect Notion" button: false ⇒ only the paste-token fallback
      *  shows. Always false on a clean/CI checkout with no creds. */
     val notionOAuthAvailable: Boolean = false,
+    /** Issue #1534 — true when this build carries Google Drive OAuth client
+     *  credentials (BuildConfig, from local.properties). Gates the
+     *  "Connect Google Drive" empty-state button: false ⇒ the source can't be
+     *  connected, so the button is hidden. Always false on a clean/CI checkout
+     *  with no creds (so the connect affordance never dangles). */
+    val googleDriveOAuthAvailable: Boolean = false,
     /** Issue #1471 — true when a Bookshare partner `api_key` has been
      *  stored. The key itself is never surfaced to the UI — only this
      *  boolean. Blank/absent ⇒ the source stays gated to AuthRequired.
@@ -2334,6 +2340,15 @@ interface SettingsRepositoryUi {
      *  don't need to override it (the redirect is handled out-of-band by
      *  MainActivity's NotionOAuthManager). */
     suspend fun beginNotionOAuth(): String? = null
+
+    /** Issue #1534 — begin the Google Drive OAuth flow (drive.file scope).
+     *  Generates + persists the PKCE verifier + CSRF `state` and returns the
+     *  authorize URL the caller opens in a Custom Tab, or null when this build
+     *  has no OAuth client credentials ([UiSettings.googleDriveOAuthAvailable]
+     *  false). Default `= null` so test/fake [SettingsRepositoryUi]
+     *  implementations don't need to override it (the redirect is handled
+     *  out-of-band by MainActivity's GoogleDriveOAuthManager). */
+    suspend fun beginGoogleDriveOAuth(): String? = null
 
     /** Issue #1471 — persist or clear the Bookshare partner API key.
      *  Pass null or empty to clear. Stored encrypted under

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -63,6 +63,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.launch
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -98,6 +99,10 @@ import `in`.jphe.storyvox.ui.component.MagicTitleBar
 import `in`.jphe.storyvox.ui.component.TestTags
 import `in`.jphe.storyvox.ui.layout.isAtLeastExpanded
 import `in`.jphe.storyvox.ui.theme.LocalSpacing
+// Issue #1534 — Google Drive connect: open the authorize URL in a Custom Tab.
+import android.net.Uri
+import androidx.browser.customtabs.CustomTabsIntent
+import androidx.compose.runtime.rememberCoroutineScope
 
 /**
  * Restructure (v0.5.40) — switch between the standalone Browse Scaffold
@@ -202,6 +207,12 @@ fun BrowseScreen(
     // #786 — live network state. Drives the OfflineBanner above the grid
     // and the full-screen-error → banner downgrade when cached items exist.
     val isOffline by viewModel.isOffline.collectAsStateWithLifecycle()
+    // Issue #1534 — "Connect Google Drive" empty state. Only oauthAvailable is
+    // read; the connect tap runs OAuth and opens the authorize URL in a Custom
+    // Tab (MainActivity's GoogleDriveOAuthManager handles the redirect).
+    val googleDriveConnection by viewModel.googleDriveConnection.collectAsStateWithLifecycle()
+    val driveConnectScope = rememberCoroutineScope()
+    val driveConnectContext = androidx.compose.ui.platform.LocalContext.current
     val spacing = LocalSpacing.current
     var showFilterSheet by remember { mutableStateOf(false) }
     /** Issue #247 — RSS feed management moved out of Settings into a
@@ -543,6 +554,31 @@ fun BrowseScreen(
                 !state.isLoading &&
                 state.error == null ->
                 NotionConnectEmptyState(onConnect = { showNotionManageSheet = true })
+            // Issue #1534 — Google Drive chip lands on AuthRequired until the
+            // user connects. AuthRequired is a FictionResult.Failure so it sets
+            // state.error (hence NO `error == null` guard here); this branch
+            // precedes the generic error state so the Connect CTA wins. The
+            // Connect button only shows when the build can run OAuth
+            // (googleDriveOAuthAvailable); otherwise the copy explains the
+            // source isn't set up in this build. Folder-grant Picker is a
+            // deferred follow-up (#1534 item 2 — needs a hosted authorized-JS-
+            // origin page); this surface makes the AuthRequired state actionable.
+            state.sourceId == GOOGLE_DRIVE_SOURCE_ID &&
+                state.tab != BrowseTab.Search &&
+                state.items.isEmpty() &&
+                !state.isLoading ->
+                GoogleDriveConnectEmptyState(
+                    oauthAvailable = googleDriveConnection.oauthAvailable,
+                    onConnect = {
+                        driveConnectScope.launch {
+                            val url = viewModel.beginGoogleDriveOAuth()
+                            if (!url.isNullOrBlank()) {
+                                CustomTabsIntent.Builder().build()
+                                    .launchUrl(driveConnectContext, Uri.parse(url))
+                            }
+                        }
+                    },
+                )
             // Issue #669 — Local backend empty state. Without this branch
             // tapping the Local chip on a fresh install rendered a
             // completely blank content area: no spinner, no message,
@@ -1205,6 +1241,64 @@ private fun NotionConnectEmptyState(onConnect: () -> Unit) {
                 onClick = onConnect,
                 variant = BrassButtonVariant.Primary,
             )
+        }
+    }
+}
+
+/**
+ * Issue #1534 — "Connect Google Drive" empty state. The `google-drive` source
+ * returns [FictionResult.AuthRequired] until the user connects; this makes that
+ * otherwise-dead state actionable. The Connect button runs the OAuth flow
+ * (`drive.file` scope) and opens the authorize URL in a Custom Tab
+ * (MainActivity's GoogleDriveOAuthManager handles the redirect).
+ *
+ * When the build carries no OAuth client id ([oauthAvailable] false — the
+ * default/CI case) the button is hidden and the copy explains the source isn't
+ * set up in this build, rather than dangling a dead button.
+ *
+ * Folder-grant Picker (#1534 item 2) is a deferred follow-up: under `drive.file`
+ * the user must additionally pick a folder in Google's Picker (a JS API hosted
+ * on an authorized origin) for its contents to become visible. This surface is
+ * the entry point that the Picker plugs into.
+ */
+@Composable
+private fun GoogleDriveConnectEmptyState(oauthAvailable: Boolean, onConnect: () -> Unit) {
+    val spacing = LocalSpacing.current
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(spacing.sm),
+            modifier = Modifier.padding(horizontal = spacing.xl),
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Add,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(48.dp),
+            )
+            Text(
+                stringResource(R.string.browse_gdrive_connect_title),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                textAlign = TextAlign.Center,
+            )
+            Text(
+                stringResource(
+                    if (oauthAvailable) R.string.browse_gdrive_connect_body
+                    else R.string.browse_gdrive_unavailable_body,
+                ),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+            if (oauthAvailable) {
+                Spacer(Modifier.height(spacing.md))
+                BrassButton(
+                    label = stringResource(R.string.browse_gdrive_connect_button),
+                    onClick = onConnect,
+                    variant = BrassButtonVariant.Primary,
+                )
+            }
         }
     }
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseViewModel.kt
@@ -298,9 +298,21 @@ class BrowseViewModel @Inject constructor(
                         // defaultEnabled=false (that governs Settings → Plugins
                         // default + generated registry state), so this is a
                         // Browse-only visibility override, not a global flip.
-                        val fallback =
-                            if (descriptor.id == SourceIds.NOTION_PAT) true
-                            else descriptor.defaultEnabled
+                        // #1534 — the Google Drive chip is discoverable in
+                        // Browse ONLY when this build can actually run OAuth
+                        // (googleDriveOAuthAvailable). That way the "Connect
+                        // Google Drive" empty state is reachable without first
+                        // visiting Settings → Plugins in a configured build,
+                        // while a clean/CI build (isAvailable=false) never
+                        // dangles a chip that can't be connected. Like NOTION_PAT
+                        // this is a Browse-only visibility fallback; an explicit
+                        // enable/disable in Plugins still wins. defaultEnabled
+                        // stays false.
+                        val fallback = when (descriptor.id) {
+                            SourceIds.NOTION_PAT -> true
+                            GOOGLE_DRIVE_SOURCE_ID -> s.googleDriveOAuthAvailable
+                            else -> descriptor.defaultEnabled
+                        }
                         val effective = explicit ?: fallback
                         if (effective) add(descriptor.id)
                     }
@@ -740,6 +752,25 @@ class BrowseViewModel @Inject constructor(
     fun disconnectNotion() {
         viewModelScope.launch { settings.setNotionApiToken(null) }
     }
+
+    // ─── Google Drive connect (#1534) ───────────────────────────────────
+
+    /** Snapshot the Browse "Connect Google Drive" empty state reads. Only
+     *  [GoogleDriveConnectionUi.oauthAvailable] is surfaced — the Connect
+     *  button is shown only when the build can actually run the flow. */
+    val googleDriveConnection: StateFlow<GoogleDriveConnectionUi> =
+        settings.settings
+            .map { GoogleDriveConnectionUi(oauthAvailable = it.googleDriveOAuthAvailable) }
+            .distinctUntilChanged()
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), GoogleDriveConnectionUi())
+
+    /**
+     * #1534 — begin the Google Drive OAuth flow: delegates to the app-level
+     * GoogleDriveOAuthManager (via the settings seam), which persists PKCE +
+     * state and returns the authorize URL for the caller to open in a Custom
+     * Tab, or null when this build has no OAuth client id.
+     */
+    suspend fun beginGoogleDriveOAuth(): String? = settings.beginGoogleDriveOAuth()
 }
 
 /** #1507 — Browse-side snapshot of the Notion connection for the manage sheet. */
@@ -762,7 +793,17 @@ data class NotionConnectionUi(
 internal fun notionPaginatorRefreshKey(sourceId: String, notionConfigKey: String): String =
     if (sourceId == SourceIds.NOTION_PAT) notionConfigKey else ""
 
+/** #1534 — Browse-side snapshot for the "Connect Google Drive" empty state. */
+data class GoogleDriveConnectionUi(
+    val oauthAvailable: Boolean = false,
+)
+
 private val AUTH_ONLY_GH_TABS: Set<BrowseTab> = setOf(BrowseTab.MyRepos, BrowseTab.Starred, BrowseTab.Gists)
+
+/** #1534 — the @SourcePlugin id of :source-google-drive. `internal` so
+ *  BrowseScreen shares the same literal (not a SourceIds entry — the annotation
+ *  id is the source of truth). */
+internal const val GOOGLE_DRIVE_SOURCE_ID = "google-drive"
 
 /** #426 PR2 — AO3 auth-only tabs (mirror of [AUTH_ONLY_GH_TABS]). */
 private val AUTH_ONLY_AO3_TABS: Set<BrowseTab> = setOf(

--- a/feature/src/main/res/values-es/strings.xml
+++ b/feature/src/main/res/values-es/strings.xml
@@ -123,4 +123,10 @@
     <!-- Tarjeta de entrada en la cuadrícula de Inicio de TechEmpower. -->
     <string name="calls_card_title">Hacer la llamada</string>
     <string name="calls_card_body">Números de teléfono de los programas, qué decir y una lista de verificación, con ayuda para vencer la ansiedad de llamar. Funciona sin conexión.</string>
+
+    <!-- #1534 — Estado vacío para conectar Google Drive -->
+    <string name="browse_gdrive_connect_title">Conecte su Google Drive</string>
+    <string name="browse_gdrive_connect_body">Vincule Google Drive y elija una carpeta; los documentos que contiene se podrán escuchar aquí. Solo vemos la carpeta que usted elija.</string>
+    <string name="browse_gdrive_unavailable_body">Google Drive aún no está configurado en esta versión de la aplicación.</string>
+    <string name="browse_gdrive_connect_button">Conectar Google Drive</string>
 </resources>

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -1363,4 +1363,10 @@
     <!-- Entry card on the TechEmpower Home grid. -->
     <string name="calls_card_title">Make the call</string>
     <string name="calls_card_body">Program phone numbers, what to say, and a checklist — with help beating call anxiety. Works offline.</string>
+
+    <!-- #1534 — Google Drive connect empty state -->
+    <string name="browse_gdrive_connect_title">Connect your Google Drive</string>
+    <string name="browse_gdrive_connect_body">Link Google Drive and pick a folder — the documents inside become listenable here. We only see the folder you choose.</string>
+    <string name="browse_gdrive_unavailable_body">Google Drive isn\'t set up in this version of the app yet.</string>
+    <string name="browse_gdrive_connect_button">Connect Google Drive</string>
 </resources>


### PR DESCRIPTION
## Google Drive: Connect button + empty state (#1534, item 1)

The deferred grant-UI slice of #1496/#1530. #1530 landed the full `drive.file` OAuth backend (`GoogleDriveOAuthManager.beginConnect()` / `handleCallback`, manifest, deeplink, MainActivity) but deferred the UI. This makes the source's `AuthRequired` state **actionable**: when a user enables the Drive source (Settings → Plugins) and lands on Browse, it returns `FictionResult.AuthRequired` — this PR surfaces a **"Connect Google Drive"** empty state whose button runs `beginConnect()` and opens the authorize URL in a Custom Tab.

Mirrors the #1509 Notion connect pattern exactly:
- `SettingsRepositoryUi.beginGoogleDriveOAuth(): String? = null` (default → hand-rolled fakes don't break) → `SettingsRepositoryUiImpl` delegates to `GoogleDriveOAuthManager.beginConnect()` through a `dagger.Lazy` edge. **Both** cycle edges are `Lazy` (manager already holds `Lazy<SettingsRepositoryUi>`), so Dagger stays acyclic — same posture as the `SyncCoordinator` `Lazy` in that ctor. The primary ctor takes a **defaulted** `suspend () -> String?`, so the 16 `SettingsRepositoryUiImpl` test harnesses are untouched.
- `UiSettings.googleDriveOAuthAvailable` ← `GoogleDriveOAuthConfig.isAvailable`.
- `BrowseViewModel.googleDriveConnection` + `beginGoogleDriveOAuth()`.
- `BrowseScreen`: `GoogleDriveConnectEmptyState` + a `when`-branch. **No `error == null` guard** — `AuthRequired` is a `FictionResult.Failure`, so it sets `state.error`; the branch precedes the generic error state so the Connect CTA wins.

### Safety: invisible by default
The Connect button shows only when `googleDriveOAuthAvailable`, which is **FALSE on every clean/CI build** (no `GOOGLE_OAUTH_CLIENT_ID`). So this surface is invisible by default and dangles nothing — zero user-facing change in shipped builds, zero empty-grant risk. It lights up only in a client-id build. When unavailable, the copy honestly says the source isn't set up in this build.

### Visibility (item 3)
Gated on `googleDriveOAuthAvailable`, mirroring the #1509 `NOTION_PAT` override: the Drive chip is discoverable in Browse when the build can run OAuth, and **hidden on clean/CI builds** (`isAvailable=false`) so it never dangles a chip that can't be connected. `defaultEnabled` stays false; an explicit enable/disable in Settings → Plugins still wins. This lands the Connect affordance both from a discoverable chip (configured builds) and from the post-enable `AuthRequired` empty state.

### Invariants
- **EN/ES** parity: `values` + `values-es` in this PR.
- **TalkBack**: the Connect control is a labeled `BrassButton`; the icon is decorative.
- **Least-scope**: `drive.file` unchanged; no new permissions.

### ⚠️ Deferred — infra/backend, NOT in this PR (why "Refs", not "Closes")
- **Item 2 — folder-grant Picker**: under `drive.file`, existing files become visible only when the user picks a folder in Google's **Picker** (a JS API whose page must be served from an **authorized JavaScript origin**). That needs a hosted picker page (e.g. GitHub Pages), a browser API key, and OAuth-client JS-origin config in Google Cloud — infrastructure that can't be stood up in-repo. Left as the entry point this surface plugs into.
- **Item 4 — silent refresh-on-401**: a `:source-google-drive` → `:app` callback seam wiring `AuthRequired` → `GoogleDriveOAuthApi.refresh()`.

**Recommend keeping #1534 open** for the Picker (item 2) + refresh seam (item 4), or splitting a fresh `feat(google-drive): folder-grant Picker page` issue and closing this one. Deliberately using `Refs #1534` (not `Closes`) so merge doesn't auto-close a partially-delivered issue.

Refs #1496, #1534
