### PR TITLE
feat(settings): source-config coverage (Slack/Matrix) + reader read-along + DND label fix (#1577)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/data/SourceConfigContributors.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SourceConfigContributors.kt
@@ -157,3 +157,92 @@ class PrimeGamingConfigContributor @Inject constructor(
         }
     }
 }
+
+/**
+ * Slack bot-token BYOK (#454, surfaced #1577). The `SlackConfigImpl` backing
+ * store + setters shipped with the source, but the Settings UI the source's
+ * own kdoc promised ("Settings → Library & Sync → Slack") never landed — so
+ * the source was permanently gated to AuthRequired with no way to configure
+ * it. Routing the token through this contributor lights it up with no bespoke
+ * row. One token = one workspace (Slack has no multi-workspace token), so a
+ * single masked field is the whole surface.
+ */
+@Singleton
+class SlackConfigContributor @Inject constructor(
+    private val config: SlackConfigImpl,
+) : SourceConfigContributor {
+    override val sourceId: String = SourceIds.SLACK
+    override val displayName: String = "Slack"
+    override val sectionHelp: String =
+        "Read a Slack workspace's channels. Create an app at api.slack.com, " +
+            "install it to your workspace, and paste its Bot User OAuth Token."
+
+    override fun fields(): List<SourceConfigField> = listOf(
+        SourceConfigField.SecretText(
+            key = "token",
+            label = "Bot token",
+            help = "Bot User OAuth Token with the channels:read, channels:history, " +
+                "groups:read, groups:history, and users:read scopes.",
+            placeholder = "xoxb-…",
+        ),
+    )
+
+    override val values: Flow<Map<String, SourceConfigValue>> = config.state.map { s ->
+        mapOf("token" to SourceConfigValue.Secret(s.apiToken.isNotBlank()))
+    }
+
+    override suspend fun set(key: String, raw: String) {
+        when (key) {
+            "token" -> config.setApiToken(raw.ifBlank { null })
+        }
+    }
+}
+
+/**
+ * Matrix access-token BYOK (#457, surfaced #1577). Same "Matrix precedent"
+ * story as Slack — `MatrixConfigImpl` + setters shipped, the Settings UI never
+ * did. The source needs BOTH a homeserver URL and an access token before it can
+ * dispatch, so both are surfaced: homeserver as an editable URL field, token as
+ * a write-only secret. (Blank homeserver clears it; the coalesce-window knob
+ * keeps its default — the generic seam has no numeric field type yet.)
+ */
+@Singleton
+class MatrixConfigContributor @Inject constructor(
+    private val config: MatrixConfigImpl,
+) : SourceConfigContributor {
+    override val sourceId: String = SourceIds.MATRIX
+    override val displayName: String = "Matrix"
+    override val sectionHelp: String =
+        "Read a Matrix room as a fiction. Paste your homeserver URL and an " +
+            "access token (Element → Settings → Help & About → Advanced → Access Token). " +
+            "No password login."
+
+    override fun fields(): List<SourceConfigField> = listOf(
+        SourceConfigField.UrlText(
+            key = "homeserver",
+            label = "Homeserver URL",
+            help = "e.g. https://matrix.org, or your self-hosted Synapse / Dendrite / Conduit.",
+            placeholder = "https://matrix.org",
+        ),
+        SourceConfigField.SecretText(
+            key = "token",
+            label = "Access token",
+            help = "A homeserver access token (syt_… / mat_…) — never your password.",
+            placeholder = "syt_…",
+        ),
+    )
+
+    override val values: Flow<Map<String, SourceConfigValue>> = config.state.map { s ->
+        mapOf(
+            "homeserver" to SourceConfigValue.Text(s.homeserverUrl),
+            "token" to SourceConfigValue.Secret(s.accessToken.isNotBlank()),
+        )
+    }
+
+    override suspend fun set(key: String, raw: String) {
+        when (key) {
+            "homeserver" -> config.setHomeserverUrl(raw)
+            "token" -> config.setAccessToken(raw.ifBlank { null })
+        }
+    }
+}

--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -117,6 +117,18 @@ object AppBindings {
         impl: `in`.jphe.storyvox.data.PrimeGamingConfigContributor,
     ): `in`.jphe.storyvox.data.source.plugin.SourceConfigContributor = impl
 
+    // #1577 — Slack (#454) + Matrix (#457): backends shipped, Settings UI didn't.
+    // Route them through the generic config seam so they're configurable at last.
+    @Provides @Singleton @IntoSet
+    fun provideSlackConfigContributor(
+        impl: `in`.jphe.storyvox.data.SlackConfigContributor,
+    ): `in`.jphe.storyvox.data.source.plugin.SourceConfigContributor = impl
+
+    @Provides @Singleton @IntoSet
+    fun provideMatrixConfigContributor(
+        impl: `in`.jphe.storyvox.data.MatrixConfigContributor,
+    ): `in`.jphe.storyvox.data.source.plugin.SourceConfigContributor = impl
+
     /** Issue #1228 — bridges the `:feature` [DocumentImporterUi] seam to
      *  the app-side single-file import path (the same one MainActivity's
      *  "Open With" ingest uses), so the Library "Import a file…" picker can

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/ReadingSettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/ReadingSettingsScreen.kt
@@ -71,6 +71,9 @@ fun ReadingSettingsScreen(
     viewModel: SettingsViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
+    // #1577 — read-along toggles live on their own repo Flows (not in UiSettings).
+    val autoScrollEnabled by viewModel.readerAutoScrollEnabled.collectAsStateWithLifecycle()
+    val focusModeEnabled by viewModel.readerFocusModeEnabled.collectAsStateWithLifecycle()
     val spacing = LocalSpacing.current
 
     SettingsSubscreenScaffold(title = stringResource(R.string.settings_reading_title), onBack = onBack) { padding ->
@@ -91,6 +94,27 @@ fun ReadingSettingsScreen(
                 // Settings → Voice & Playback → "Sleep timer", where it sits with
                 // the rest of the sleep-timer knobs (duration, Bedtime auto-arm,
                 // Do Not Disturb). It was the odd one out here under Reading.
+            }
+
+            // Issue #1577 — read-along behaviour. Auto-scroll (#946) and Focused
+            // Reading (#997) shipped with in-reader IconButtons but no Settings
+            // home, so a user who wanted a different default — or who never found
+            // the in-reader control — had no discoverable path. These rows drive
+            // the same persisted prefs the reader controls do.
+            SettingsSectionHeader(label = stringResource(R.string.settings_reading_readalong_group_title))
+            SettingsGroupCard {
+                SettingsSwitchRow(
+                    title = stringResource(R.string.settings_reading_autoscroll_title),
+                    subtitle = stringResource(R.string.settings_reading_autoscroll_subtitle),
+                    checked = autoScrollEnabled,
+                    onCheckedChange = viewModel::setReaderAutoScrollEnabled,
+                )
+                SettingsSwitchRow(
+                    title = stringResource(R.string.settings_reading_focus_title),
+                    subtitle = stringResource(R.string.settings_reading_focus_subtitle),
+                    checked = focusModeEnabled,
+                    onCheckedChange = viewModel::setReaderFocusModeEnabled,
+                )
             }
 
             // #993 — reading-color theme (page overlay), separate from the

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsHubScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsHubScreen.kt
@@ -559,7 +559,7 @@ internal object HubKeywords {
     val aiSessions = listOf("sessions", "chats", "history", "delete history")
     val plugins = listOf(
         "sources", "backends", "voice families", "voice bundles", "enable", "disable",
-        "reddit", "notion", "prime gaming",
+        "reddit", "notion", "prime gaming", "slack", "matrix", "discord", "telegram",
     )
     val pronunciation = listOf("pronunciation", "phonetic", "lexicon", "word override", "ipa")
     val account = listOf("royal road", "github", "sign in", "login", "cloud sync", "oauth")

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsSearchIndex.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsSearchIndex.kt
@@ -79,6 +79,8 @@ val SettingsSearchSections: List<SettingsSearchSection> = listOf(
             "plugins", "sources", "epub", "outline", "wikipedia", "notion",
             "discord", "telegram", "inbox", "royal road", "kvmr", "wifi",
             "poll", "interval", "download",
+            // #1577 — credentialed sources whose config renders in this section.
+            "reddit", "slack", "matrix", "prime gaming", "bookshare", "github",
         ),
     ),
     SettingsSearchSection(

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
@@ -632,6 +632,33 @@ class SettingsViewModel @Inject constructor(
      *  the override → fall back to the reading-theme accent). */
     fun setWordHighlightColor(argb: Int) =
         viewModelScope.launch { repo.setWordHighlightColor(argb) }
+
+    // ── Reader read-along toggles (#946 auto-scroll, #997 focus mode) ──
+    // Issue #1577 — these ship with in-reader controls but had no Settings
+    // home, so a user who wanted them off by default (or who never found the
+    // in-reader button) had no discoverable path. Surfaced as standalone
+    // StateFlows rather than folded into [uiState], whose typed combine is
+    // already at its 5-flow ceiling.
+    val readerAutoScrollEnabled: StateFlow<Boolean> =
+        repo.readerAutoScrollEnabled.stateIn(
+            viewModelScope,
+            SharingStarted.WhileSubscribed(5_000),
+            true,
+        )
+    val readerFocusModeEnabled: StateFlow<Boolean> =
+        repo.readerFocusModeEnabled.stateIn(
+            viewModelScope,
+            SharingStarted.WhileSubscribed(5_000),
+            false,
+        )
+
+    /** Issue #946 — persist the reader auto-scroll (follow-along) toggle. */
+    fun setReaderAutoScrollEnabled(enabled: Boolean) =
+        viewModelScope.launch { repo.setReaderAutoScrollEnabled(enabled) }
+
+    /** Issue #997 — persist the Focused Reading toggle. */
+    fun setReaderFocusModeEnabled(enabled: Boolean) =
+        viewModelScope.launch { repo.setReaderFocusModeEnabled(enabled) }
 }
 
 /** Map the feature-layer enum to the :core-llm enum. The two are

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -703,6 +703,12 @@
     <string name="settings_reading_theme_subtitle">System matches the device\'s day/night.</string>
     <string name="settings_reading_shake_extend_title">Shake to extend sleep timer</string>
     <string name="settings_reading_shake_extend_subtitle">Shake during the fade-out to add 15 more minutes.</string>
+    <!-- #1577 — read-along behaviour toggles, surfaced from the reader's in-context controls. -->
+    <string name="settings_reading_readalong_group_title">Read-along</string>
+    <string name="settings_reading_autoscroll_title">Auto-scroll</string>
+    <string name="settings_reading_autoscroll_subtitle">Follow the narrated sentence down the page automatically.</string>
+    <string name="settings_reading_focus_title">Focused reading</string>
+    <string name="settings_reading_focus_subtitle">Dim the off-focus lines and centre the active line for distraction-free reading.</string>
 
     <!-- Settings · Reading-theme color overlay (#993) -->
     <string name="settings_reading_overlay_group_title">Reading colors</string>

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -861,10 +861,15 @@
     <string name="settings_voice_shake_extend_title">Sleep timer: shake-to-extend</string>
     <string name="settings_voice_shake_extend_subtitle">Minutes the timer extends when you shake during the 10-second fade tail.</string>
     <string name="settings_voice_shake_extend_option">%1$d min</string>
-    <string name="settings_voice_bedtime_auto_title">Sleep timer with Bedtime mode</string>
-    <string name="settings_voice_bedtime_auto_subtitle">Auto-start the sleep timer when your phone enters Sleep or Bedtime mode.</string>
-    <string name="settings_voice_dnd_sleep_title">Do Not Disturb with sleep timer</string>
-    <string name="settings_voice_dnd_sleep_subtitle">Silence notifications while a sleep timer is running, then restore your previous setting when it ends. Needs Do Not Disturb access.</string>
+    <!-- #1577 — these two are INVERSE features with confusingly-similar names
+         (half of why JP couldn't find #1574). Relabelled so the direction of
+         causation is obvious, and BOTH now name "Do Not Disturb" so either is
+         recognizable to a user thinking "dnd". #1574: phone Bedtime/DND → timer
+         auto-STARTS. #1190: timer running → DND auto-turns-ON. -->
+    <string name="settings_voice_bedtime_auto_title">Start timer in Bedtime or Do Not Disturb</string>
+    <string name="settings_voice_bedtime_auto_subtitle">When your phone enters Bedtime, Sleep, or Do Not Disturb mode, a sleep timer starts automatically.</string>
+    <string name="settings_voice_dnd_sleep_title">Turn on Do Not Disturb during a timer</string>
+    <string name="settings_voice_dnd_sleep_subtitle">The reverse: while a sleep timer is running, silence notifications with Do Not Disturb, then restore your previous setting when it ends. Needs Do Not Disturb access.</string>
     <!-- #1577 — Voice &amp; Playback section headers + the shake-to-extend enable row moved here from Reading so the whole sleep-timer feature lives on one screen. -->
     <string name="settings_voice_transport_group_title">Playback controls</string>
     <string name="settings_voice_sleep_group_title">Sleep timer</string>


### PR DESCRIPTION
Follow-up to #1587 (merged — hub keyword search + sleep-timer consolidation). Same issue (#1577); this PR lands the **coverage** half + the sibling-toggle disambiguation the review asked for. Branched off the post-#1587 `main`.

Audit: `scratch/settings-audit.md` (+ `1577/audit-sources.md`, `1577/audit-features.md`).

## Coverage — features that shipped a backend but never got Settings UI ("the Matrix precedent")
- **Slack** (`SlackConfigContributor`, #454) — bot-token field via the generic config seam (#1531). `SlackConfigImpl` + setters shipped; the "Settings → Slack" UI its own kdoc promised never did, so the source was permanently gated to AuthRequired. Now configurable.
- **Matrix** (`MatrixConfigContributor`, #457) — homeserver URL + access-token fields, same story. Both bound `@IntoSet` in `AppBindings`; they render in the source-config section and are keyword-findable (hub *Plugins* + legacy *Library & Sync*).
- **Focus reading** (#997) + **Auto-scroll** (#946) — reader toggles that had in-reader controls but no Settings home. Now in Settings → Reading → "Read-along", driving the same persisted prefs (standalone ViewModel StateFlows — `uiState`'s combine is at its 5-flow ceiling).

## Disambiguation — the sibling name collision (review follow-up)
Half of why JP couldn't find the sleep-timer/DND feature (#1574) was two **inverse** settings with near-identical names sitting side by side. Relabelled so the direction of causation is obvious and **both name "Do Not Disturb"** (so either is recognizable to a user thinking "dnd"; both already surface under the dnd/sleep/bedtime hub keywords from #1587):
- #1574 (phone Bedtime/DND ⇒ timer auto-starts): → **"Start timer in Bedtime or Do Not Disturb"**
- #1190 (timer running ⇒ DND auto-turns-on): → **"Turn on Do Not Disturb during a timer"** (subtitle opens "The reverse:")

## Constraints
- **No defaults flipped.** Bedtime-auto (#1574) stays default-OFF per JP's product call — only made findable + clearly labelled.
- **No core-playback changes** — settings UI + repo/DataStore plumbing only.
- **EN-only new strings**, deliberately: new rows land on existing English settings screens, so they match (the ES precedent — real per #1520 — is to fully translate *new* screens like Calls/GDrive, not to sprinkle ES into English ones). Full settings-ES localization is tracked in **#1583** (umbrella #1581).

## Test plan
- Existing `SettingsSearchIndexTest` (legacy Library & Sync keyword additions stay clear of the 7 pinned exact-match queries — verified via subsequence analysis).
- Slack/Matrix contributors flow through `SettingsRepositoryUiImpl`'s generic `Set<SourceConfigContributor>` path (build sections + route writes) — no bespoke wiring.
- New Reading toggles reuse `SettingsSwitchRow` (TalkBack) + `SettingsSectionHeader` (`heading()` semantics).

_Do not merge — main session merges._ 🤖 Luna
