### PR TITLE
fix(wallet): thread-safety + error handling in EncryptedFileWalletStore/WalletViewModel

### DIFF
--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/wallet/EncryptedFileWalletStore.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/wallet/EncryptedFileWalletStore.kt
@@ -11,6 +11,8 @@ import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
@@ -42,6 +44,25 @@ class EncryptedFileWalletStore @Inject constructor(
 
     private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
 
+    /**
+     * Issue #1593 — serializes every store operation. This is a
+     * `@Singleton` and the manifest is mutated read-modify-write
+     * (`save`/`delete` do `writeManifest(readManifest() ± doc)`), while
+     * `writeManifest` must delete-then-recreate the file (EncryptedFile
+     * refuses to overwrite). Without this lock two concurrent mutations
+     * lose an update, and a concurrent [list] that hits the delete→write
+     * window sees no manifest and returns empty — documents transiently
+     * "vanish". The same lock covers cache (de)materialization so
+     * [materializePagesToCache] / [clearMaterialized] / [delete] can't
+     * race on `wallet_tmp` or a doc dir. The wallet is user-paced, so full
+     * serialization costs nothing and is correct by construction.
+     *
+     * All public entry points take the lock; the private [readManifest] /
+     * [writeManifest] helpers never do, so there is no re-entrant acquire
+     * (Mutex is non-reentrant — that would deadlock).
+     */
+    private val mutex = Mutex()
+
     private val walletDir: File
         get() = File(context.filesDir, WALLET_DIR).apply { mkdirs() }
 
@@ -65,8 +86,10 @@ class EncryptedFileWalletStore @Inject constructor(
             EncryptedFile.FileEncryptionScheme.AES256_GCM_HKDF_4KB,
         ).build()
 
-    override suspend fun list(): List<WalletDoc> = withContext(Dispatchers.IO) {
-        readManifest().sortedByDescending { it.capturedAtEpochMs }
+    override suspend fun list(): List<WalletDoc> = mutex.withLock {
+        withContext(Dispatchers.IO) {
+            readManifest().sortedByDescending { it.capturedAtEpochMs }
+        }
     }
 
     override suspend fun save(
@@ -74,57 +97,65 @@ class EncryptedFileWalletStore @Inject constructor(
         title: String,
         note: String,
         pageUris: List<String>,
-    ): WalletDoc = withContext(Dispatchers.IO) {
-        val id = UUID.randomUUID().toString()
-        val docDir = File(walletDir, id).apply { mkdirs() }
-        var pages = 0
-        pageUris.forEach { uriString ->
-            val bytes = runCatching {
-                context.contentResolver.openInputStream(Uri.parse(uriString))?.use { it.readBytes() }
-            }.getOrNull() ?: return@forEach
-            val pageFile = File(docDir, "page_$pages.enc")
-            if (pageFile.exists()) pageFile.delete()
-            encrypted(pageFile).openFileOutput().use { it.write(bytes) }
-            pages++
+    ): WalletDoc = mutex.withLock {
+        withContext(Dispatchers.IO) {
+            val id = UUID.randomUUID().toString()
+            val docDir = File(walletDir, id).apply { mkdirs() }
+            var pages = 0
+            pageUris.forEach { uriString ->
+                val bytes = runCatching {
+                    context.contentResolver.openInputStream(Uri.parse(uriString))?.use { it.readBytes() }
+                }.getOrNull() ?: return@forEach
+                val pageFile = File(docDir, "page_$pages.enc")
+                if (pageFile.exists()) pageFile.delete()
+                encrypted(pageFile).openFileOutput().use { it.write(bytes) }
+                pages++
+            }
+            val doc = WalletDoc(
+                id = id,
+                type = type,
+                title = title.ifBlank { defaultTitle(type) }.trim(),
+                capturedAtEpochMs = System.currentTimeMillis(),
+                pageCount = pages,
+                note = note.trim(),
+            )
+            writeManifest(readManifest() + doc)
+            doc
         }
-        val doc = WalletDoc(
-            id = id,
-            type = type,
-            title = title.ifBlank { defaultTitle(type) }.trim(),
-            capturedAtEpochMs = System.currentTimeMillis(),
-            pageCount = pages,
-            note = note.trim(),
-        )
-        writeManifest(readManifest() + doc)
-        doc
     }
 
-    override suspend fun delete(docId: String): Unit = withContext(Dispatchers.IO) {
-        File(walletDir, docId).deleteRecursively()
-        writeManifest(readManifest().filterNot { it.id == docId })
+    override suspend fun delete(docId: String): Unit = mutex.withLock {
+        withContext(Dispatchers.IO) {
+            File(walletDir, docId).deleteRecursively()
+            writeManifest(readManifest().filterNot { it.id == docId })
+        }
     }
 
     override suspend fun materializePagesToCache(docId: String): List<String> =
-        withContext(Dispatchers.IO) {
-            val doc = readManifest().firstOrNull { it.id == docId } ?: return@withContext emptyList()
-            val docDir = File(walletDir, docId)
-            val outDir = File(tmpDir, docId).apply { mkdirs() }
-            val uris = mutableListOf<String>()
-            for (i in 0 until doc.pageCount) {
-                val enc = File(docDir, "page_$i.enc")
-                if (!enc.exists()) continue
-                val bytes = runCatching {
-                    encrypted(enc).openFileInput().use { it.readBytes() }
-                }.getOrNull() ?: continue
-                val out = File(outDir, "page_$i.jpg")
-                out.writeBytes(bytes)
-                uris += Uri.fromFile(out).toString()
+        mutex.withLock {
+            withContext(Dispatchers.IO) {
+                val doc = readManifest().firstOrNull { it.id == docId } ?: return@withContext emptyList()
+                val docDir = File(walletDir, docId)
+                val outDir = File(tmpDir, docId).apply { mkdirs() }
+                val uris = mutableListOf<String>()
+                for (i in 0 until doc.pageCount) {
+                    val enc = File(docDir, "page_$i.enc")
+                    if (!enc.exists()) continue
+                    val bytes = runCatching {
+                        encrypted(enc).openFileInput().use { it.readBytes() }
+                    }.getOrNull() ?: continue
+                    val out = File(outDir, "page_$i.jpg")
+                    out.writeBytes(bytes)
+                    uris += Uri.fromFile(out).toString()
+                }
+                uris
             }
-            uris
         }
 
-    override suspend fun clearMaterialized(): Unit = withContext(Dispatchers.IO) {
-        tmpDir.deleteRecursively()
+    override suspend fun clearMaterialized(): Unit = mutex.withLock {
+        withContext(Dispatchers.IO) {
+            tmpDir.deleteRecursively()
+        }
     }
 
     private fun readManifest(): List<WalletDoc> {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/docs/WalletViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/docs/WalletViewModel.kt
@@ -13,11 +13,14 @@ import `in`.jphe.storyvox.data.wallet.WalletDocType
 import `in`.jphe.storyvox.data.wallet.WalletProgramCatalog
 import `in`.jphe.storyvox.data.wallet.WalletStore
 import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 /**
  * Issue #1514 — drives the encrypted "My Documents" wallet.
@@ -67,16 +70,30 @@ class WalletViewModel @Inject constructor(
         if (pageUris.isEmpty()) return
         _state.update { it.copy(isSaving = true, error = null) }
         viewModelScope.launch {
-            store.save(type, title, note, pageUris)
-            val docs = store.list()
-            _state.update { it.copy(isSaving = false, docs = docs) }
+            try {
+                store.save(type, title, note, pageUris)
+                val docs = store.list()
+                _state.update { it.copy(isSaving = false, docs = docs) }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                // Encrypt/write can throw (disk full, keystore/MAC failure).
+                // Clear the spinner and surface it instead of crashing. (#1593)
+                _state.update { it.copy(isSaving = false, error = "Couldn't save that document.") }
+            }
         }
     }
 
     fun delete(docId: String) {
         viewModelScope.launch {
-            store.delete(docId)
-            _state.update { it.copy(docs = store.list()) }
+            try {
+                store.delete(docId)
+                _state.update { it.copy(docs = store.list()) }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                _state.update { it.copy(error = "Couldn't delete that document.") }
+            }
         }
     }
 
@@ -87,24 +104,36 @@ class WalletViewModel @Inject constructor(
         if (_state.value.isExporting) return
         _state.update { it.copy(isExporting = true, error = null) }
         viewModelScope.launch {
-            val uris = store.materializePagesToCache(docId)
-            if (uris.isEmpty()) {
-                _state.update { it.copy(isExporting = false, error = "Couldn't open that document.") }
-                return@launch
-            }
-            val result = pdfExporter.exportToPdf(
-                DocPdfRequest(title = title.ifBlank { "Document" }, pages = uris.map { DocPageRef(it) }),
-            )
-            store.clearMaterialized()
-            when (result) {
-                is DocPdfResult.Success -> {
-                    val ready = DocExportReady(result.filePath, result.fileName, result.pageCount, result.byteSize)
-                    _state.update { it.copy(isExporting = false, exportResult = ready, shareRequest = ready) }
+            try {
+                val uris = store.materializePagesToCache(docId)
+                if (uris.isEmpty()) {
+                    _state.update { it.copy(isExporting = false, error = "Couldn't open that document.") }
+                    return@launch
                 }
+                val result = pdfExporter.exportToPdf(
+                    DocPdfRequest(title = title.ifBlank { "Document" }, pages = uris.map { DocPageRef(it) }),
+                )
+                when (result) {
+                    is DocPdfResult.Success -> {
+                        val ready = DocExportReady(result.filePath, result.fileName, result.pageCount, result.byteSize)
+                        _state.update { it.copy(isExporting = false, exportResult = ready, shareRequest = ready) }
+                    }
 
-                is DocPdfResult.Failure -> _state.update {
-                    it.copy(isExporting = false, error = result.message)
+                    is DocPdfResult.Failure -> _state.update {
+                        it.copy(isExporting = false, error = result.message)
+                    }
                 }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                // materializePagesToCache / exportToPdf can throw on IO
+                // failure. Clear the spinner and surface it, don't crash. (#1593)
+                _state.update { it.copy(isExporting = false, error = "Couldn't export that document.") }
+            } finally {
+                // Always wipe the decrypted temp pages — on success, on
+                // failure, and even if the screen closes mid-export
+                // (NonCancellable) — so nothing decrypted lingers. (#1593)
+                withContext(NonCancellable) { runCatching { store.clearMaterialized() } }
             }
         }
     }

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/docs/WalletViewModelTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/docs/WalletViewModelTest.kt
@@ -7,6 +7,7 @@ import `in`.jphe.storyvox.data.wallet.WalletDoc
 import `in`.jphe.storyvox.data.wallet.WalletDocType
 import `in`.jphe.storyvox.data.wallet.WalletProgramCatalog
 import `in`.jphe.storyvox.data.wallet.WalletStore
+import java.io.IOException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -40,22 +41,29 @@ class WalletViewModelTest {
         var materialized: List<String> = listOf("file:///cache/p0.jpg", "file:///cache/p1.jpg")
         var cleared = 0
         var counter = 0
+        var throwOnSave = false
+        var throwOnMaterialize = false
         override suspend fun list(): List<WalletDoc> = docs.sortedByDescending { it.capturedAtEpochMs }
         override suspend fun save(type: WalletDocType, title: String, note: String, pageUris: List<String>): WalletDoc {
+            if (throwOnSave) throw IOException("encrypt/write failed")
             val doc = WalletDoc("id${counter++}", type, title.ifBlank { "Doc" }, 1000L + counter, pageUris.size, note)
             docs += doc
             return doc
         }
         override suspend fun delete(docId: String) { docs.removeAll { it.id == docId } }
-        override suspend fun materializePagesToCache(docId: String): List<String> =
-            if (docs.any { it.id == docId }) materialized else emptyList()
+        override suspend fun materializePagesToCache(docId: String): List<String> {
+            if (throwOnMaterialize) throw IOException("cache write failed")
+            return if (docs.any { it.id == docId }) materialized else emptyList()
+        }
         override suspend fun clearMaterialized() { cleared++ }
     }
 
     private class FakeExporter(var next: DocPdfResult) : DocPdfExporter {
         var lastRequest: DocPdfRequest? = null
+        var throwOnExport = false
         override suspend fun exportToPdf(request: DocPdfRequest): DocPdfResult {
             lastRequest = request
+            if (throwOnExport) throw IOException("pdf compose failed")
             return next
         }
     }
@@ -171,5 +179,62 @@ class WalletViewModelTest {
         dispatcher.scheduler.advanceUntilIdle()
         assertNull(vm.state.value.shareRequest)
         assertTrue(vm.state.value.error != null)
+    }
+
+    // ── error handling (#1593): a throwing store/exporter must not crash ─
+    //  the VM or wedge a spinner, and re-export must still wipe temp files.
+
+    @Test
+    fun `addDocument surfaces an error and clears the saving flag when the store throws`() = runTest(dispatcher) {
+        val store = FakeStore().apply { throwOnSave = true }
+        val vm = WalletViewModel(store, FakeExporter(okExport()))
+        vm.onUnlocked()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        vm.addDocument(WalletDocType.ID, "License", "", listOf("content://a"))
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertFalse(vm.state.value.isSaving)
+        assertTrue(vm.state.value.error != null)
+        assertTrue(vm.state.value.docs.isEmpty())
+    }
+
+    @Test
+    fun `reExport recovers, clears exporting, and still wipes temp files when materialize throws`() =
+        runTest(dispatcher) {
+            val store = FakeStore().apply {
+                docs += WalletDoc("doc1", WalletDocType.AWARD_LETTER, "Award letter", 5000L, 2)
+                throwOnMaterialize = true
+            }
+            val vm = WalletViewModel(store, FakeExporter(okExport()))
+            vm.onUnlocked()
+            dispatcher.scheduler.advanceUntilIdle()
+
+            vm.reExport("doc1", "Award letter")
+            dispatcher.scheduler.advanceUntilIdle()
+
+            assertFalse(vm.state.value.isExporting)
+            assertTrue(vm.state.value.error != null)
+            assertNull(vm.state.value.shareRequest)
+            assertEquals(1, store.cleared) // decrypted temp files wiped even on failure
+        }
+
+    @Test
+    fun `reExport recovers and still wipes temp files when the exporter throws`() = runTest(dispatcher) {
+        val store = FakeStore().apply {
+            docs += WalletDoc("doc1", WalletDocType.AWARD_LETTER, "Award letter", 5000L, 2)
+        }
+        val exporter = FakeExporter(okExport()).apply { throwOnExport = true }
+        val vm = WalletViewModel(store, exporter)
+        vm.onUnlocked()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        vm.reExport("doc1", "Award letter")
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertFalse(vm.state.value.isExporting)
+        assertTrue(vm.state.value.error != null)
+        assertNull(vm.state.value.shareRequest)
+        assertEquals(1, store.cleared)
     }
 }


### PR DESCRIPTION
Two Gemini HIGHs on the merged **My Documents** wallet (#1573) — non-blocking but real robustness. AES-256-GCM encryption + backup-exclusion are sound; these are the concurrency + error paths that audit didn't cover.

## 1. Unsynchronized `@Singleton` store → lost updates + vanishing docs
`EncryptedFileWalletStore` is a `@Singleton` doing **non-atomic read-modify-write** on a shared encrypted manifest:
- `save` → `writeManifest(readManifest() + doc)`, `delete` → `writeManifest(readManifest().filterNot{})` — two concurrent mutations interleave and **one clobbers the other**.
- `writeManifest` must `delete()` the file before rewriting (EncryptedFile refuses to overwrite). A concurrent `list()`/`readManifest()` landing in the **delete→write window** sees `!exists()` → returns `emptyList()`, so documents **transiently vanish** in the UI.
- `materializePagesToCache` (writes `wallet_tmp/<id>`) races `clearMaterialized` (`deleteRecursively`) and `delete`.

**Fix:** a single `kotlinx.coroutines.sync.Mutex` guards every public op (list/save/delete/materialize/clear). The private `readManifest`/`writeManifest` helpers stay lock-free, so there's **no re-entrant acquire** (Mutex is non-reentrant → would deadlock). Wallet is user-paced, so full serialization is free and correct-by-construction.

## 2. Unhandled throws in `WalletViewModel` → crash / stuck spinner / lingering plaintext
`store.save`, `store.materializePagesToCache`, and `pdfExporter.exportToPdf` ran in `viewModelScope.launch` with **no try/catch**. `materializePagesToCache`'s `out.writeBytes(bytes)` is unguarded, so an `IOException` (disk full, keystore/MAC failure) would:
- **crash the app** (uncaught in the coroutine),
- **wedge** `isSaving`/`isExporting = true` (spinner forever),
- in `reExport`, skip `clearMaterialized()` → **decrypted plaintext pages linger** in cache, breaking the wallet's core "nothing decrypted lingers" invariant.

**Fix:** wrap the coroutine bodies, **rethrow `CancellationException`** (don't break structured concurrency), surface a user-facing `error`, and move `clearMaterialized()` into a **`NonCancellable` `finally`** so temp files are wiped on success, on failure, and even on a mid-export screen close.

## Tests
3 new `WalletViewModel` cases (plain JVM, hand-rolled fakes) — save throws, materialize throws, exporter throws — assert the spinner clears, an error surfaces, and decrypted temp files are still wiped. No interface changes, so no fakes break.

Verified the bugs are present on `origin/main` (0 `Mutex`, 0 `catch` upstream) — this is a real fix, not a re-fix.

Ref #1573, #1514. Closes #1593