### PR TITLE
feat(sleep): default bedtime/DND auto-sleep ON (#1574)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
@@ -1625,7 +1625,7 @@ class SettingsRepositoryUiImpl(
             sleepShakeExtendMinutes = snapSleepShakeExtendMinutes(
                 prefs[Keys.SLEEP_SHAKE_EXTEND_MINUTES] ?: 15,
             ),
-            sleepBedtimeAutoEnabled = prefs[Keys.SLEEP_BEDTIME_AUTO_ENABLED] ?: false,
+            sleepBedtimeAutoEnabled = prefs[Keys.SLEEP_BEDTIME_AUTO_ENABLED] ?: true,
             // Issue #1190 — auto Do Not Disturb while a sleep timer runs.
             dndWithSleepTimerEnabled = prefs[Keys.SLEEP_TIMER_DND_ENABLED] ?: false,
             // Issue #596 — pre-render window in chapters.
@@ -1937,7 +1937,7 @@ class SettingsRepositoryUiImpl(
     //     StoryvoxPlaybackService to auto-arm sleep timer on DND) ---
 
     override val bedtimeAutoSleepEnabled: Flow<Boolean> = store.data.map { prefs ->
-        prefs[Keys.SLEEP_BEDTIME_AUTO_ENABLED] ?: false
+        prefs[Keys.SLEEP_BEDTIME_AUTO_ENABLED] ?: true
     }
 
     override suspend fun isBedtimeAutoSleepEnabled(): Boolean =


### PR DESCRIPTION
JP's product decision (2026-07-04): the DND/Sleep-mode auto-arm should be on by default so it 'just works' as expected. Flips `SLEEP_BEDTIME_AUTO_ENABLED` default false→true at both read sites (state assembly + the Flow). Users who explicitly set OFF keep it; only the untouched default changes. On-device only (arms a local sleep timer), no data collected → no Data-Safety impact. Findability/naming already fixed in #1587/#1594.

Note: bug ② (#1574 — arm didn't fire in an inconclusive on-device test) is separately deprioritized; worst case this default is inert. Refs #1574.