### PR TITLE
ux(settings): coverage + discoverability overhaul — findable settings (#1577)

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/ReadingSettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/ReadingSettingsScreen.kt
@@ -54,7 +54,6 @@ import kotlin.math.roundToInt
  *
  * Visual reading knobs:
  *  - App theme override (System / Dark / Light, shipped in v0.5.32 #427).
- *  - Shake-to-extend sleep timer (#150).
  *  - Reading-color theme + custom overlay (#993) — tints the reading page
  *    only, leaving app chrome alone. Device-local pref.
  *  - Reading-text typography (#992): font family (incl. OpenDyslexic /
@@ -88,13 +87,10 @@ fun ReadingSettingsScreen(
                     selectedIndex = ThemeOverride.entries.indexOf(s.themeOverride).coerceAtLeast(0),
                     onSelected = { idx -> viewModel.setTheme(ThemeOverride.entries[idx]) },
                 )
-
-                SettingsSwitchRow(
-                    title = stringResource(R.string.settings_reading_shake_extend_title),
-                    subtitle = stringResource(R.string.settings_reading_shake_extend_subtitle),
-                    checked = s.sleepShakeToExtendEnabled,
-                    onCheckedChange = viewModel::setSleepShakeToExtendEnabled,
-                )
+                // Issue #1577 — the shake-to-extend sleep-timer toggle moved to
+                // Settings → Voice & Playback → "Sleep timer", where it sits with
+                // the rest of the sleep-timer knobs (duration, Bedtime auto-arm,
+                // Do Not Disturb). It was the odd one out here under Reading.
             }
 
             // #993 — reading-color theme (page overlay), separate from the

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsHubScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsHubScreen.kt
@@ -66,10 +66,28 @@ import `in`.jphe.storyvox.ui.theme.LocalSpacing
  */
 private val LocalSettingsHubQuery = staticCompositionLocalOf { "" }
 
-private fun matchesHubQuery(query: String, title: String, subtitle: String): Boolean {
+/**
+ * Issue #1577 — the hub search used to match a row's title + subtitle only,
+ * so a setting that lived *inside* a subscreen was invisible to search: typing
+ * "dnd", "bedtime", "handbook", "privacy", or "impact" surfaced nothing even
+ * though every one of those settings ships today (the buried DND auto-sleep
+ * toggle of #1574 is the worked example). Each row now also carries a
+ * [SettingsHubSection.keywords] list — the non-obvious synonyms and the names
+ * of the individual knobs it houses — and the query matches against those too.
+ * Keywords are internal search tokens, never rendered, so they don't need
+ * translation and stay in English to match the (English) settings surface.
+ */
+internal fun matchesHubQuery(
+    query: String,
+    title: String,
+    subtitle: String,
+    keywords: List<String> = emptyList(),
+): Boolean {
     if (query.isBlank()) return true
     val q = query.trim()
-    return title.contains(q, ignoreCase = true) || subtitle.contains(q, ignoreCase = true)
+    return title.contains(q, ignoreCase = true) ||
+        subtitle.contains(q, ignoreCase = true) ||
+        keywords.any { it.contains(q, ignoreCase = true) }
 }
 
 /**
@@ -239,6 +257,7 @@ fun SettingsHubScreen(
                     title = stringResource(R.string.settings_hub_voice_playback_title),
                     subtitle = stringResource(R.string.settings_hub_voice_playback_subtitle),
                     onClick = onOpenVoicePlayback,
+                    keywords = HubKeywords.voicePlayback,
                 )
                 // Voice library — dedicated subscreen.
                 SettingsHubRow(
@@ -246,12 +265,14 @@ fun SettingsHubScreen(
                     title = stringResource(R.string.settings_hub_voice_library_title),
                     subtitle = stringResource(R.string.settings_hub_voice_library_subtitle),
                     onClick = onOpenVoiceLibrary,
+                    keywords = HubKeywords.voiceLibrary,
                 )
                 SettingsHubRow(
                     icon = Icons.AutoMirrored.Outlined.MenuBook,
                     title = stringResource(R.string.settings_hub_reading_title),
                     subtitle = stringResource(R.string.settings_hub_reading_subtitle),
                     onClick = onOpenReading,
+                    keywords = HubKeywords.reading,
                 )
                 // Issue #1235 — Listening stats dashboard. Sits next to
                 // Reading: both are about the user's own reading, one the
@@ -261,6 +282,7 @@ fun SettingsHubScreen(
                     title = stringResource(R.string.settings_hub_stats_title),
                     subtitle = stringResource(R.string.settings_hub_stats_subtitle),
                     onClick = onOpenStats,
+                    keywords = HubKeywords.stats,
                 )
                 // Issue #1467 — morning briefing / personal-podcast queue.
                 // Reading-adjacent: a curated listen-through of your sources'
@@ -271,6 +293,7 @@ fun SettingsHubScreen(
                     title = "Morning Briefing",
                     subtitle = "One episode from your sources — HN, arXiv, RSS, GitHub",
                     onClick = onOpenBriefing,
+                    keywords = HubKeywords.briefing,
                 )
                 // Issue #1369 — teleprompter script manager. Reading-adjacent:
                 // save/edit/organize scripts the teleprompter can load.
@@ -279,6 +302,7 @@ fun SettingsHubScreen(
                     title = stringResource(R.string.settings_hub_scripts_title),
                     subtitle = stringResource(R.string.settings_hub_scripts_subtitle),
                     onClick = onOpenScripts,
+                    keywords = HubKeywords.scripts,
                 )
                 // v0.5.59 (#cover-style-toggle) — Appearance. Book-
                 // cover fallback style (Monogram / Branded / Cover
@@ -289,18 +313,21 @@ fun SettingsHubScreen(
                     title = stringResource(R.string.settings_hub_appearance_title),
                     subtitle = stringResource(R.string.settings_hub_appearance_subtitle),
                     onClick = onOpenAppearance,
+                    keywords = HubKeywords.appearance,
                 )
                 SettingsHubRow(
                     icon = Icons.Outlined.Speed,
                     title = stringResource(R.string.settings_hub_performance_title),
                     subtitle = stringResource(R.string.settings_hub_performance_subtitle),
                     onClick = onOpenPerformance,
+                    keywords = HubKeywords.performance,
                 )
                 SettingsHubRow(
                     icon = Icons.Outlined.AutoAwesome,
                     title = stringResource(R.string.settings_hub_ai_title),
                     subtitle = stringResource(R.string.settings_hub_ai_subtitle),
                     onClick = onOpenAi,
+                    keywords = HubKeywords.ai,
                 )
                 // Accessibility — Phase 1 scaffold (v0.5.42). Positioned
                 // between AI and AI sessions per spec: user-facing tier,
@@ -310,12 +337,14 @@ fun SettingsHubScreen(
                     title = stringResource(R.string.settings_hub_accessibility_title),
                     subtitle = stringResource(R.string.settings_hub_accessibility_subtitle),
                     onClick = onOpenAccessibility,
+                    keywords = HubKeywords.accessibility,
                 )
                 SettingsHubRow(
                     icon = Icons.Outlined.AutoStories,
                     title = stringResource(R.string.settings_hub_ai_sessions_title),
                     subtitle = stringResource(R.string.settings_hub_ai_sessions_subtitle),
                     onClick = onOpenAiSessions,
+                    keywords = HubKeywords.aiSessions,
                 )
                 // Plugin manager (#404). Dedicated subscreen with its own
                 // search + filter chips + capability legend.
@@ -324,24 +353,28 @@ fun SettingsHubScreen(
                     title = stringResource(R.string.settings_hub_plugins_title),
                     subtitle = stringResource(R.string.settings_hub_plugins_subtitle),
                     onClick = onOpenPluginManager,
+                    keywords = HubKeywords.plugins,
                 )
                 SettingsHubRow(
                     icon = Icons.AutoMirrored.Outlined.LibraryBooks,
                     title = stringResource(R.string.settings_hub_pronunciation_title),
                     subtitle = stringResource(R.string.settings_hub_pronunciation_subtitle),
                     onClick = onOpenPronunciationDict,
+                    keywords = HubKeywords.pronunciation,
                 )
                 SettingsHubRow(
                     icon = Icons.Outlined.AccountCircle,
                     title = stringResource(R.string.settings_hub_account_title),
                     subtitle = stringResource(R.string.settings_hub_account_subtitle),
                     onClick = onOpenAccount,
+                    keywords = HubKeywords.account,
                 )
                 SettingsHubRow(
                     icon = Icons.Outlined.Cloud,
                     title = stringResource(R.string.settings_hub_memory_palace_title),
                     subtitle = stringResource(R.string.settings_hub_memory_palace_subtitle),
                     onClick = onOpenMemoryPalace,
+                    keywords = HubKeywords.memoryPalace,
                 )
                 // Issue #1471 — Bookshare partner-key entry. Source-
                 // credential subscreen, adjacent to Memory Palace (both
@@ -351,6 +384,7 @@ fun SettingsHubScreen(
                     title = stringResource(R.string.settings_hub_bookshare_title),
                     subtitle = stringResource(R.string.settings_hub_bookshare_subtitle),
                     onClick = onOpenBookshare,
+                    keywords = HubKeywords.bookshare,
                 )
                 // v1 settings-bundle-7 — Advanced subscreen. Power-
                 // user knobs (Android Auto bucket size, future
@@ -363,18 +397,21 @@ fun SettingsHubScreen(
                     title = stringResource(R.string.settings_hub_advanced_title),
                     subtitle = stringResource(R.string.settings_hub_advanced_subtitle),
                     onClick = onOpenAdvanced,
+                    keywords = HubKeywords.advanced,
                 )
                 SettingsHubRow(
                     icon = Icons.Outlined.BugReport,
                     title = stringResource(R.string.settings_hub_developer_title),
                     subtitle = stringResource(R.string.settings_hub_developer_subtitle),
                     onClick = onOpenDebug,
+                    keywords = HubKeywords.developer,
                 )
                 SettingsHubRow(
                     icon = Icons.Outlined.Info,
                     title = stringResource(R.string.settings_hub_about_title),
                     subtitle = stringResource(R.string.settings_hub_about_subtitle),
                     onClick = onOpenAbout,
+                    keywords = HubKeywords.about,
                 )
                 // Escape hatch — the legacy flat-scroll SettingsScreen
                 // still works; users who want the old experience reach
@@ -385,6 +422,7 @@ fun SettingsHubScreen(
                     title = stringResource(R.string.settings_hub_all_settings_title),
                     subtitle = stringResource(R.string.settings_hub_all_settings_subtitle),
                     onClick = onOpenAllSettings,
+                    keywords = HubKeywords.allSettings,
                 )
             }
             }
@@ -394,7 +432,7 @@ fun SettingsHubScreen(
             // test-pinned to mirror the rendered rows, so reusing matchesHubQuery
             // over it tracks visibility exactly; a blank query matches every
             // section, so this branch only fires when the user has typed.
-            val hasResults = SettingsHubSections.any { matchesHubQuery(query, it.title, it.subtitle) }
+            val hasResults = SettingsHubSections.any { matchesHubQuery(query, it.title, it.subtitle, it.keywords) }
             if (!hasResults) {
                 Text(
                     text = stringResource(R.string.settings_hub_no_results, query.trim()),
@@ -424,11 +462,18 @@ internal fun SettingsHubRow(
     title: String,
     subtitle: String,
     onClick: () -> Unit,
+    /**
+     * Issue #1577 — non-obvious search synonyms + the names of the settings
+     * this row leads to, so hub search can surface a row for a knob buried in
+     * its subscreen (e.g. "dnd" → Voice & Playback). Empty for rows whose
+     * title/subtitle already cover every term a user would type.
+     */
+    keywords: List<String> = emptyList(),
 ) {
-    // Issue #773 — search filter. When [LocalSettingsHubQuery] is
-    // non-blank and matches neither title nor subtitle, the row
+    // Issue #773 / #1577 — search filter. When [LocalSettingsHubQuery] is
+    // non-blank and matches neither title, subtitle, nor any keyword, the row
     // skips itself so the hub collapses to just the matches.
-    if (!matchesHubQuery(LocalSettingsHubQuery.current, title, subtitle)) return
+    if (!matchesHubQuery(LocalSettingsHubQuery.current, title, subtitle, keywords)) return
     SettingsRow(
         title = title,
         subtitle = subtitle,
@@ -463,27 +508,99 @@ internal fun SettingsHubRow(
  *
  * Order matches the row order in [SettingsHubScreen]'s kdoc.
  */
-data class SettingsHubSection(val title: String, val subtitle: String)
+data class SettingsHubSection(
+    val title: String,
+    val subtitle: String,
+    /** Issue #1577 — hub search synonyms; see [SettingsHubRow.keywords]. */
+    val keywords: List<String> = emptyList(),
+)
+
+/**
+ * Issue #1577 — the hub-search keyword lists, defined once and referenced by
+ * BOTH the rendered [SettingsHubRow]s (so a row self-shows on a keyword hit)
+ * AND the [SettingsHubSections] catalog (so the "No results" line agrees with
+ * what's actually on screen). Keeping them in one place is what stops the two
+ * from drifting apart. Terms already present in a row's title/subtitle are not
+ * repeated here — [matchesHubQuery] scans all three.
+ */
+internal object HubKeywords {
+    // The flagship: sleep-timer + Do-Not-Disturb settings live in Voice &
+    // Playback (#1574). Every term a user might reach for lands them here.
+    val voicePlayback = listOf(
+        "sleep", "sleep timer", "bedtime", "dnd", "do not disturb", "timer",
+        "shake", "skip", "rewind", "speed", "pitch", "cadence", "punctuation",
+        "pause", "tts", "language", "pronunciation", "narration",
+    )
+    val voiceLibrary = listOf("voice", "narrator", "speaker", "download", "kokoro", "piper", "azure")
+    val reading = listOf(
+        "font", "text size", "dyslexic", "opendyslexic", "sepia", "cream",
+        "highlight", "karaoke", "theme", "dark", "light", "focus", "auto-scroll",
+        "autoscroll", "typography", "colour", "color", "line spacing", "contrast",
+    )
+    val stats = listOf("stats", "streak", "history", "finished", "time listened", "progress")
+    val briefing = listOf("briefing", "podcast", "digest", "morning", "episode", "queue")
+    val scripts = listOf("teleprompter", "script", "prompter", "rehearsal", "wpm", "words per minute")
+    val appearance = listOf(
+        "cover", "monogram", "animation", "motion", "particle", "confetti",
+        "skeleton", "shimmer", "brass pulse", "theme",
+    )
+    val performance = listOf(
+        "buffer", "cache", "prerender", "pre-render", "network", "patience",
+        "warm-up", "warmup", "catch-up", "determinism", "threads", "parallel synth",
+    )
+    val ai = listOf(
+        "chat", "model", "claude", "openai", "gpt", "ollama", "vertex", "bedrock",
+        "foundry", "recap", "grounding", "api key",
+    )
+    val accessibility = listOf(
+        "talkback", "contrast", "reduced motion", "font scale", "touch target",
+        "screen reader", "reading direction", "dyslexia", "a11y",
+    )
+    val aiSessions = listOf("sessions", "chats", "history", "delete history")
+    val plugins = listOf(
+        "sources", "backends", "voice families", "voice bundles", "enable", "disable",
+        "reddit", "notion", "prime gaming",
+    )
+    val pronunciation = listOf("pronunciation", "phonetic", "lexicon", "word override", "ipa")
+    val account = listOf("royal road", "github", "sign in", "login", "cloud sync", "oauth")
+    val memoryPalace = listOf("mempalace", "memory palace", "daemon", "host", "lan", "probe")
+    val bookshare = listOf("bookshare", "daisy", "accessible", "partner", "api key")
+    val advanced = listOf("android auto", "car", "items per category", "integration")
+    val developer = listOf("debug", "overlay", "log", "diagnostics", "reset onboarding", "verbose")
+    val about = listOf(
+        "version", "sigil", "build", "license", "open source", "handbook", "help",
+        "guide", "manual", "user guide", "privacy", "impact sharing", "accessibility statement",
+        "report content", "welcome", "tour", "replay",
+    )
+    val allSettings = listOf("everything", "all", "legacy", "full list")
+}
 
 val SettingsHubSections: List<SettingsHubSection> = listOf(
-    SettingsHubSection("Voice & Playback", "Voice, speed, cadence, pitch."),
-    SettingsHubSection("Voice library", "Browse and switch between available voices."),
-    SettingsHubSection("Reading", "Theme, sleep timer."),
+    SettingsHubSection("Voice & Playback", "Voice, speed, sleep timer, Do Not Disturb.", HubKeywords.voicePlayback),
+    SettingsHubSection("Voice library", "Browse and switch between available voices.", HubKeywords.voiceLibrary),
+    SettingsHubSection("Reading", "Theme, fonts, colours, highlight, focus.", HubKeywords.reading),
     // Issue #1235 — Listening stats dashboard.
-    SettingsHubSection("Listening stats", "Time listened, streaks, books finished."),
+    SettingsHubSection("Listening stats", "Time listened, streaks, books finished.", HubKeywords.stats),
+    // Issue #1467 — morning briefing / personal-podcast queue. Rendered inline
+    // in the composable; catalogued here (#1577) so search + "No results" agree.
+    SettingsHubSection("Morning Briefing", "One episode from your sources — HN, arXiv, RSS, GitHub.", HubKeywords.briefing),
+    // Issue #1369 — teleprompter script manager. Also rendered inline.
+    SettingsHubSection("Scripts", "Save, edit, and organize teleprompter scripts.", HubKeywords.scripts),
     // v0.5.59 (#cover-style-toggle) — Appearance.
-    SettingsHubSection("Appearance", "Book cover style."),
-    SettingsHubSection("Performance", "Buffer, parallel synth, decoder choice."),
-    SettingsHubSection("AI", "Chat model, grounding, recap."),
+    SettingsHubSection("Appearance", "Book cover style, animation, particles.", HubKeywords.appearance),
+    SettingsHubSection("Performance", "Buffer, parallel synth, decoder choice.", HubKeywords.performance),
+    SettingsHubSection("AI", "Chat model, grounding, recap.", HubKeywords.ai),
     // Phase 1 scaffold — v0.5.42. Phase 2 wires the actual behavior.
-    SettingsHubSection("Accessibility", "TalkBack, contrast, motion, font scale."),
-    SettingsHubSection("AI sessions", "Review past chats and delete history."),
-    SettingsHubSection("Plugins", "Toggle backends — Fiction, Audio streams, Voice bundles."),
-    SettingsHubSection("Pronunciation dictionary", "Per-word phonetic overrides."),
-    SettingsHubSection("Account", "Royal Road, GitHub."),
-    SettingsHubSection("Memory Palace", "Daemon host, probe, integration."),
-    SettingsHubSection("Advanced", "Android Auto, integration tunables."),
-    SettingsHubSection("Developer", "Debug overlay, log ring, advanced toggles."),
-    SettingsHubSection("About", "Version, sigil, open-source notices."),
-    SettingsHubSection("All settings", "Every setting on one long page (legacy)."),
+    SettingsHubSection("Accessibility", "TalkBack, contrast, motion, font scale.", HubKeywords.accessibility),
+    SettingsHubSection("AI sessions", "Review past chats and delete history.", HubKeywords.aiSessions),
+    SettingsHubSection("Plugins", "Toggle backends — Fiction, Audio streams, Voice bundles.", HubKeywords.plugins),
+    SettingsHubSection("Pronunciation dictionary", "Per-word phonetic overrides.", HubKeywords.pronunciation),
+    SettingsHubSection("Account", "Royal Road, GitHub.", HubKeywords.account),
+    SettingsHubSection("Memory Palace", "Daemon host, probe, integration.", HubKeywords.memoryPalace),
+    // Issue #1471 — Bookshare partner-key entry. Rendered inline; catalogued (#1577).
+    SettingsHubSection("Bookshare", "Accessible DAISY library · partner API key.", HubKeywords.bookshare),
+    SettingsHubSection("Advanced", "Android Auto, integration tunables.", HubKeywords.advanced),
+    SettingsHubSection("Developer", "Debug overlay, log ring, advanced toggles.", HubKeywords.developer),
+    SettingsHubSection("About", "Version, sigil, handbook, privacy, licenses.", HubKeywords.about),
+    SettingsHubSection("All settings", "Every setting on one long page (legacy).", HubKeywords.allSettings),
 )

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsSearchIndex.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsSearchIndex.kt
@@ -38,12 +38,22 @@ val SettingsSearchSections: List<SettingsSearchSection> = listOf(
         keywords = listOf(
             "tts", "engine", "kokoro", "piper", "sonic", "pitch",
             "punctuation", "pause", "pronunciation", "rate", "tempo",
+            // #1577 — the sleep-timer + transport knobs live in this section
+            // too; surface the terms a user actually types for them (the DND
+            // auto-sleep toggle of #1574 is the worked example).
+            "sleep", "timer", "dnd", "do not disturb", "bedtime", "shake",
+            "skip", "rewind", "speed", "cadence", "language",
         ),
     ),
     SettingsSearchSection(
         label = "Reading",
         descriptor = "How chapter text and the reader behave.",
-        keywords = listOf("theme", "dark", "light", "sleep", "timer", "shake"),
+        keywords = listOf(
+            "theme", "dark", "light", "sleep", "timer", "shake",
+            // #1577 — reading-comfort typography + highlight knobs (#992/#993/#994).
+            "font", "typography", "highlight", "karaoke", "dyslexic", "sepia",
+            "size", "spacing", "colour", "color",
+        ),
     ),
     SettingsSearchSection(
         label = "Performance & buffering",
@@ -98,6 +108,10 @@ val SettingsSearchSections: List<SettingsSearchSection> = listOf(
             "version", "sigil", "build", "license", "open source",
             // #1558 — the "Replay the welcome tour" row lives in the About surface.
             "welcome", "tour", "wizard", "replay",
+            // #1577 — the handbook (#1544), privacy policy (#1138), impact-sharing
+            // explainer (#1463), and content-report link all live under About.
+            "handbook", "help", "guide", "manual", "privacy", "impact",
+            "report", "content",
         ),
     ),
 )

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/VoiceAndPlaybackSettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/VoiceAndPlaybackSettingsScreen.kt
@@ -27,13 +27,21 @@ import `in`.jphe.storyvox.ui.theme.LocalSpacing
  * single-purpose surface reached from the [SettingsHubScreen] gear-
  * icon hub.
  *
- * Row order matches the legacy screen — most-touched first:
+ * Row order — most-touched first:
  *  1. Voice library link
  *  2. Speed slider (with the 1× tick anchor — #273)
  *  3. Pitch slider (with the 1× tick anchor)
  *  4. Punctuation cadence slider (#109)
  *  5. High-quality pitch interpolation switch (#193)
- *  6. Pronunciation dictionary link (#135)
+ *  6. Auto language detection switch (#1233)
+ *  7. Pronunciation dictionary link (#135)
+ *
+ * Then two labelled groups (#1577):
+ *  - **Playback controls** — skip distance (#593), rewind-to-start (#594).
+ *  - **Sleep timer** — shake-to-extend enable (#150, moved here from Reading)
+ *    + duration (#595), Bedtime auto-arm, and Do Not Disturb auto-sleep
+ *    (#1190/#1574). Consolidated so the whole sleep-timer feature lives on one
+ *    screen instead of straddling Reading and Voice & Playback.
  */
 @Composable
 fun VoiceAndPlaybackSettingsScreen(
@@ -159,6 +167,7 @@ fun VoiceAndPlaybackSettingsScreen(
             // controls how SkipPrevious behaves mid-chapter. Bundled
             // because the two prefs pair conceptually — users
             // calibrate them together for their content style.
+            SettingsSectionHeader(label = stringResource(R.string.settings_voice_transport_group_title))
             SettingsGroupCard {
                 // #593 — skip distance. Matches Spotify / Apple Music
                 // / Pocket Casts default of 30s; users on dense
@@ -193,6 +202,25 @@ fun VoiceAndPlaybackSettingsScreen(
                     options = rewindOptions.map { if (it == 0) rewindOffLabel else stringResource(R.string.settings_voice_rewind_option, it) },
                     selectedIndex = rewindSelectedIndex,
                     onSelected = { idx -> viewModel.setRewindToStartThresholdSec(rewindOptions[idx]) },
+                )
+            }
+
+            // Issue #1577 — sleep-timer settings, consolidated. Before this,
+            // the shake-to-extend ENABLE toggle lived under Settings → Reading
+            // while its DURATION, the Bedtime auto-arm, and the DND auto-sleep
+            // toggle (#1190/#1574) lived here — so no single screen held the
+            // whole feature and the flagship DND toggle was doubly buried. All
+            // four now sit together under one labelled "Sleep timer" group,
+            // enable → duration → auto-arm → Do Not Disturb.
+            SettingsSectionHeader(label = stringResource(R.string.settings_voice_sleep_group_title))
+            SettingsGroupCard {
+                // #150 — shake-to-extend enable (moved here from Reading in
+                // #1577 so it sits directly above the duration it governs).
+                SettingsSwitchRow(
+                    title = stringResource(R.string.settings_voice_shake_enable_title),
+                    subtitle = stringResource(R.string.settings_voice_shake_enable_subtitle),
+                    checked = s.sleepShakeToExtendEnabled,
+                    onCheckedChange = viewModel::setSleepShakeToExtendEnabled,
                 )
 
                 // Issue #595 — sleep-timer shake-to-extend duration.

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -657,13 +657,13 @@
     <string name="settings_hub_clear_search">Clear search</string>
     <string name="settings_hub_no_results">No settings match “%1$s”. Try a different term or clear the search.</string>
     <string name="settings_hub_voice_playback_title">Voice &amp; Playback</string>
-    <string name="settings_hub_voice_playback_subtitle">Voice, speed, cadence, pitch.</string>
+    <string name="settings_hub_voice_playback_subtitle">Voice, speed, sleep timer, Do Not Disturb.</string>
     <string name="settings_hub_voice_library_title">Voice library</string>
     <string name="settings_hub_voice_library_subtitle">Browse and switch between available voices.</string>
     <string name="settings_hub_reading_title">Reading</string>
-    <string name="settings_hub_reading_subtitle">Theme, sleep timer.</string>
+    <string name="settings_hub_reading_subtitle">Theme, fonts, colours, highlight, focus.</string>
     <string name="settings_hub_appearance_title">Appearance</string>
-    <string name="settings_hub_appearance_subtitle">Book cover style.</string>
+    <string name="settings_hub_appearance_subtitle">Book cover style, animation, particles.</string>
     <string name="settings_hub_performance_title">Performance</string>
     <string name="settings_hub_performance_subtitle">Buffer, parallel synth, decoder choice.</string>
     <string name="settings_hub_ai_title">AI</string>
@@ -687,7 +687,7 @@
     <string name="settings_hub_developer_title">Developer</string>
     <string name="settings_hub_developer_subtitle">Debug overlay, log ring, advanced toggles.</string>
     <string name="settings_hub_about_title">About</string>
-    <string name="settings_hub_about_subtitle">Version, sigil, open-source notices.</string>
+    <string name="settings_hub_about_subtitle">Version, sigil, handbook, privacy, licenses.</string>
     <!-- Issue #1235 — Listening stats hub row -->
     <string name="settings_hub_stats_title">Listening stats</string>
     <string name="settings_hub_stats_subtitle">Time listened, streaks, books finished.</string>
@@ -859,6 +859,11 @@
     <string name="settings_voice_bedtime_auto_subtitle">Auto-start the sleep timer when your phone enters Sleep or Bedtime mode.</string>
     <string name="settings_voice_dnd_sleep_title">Do Not Disturb with sleep timer</string>
     <string name="settings_voice_dnd_sleep_subtitle">Silence notifications while a sleep timer is running, then restore your previous setting when it ends. Needs Do Not Disturb access.</string>
+    <!-- #1577 — Voice &amp; Playback section headers + the shake-to-extend enable row moved here from Reading so the whole sleep-timer feature lives on one screen. -->
+    <string name="settings_voice_transport_group_title">Playback controls</string>
+    <string name="settings_voice_sleep_group_title">Sleep timer</string>
+    <string name="settings_voice_shake_enable_title">Shake to extend</string>
+    <string name="settings_voice_shake_enable_subtitle">Shake your device during the timer\'s fade-out to keep listening.</string>
 
     <!-- Settings · Performance subscreen -->
     <string name="settings_performance_title">Performance</string>

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsHubSectionsTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsHubSectionsTest.kt
@@ -27,16 +27,21 @@ import org.junit.Test
 class SettingsHubSectionsTest {
 
     @Test
-    fun `hub catalog renders seventeen sections in fixed order`() {
-        // 16 named sections + 1 escape hatch ("All settings"). The
+    fun `hub catalog renders twenty sections in fixed order`() {
+        // 19 named sections + 1 escape hatch ("All settings"). The
         // count bumped 13 → 14 in v0.5.42 (Accessibility scaffold);
         // 14 → 15 in v0.5.59 (Appearance / book cover style); 15 →
         // 16 in the v1 settings-bundle-7 (Advanced subscreen — #598
         // Android Auto bucket size and future integration tunables);
-        // 16 → 17 in #1235 (Listening stats dashboard). Adding a new
-        // section requires updating both this assertion AND the
-        // composable's row list — that drift is the point of pinning.
-        assertEquals(17, SettingsHubSections.size)
+        // 16 → 17 in #1235 (Listening stats dashboard); 17 → 20 in
+        // #1577, which catalogued the three rows the composable already
+        // rendered but the catalog had drifted from — Morning Briefing
+        // (#1467), Scripts (#1369), and Bookshare (#1471). That drift
+        // meant a search hitting only those rows still showed a false
+        // "No results" line, since the message reads the catalog.
+        // Adding a new section requires updating both this assertion AND
+        // the composable's row list — that drift is the point of pinning.
+        assertEquals(20, SettingsHubSections.size)
     }
 
     @Test
@@ -110,6 +115,59 @@ class SettingsHubSectionsTest {
         // leads the hub. If a reorder ever buries it, this test fails
         // first so the change is intentional.
         assertEquals("Voice & Playback", SettingsHubSections.first().title)
+    }
+
+    // ── Issue #1577 — hub keyword search ────────────────────────────
+
+    private fun sectionsMatching(query: String): List<String> =
+        SettingsHubSections
+            .filter { matchesHubQuery(query, it.title, it.subtitle, it.keywords) }
+            .map { it.title }
+
+    @Test
+    fun `flagship — DND and sleep synonyms surface Voice and Playback (#1574)`() {
+        // The worked example from #1574: the DND auto-sleep toggle lives in
+        // Voice & Playback but was unsearchable. Every term a user reaches for
+        // must now surface that row.
+        for (q in listOf("dnd", "do not disturb", "bedtime", "sleep", "sleep timer", "timer")) {
+            assertTrue(
+                "'$q' should surface Voice & Playback so the DND auto-sleep toggle is findable",
+                sectionsMatching(q).contains("Voice & Playback"),
+            )
+        }
+    }
+
+    @Test
+    fun `help and legal synonyms surface About`() {
+        // The handbook (#1544), privacy policy (#1138), and impact-sharing
+        // explainer (#1463) all live under About but its title/subtitle name
+        // none of them; keywords carry the discoverability.
+        for (q in listOf("handbook", "help", "guide", "manual", "privacy", "impact")) {
+            assertTrue(
+                "'$q' should surface About",
+                sectionsMatching(q).contains("About"),
+            )
+        }
+    }
+
+    @Test
+    fun `every catalogued row carries at least one search keyword`() {
+        // The #1577 discoverability contract: no row may be findable by its
+        // title alone — each carries synonyms + the names of the knobs inside.
+        for (section in SettingsHubSections) {
+            assertTrue(
+                "Hub row '${section.title}' has no search keywords (see #1577)",
+                section.keywords.isNotEmpty(),
+            )
+        }
+    }
+
+    @Test
+    fun `blank query still matches every row`() {
+        // Regression guard: the keyword layer must not change the unfiltered
+        // default — an empty search shows the whole hub.
+        assertEquals(SettingsHubSections.size, sectionsMatching("").size)
+        assertEquals(SettingsHubSections.size, sectionsMatching("   ").size)
     }
 
     @Test

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsSearchIndexTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsSearchIndexTest.kt
@@ -102,6 +102,30 @@ class SettingsSearchIndexTest {
     }
 
     @Test
+    fun `sleep-timer synonyms surface Voice and Playback (#1577)`() {
+        // The flagship: the sleep-timer + DND settings live in the Voice &
+        // Playback section, so every term a user types for them must reach it.
+        for (q in listOf("sleep", "dnd", "do not disturb", "bedtime", "shake")) {
+            assertTrue(
+                "'$q' should surface Voice & Playback",
+                matchingLabels(q).contains("Voice & Playback"),
+            )
+        }
+    }
+
+    @Test
+    fun `help synonyms surface About (#1577)`() {
+        // The handbook, privacy policy, and impact-sharing explainer all live
+        // under About; keywords make them findable by intent, not just by name.
+        for (q in listOf("handbook", "help", "guide", "privacy", "impact")) {
+            assertTrue(
+                "'$q' should surface About",
+                matchingLabels(q).contains("About"),
+            )
+        }
+    }
+
+    @Test
     fun `every section carries a non-blank label and descriptor`() {
         for (section in SettingsSearchSections) {
             assertFalse("Blank label", section.label.isBlank())


### PR DESCRIPTION
Closes #1577.

Audit-first, then implement in reviewable chunks. Full audit: `scratch/settings-audit.md` (+ `scratch/1577/audit-sources.md`, `scratch/1577/audit-features.md`).

## The problem
The settings **model** is already rich (~90 prefs in `UiSettings`/`SettingsRepositoryUi`). The gaps are **findability** and a few features that shipped a backend but never got Settings UI ("the Matrix precedent"). The flagship: the **DND auto-sleep toggle (#1574)** exists but was buried in Voice & Playback *and* unsearchable — hub search matched only a row's title/subtitle, so "dnd", "bedtime", "handbook", "privacy", "impact" all returned nothing.

## What this PR does

### Discoverability
- **Hub keyword search layer** — `SettingsHubRow`/`SettingsHubSection` gain a `keywords` list; `matchesHubQuery` now scans title + subtitle + keywords. Every row carries synonyms + the names of the knobs inside it. Keywords are internal search tokens (never rendered → not translated). Now "dnd / do not disturb / bedtime / sleep" → **Voice & Playback**; "handbook / help / privacy / impact" → **About**.
- **Catalog drift fixed** — `SettingsHubSections` had drifted from the rendered rows (Morning Briefing #1467, Scripts #1369, Bookshare #1471 were rendered but uncatalogued), so a search hitting only those showed a false "No results". Catalogued → **17 → 20**.
- **Mislabeled subtitles fixed** — Reading no longer promises "sleep timer" (it moved); Voice & Playback / About / Appearance subtitles now name what's inside.
- **Legacy `SettingsSearchIndex`** enriched with the same terms (kept clear of the 7 pinned exact-match queries).

### Consolidation (flagship)
- All four **sleep-timer** knobs now live under one "Sleep timer" group in Voice & Playback: shake-enable (**moved here from Reading**), duration, Bedtime auto-arm, DND auto-sleep. Skip/rewind split into a "Playback controls" group.

### Coverage
- **Slack** + **Matrix** source config surfaced via the existing generic config seam (#1531) — backends + setters already existed, just no UI (`SlackConfigContributor`/`MatrixConfigContributor` + `@IntoSet` bindings).
- **Focus reading mode** + **Auto-scroll** — reader toggles that had no Settings home (in-reader only) now have discoverable rows in Settings → Reading.

## Behavior changes
- **No defaults flipped.** DND auto-sleep stays **default-off** (JP's product call) — only made *findable*.
- Only relocation: the shake-to-extend enable toggle moved Reading → Voice & Playback (same pref key, behavior-neutral).

## Follow-ups (out of scope — documented in the audit)
- Sleep-timer **default duration/mode** pref (needs core-playback to consume it — task scoped me out of core-playback).
- Morning Briefing config UI; Google Drive "Connect" + AO3 Account row + Palace Library store (remaining "Matrix precedent" debt).
- **Full settings ES localization** — `values-es` is a 7% stub (0 settings strings today); new strings kept EN-only to match the 1000+ existing EN-only settings strings. A real ES pass is ~1000 strings / its own PR.

## Test plan
- `SettingsHubSectionsTest` — catalog size 20, flagship DND findability, keyword coverage, blank-query default.
- `SettingsSearchIndexTest` — new sleep/help synonym coverage; 7 pinned exact-match queries still hold.
- `SettingsSubscreenContractTest` — subscreens still present + catalogued.
- Accessibility: new controls use existing `SettingsSwitchRow` (TalkBack labels) + `SettingsSectionHeader` (`heading()` semantics).

_Do not merge — main session merges._ 🤖 Luna
