### PR TITLE
fix(google-drive): OAuth threading + empty-state error-type guard (#1588)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/auth/googledrive/GoogleDriveOAuthManager.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/auth/googledrive/GoogleDriveOAuthManager.kt
@@ -7,6 +7,8 @@ import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
 import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 /**
  * Issue #1496 — orchestrates the Google Drive OAuth flow end to end:
@@ -53,16 +55,23 @@ class GoogleDriveOAuthManager @Inject constructor(
      * Custom Tab, or null when this build has no OAuth client id (the
      * Connect button should be hidden in that case).
      */
-    fun beginConnect(): String? {
+    suspend fun beginConnect(): String? {
         if (!GoogleDriveOAuthConfig.isAvailable) return null
-        val state = UUID.randomUUID().toString()
-        val verifier = GoogleDrivePkce.newCodeVerifier()
-        config.setOAuthState(state)
-        config.setCodeVerifier(verifier)
-        return GoogleDriveOAuthConfig.authorizeUrl(
-            state = state,
-            codeChallenge = GoogleDrivePkce.challengeFor(verifier),
-        )
+        // #1588 — the PKCE verifier generation (SecureRandom) plus the two
+        // EncryptedSharedPreferences writes below all touch disk / Tink crypto
+        // and can block 50-200ms on first use. This is invoked from the Browse
+        // "Connect" tap on a Main-dispatcher coroutine, so do it on IO to keep
+        // the persist off the main thread (ANR risk).
+        return withContext(Dispatchers.IO) {
+            val state = UUID.randomUUID().toString()
+            val verifier = GoogleDrivePkce.newCodeVerifier()
+            config.setOAuthState(state)
+            config.setCodeVerifier(verifier)
+            GoogleDriveOAuthConfig.authorizeUrl(
+                state = state,
+                codeChallenge = GoogleDrivePkce.challengeFor(verifier),
+            )
+        }
     }
 
     /**
@@ -70,39 +79,46 @@ class GoogleDriveOAuthManager @Inject constructor(
      * single-use nonce + verifier first so a replayed redirect can't reuse
      * them.
      */
-    suspend fun handleCallback(code: String?, state: String?, error: String?): Outcome {
-        val expectedState = config.oauthState()
-        val verifier = config.codeVerifier()
-        config.clearOAuthTransient()
+    suspend fun handleCallback(code: String?, state: String?, error: String?): Outcome =
+        // #1588 — reads/clears the PKCE verifier + CSRF nonce and (on success)
+        // persists the session, all against EncryptedSharedPreferences
+        // (synchronous Tink crypto), plus the network token exchange. Invoked
+        // from MainActivity's lifecycleScope (Main), so run the disk + network
+        // work on IO; the returned Outcome resumes on the caller's dispatcher
+        // for the user-facing Toast.
+        withContext(Dispatchers.IO) {
+            val expectedState = config.oauthState()
+            val verifier = config.codeVerifier()
+            config.clearOAuthTransient()
 
-        if (error != null) {
-            Log.i(TAG, "Google Drive OAuth declined: $error")
-            return Outcome.Cancelled
-        }
-        if (code.isNullOrBlank() || state.isNullOrBlank() ||
-            expectedState.isNullOrBlank() || state != expectedState ||
-            verifier.isNullOrBlank()
-        ) {
-            Log.w(TAG, "Google Drive OAuth callback failed state/verifier verification")
-            return Outcome.InvalidCallback
-        }
+            if (error != null) {
+                Log.i(TAG, "Google Drive OAuth declined: $error")
+                return@withContext Outcome.Cancelled
+            }
+            if (code.isNullOrBlank() || state.isNullOrBlank() ||
+                expectedState.isNullOrBlank() || state != expectedState ||
+                verifier.isNullOrBlank()
+            ) {
+                Log.w(TAG, "Google Drive OAuth callback failed state/verifier verification")
+                return@withContext Outcome.InvalidCallback
+            }
 
-        return when (val r = api.exchangeCode(code = code, codeVerifier = verifier)) {
-            is GoogleDriveOAuthResult.Success -> {
-                config.saveOAuthSession(
-                    accessToken = r.accessToken,
-                    refreshToken = r.refreshToken,
-                )
-                runCatching { settings.get().setSourcePluginEnabled(SOURCE_ID, true) }
-                    .onFailure { Log.w(TAG, "auto-enable google-drive failed", it) }
-                Outcome.Connected(config.current().accountLabel)
-            }
-            is GoogleDriveOAuthResult.Failure -> {
-                Log.w(TAG, "Google Drive token exchange failed: ${r.code} ${r.message}")
-                Outcome.ExchangeFailed(r.message)
+            when (val r = api.exchangeCode(code = code, codeVerifier = verifier)) {
+                is GoogleDriveOAuthResult.Success -> {
+                    config.saveOAuthSession(
+                        accessToken = r.accessToken,
+                        refreshToken = r.refreshToken,
+                    )
+                    runCatching { settings.get().setSourcePluginEnabled(SOURCE_ID, true) }
+                        .onFailure { Log.w(TAG, "auto-enable google-drive failed", it) }
+                    Outcome.Connected(config.current().accountLabel)
+                }
+                is GoogleDriveOAuthResult.Failure -> {
+                    Log.w(TAG, "Google Drive token exchange failed: ${r.code} ${r.message}")
+                    Outcome.ExchangeFailed(r.message)
+                }
             }
         }
-    }
 
     private companion object {
         const val TAG = "GoogleDriveOAuth"

--- a/app/src/main/kotlin/in/jphe/storyvox/data/GoogleDriveConfigImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/GoogleDriveConfigImpl.kt
@@ -5,10 +5,13 @@ import `in`.jphe.storyvox.source.googledrive.config.GoogleDriveConfig
 import `in`.jphe.storyvox.source.googledrive.config.GoogleDriveConfigState
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
 
 /** EncryptedSharedPreferences key for the Google Drive OAuth access token.
  *  Lives next to the Notion / Outline / palace tokens in `storyvox.secrets`. */
@@ -47,10 +50,17 @@ class GoogleDriveConfigImpl @Inject constructor(
     /** Bumped on every write so [state] re-emits with fresh values. */
     private val secretsTick = MutableStateFlow(0L)
 
+    // #1588 — snapshot() reads EncryptedSharedPreferences (synchronous Tink
+    // crypto; the first touch after process start pays a 50-200ms keyset-init
+    // cost). flowOn(IO) keeps that decrypt off whatever thread collects `state`
+    // (SourceConfigContributors, the Settings UI), never the main thread.
     override val state: Flow<GoogleDriveConfigState> =
-        secretsTick.map { snapshot() }.distinctUntilChanged()
+        secretsTick.map { snapshot() }.flowOn(Dispatchers.IO).distinctUntilChanged()
 
-    override suspend fun current(): GoogleDriveConfigState = snapshot()
+    // #1588 — same encrypted read as `state`; both GoogleDriveSource.token()
+    // and the OAuth manager await this, so pin the decrypt to IO.
+    override suspend fun current(): GoogleDriveConfigState =
+        withContext(Dispatchers.IO) { snapshot() }
 
     private fun snapshot(): GoogleDriveConfigState = GoogleDriveConfigState(
         accessToken = secrets.getString(GDRIVE_ACCESS_TOKEN_PREF, "").orEmpty(),

--- a/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
@@ -1206,8 +1206,9 @@ class SettingsRepositoryUiImpl(
         coordinator: dagger.Lazy<SyncCoordinator>,
         // Issue #1534 — Lazy so construction doesn't pull the OAuth manager
         // into the graph early; `get().beginConnect()` runs only when the user
-        // taps "Connect Google Drive". beginConnect() is non-suspend + returns
-        // null when the build has no client id (button then hidden upstream).
+        // taps "Connect Google Drive". #1588 — beginConnect() is now suspend
+        // (persists PKCE + state on Dispatchers.IO) and returns null when the
+        // build has no client id (button then hidden upstream).
         googleDriveOAuth: dagger.Lazy<`in`.jphe.storyvox.auth.googledrive.GoogleDriveOAuthManager>,
     ) : this(
         context.settingsDataStore, auth, hydrator,

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -436,6 +436,14 @@ interface BrowsePaginator {
     val hasMore: Flow<Boolean>
     val error: Flow<String?>
 
+    /** #1588 — true when the most recent failure was specifically an
+     *  auth-required one (the source needs sign-in), as opposed to a network /
+     *  rate-limit / server error. Both otherwise collapse into a non-null
+     *  [error] string, so source-specific empty states (e.g. Browse's "Connect
+     *  Google Drive") need this to tell "sign in" apart from "the fetch failed".
+     *  Defaulted so non-paginating fakes/impls need no change. */
+    val authRequired: Flow<Boolean> get() = kotlinx.coroutines.flow.flowOf(false)
+
     suspend fun loadNext()
     /** Reset to page 1 (caller should follow with [loadNext]). Wired up
      *  for future pull-to-refresh; not used in v1 of the feature. */

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseScreen.kt
@@ -556,17 +556,23 @@ fun BrowseScreen(
                 NotionConnectEmptyState(onConnect = { showNotionManageSheet = true })
             // Issue #1534 — Google Drive chip lands on AuthRequired until the
             // user connects. AuthRequired is a FictionResult.Failure so it sets
-            // state.error (hence NO `error == null` guard here); this branch
-            // precedes the generic error state so the Connect CTA wins. The
-            // Connect button only shows when the build can run OAuth
-            // (googleDriveOAuthAvailable); otherwise the copy explains the
-            // source isn't set up in this build. Folder-grant Picker is a
-            // deferred follow-up (#1534 item 2 — needs a hosted authorized-JS-
-            // origin page); this surface makes the AuthRequired state actionable.
+            // state.error; this branch precedes the generic error state so the
+            // Connect CTA wins. #1588 — but ONLY for an auth failure (or no
+            // error at all): the paginator collapses every failure into the same
+            // error string, so we gate on state.authRequired to avoid rendering
+            // the misleading "Connect Google Drive" prompt on a transient
+            // network/server error (which must fall through to the generic error
+            // state). It also re-surfaces Connect if a stored token later expires
+            // (the source returns AuthRequired again). The Connect button only
+            // shows when the build can run OAuth (googleDriveOAuthAvailable);
+            // otherwise the copy explains the source isn't set up in this build.
+            // Folder-grant Picker is a deferred follow-up (#1534 item 2 — needs a
+            // hosted authorized-JS-origin page).
             state.sourceId == GOOGLE_DRIVE_SOURCE_ID &&
                 state.tab != BrowseTab.Search &&
                 state.items.isEmpty() &&
-                !state.isLoading ->
+                !state.isLoading &&
+                (state.error == null || state.authRequired) ->
                 GoogleDriveConnectEmptyState(
                     oauthAvailable = googleDriveConnection.oauthAvailable,
                     onConnect = {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/BrowseViewModel.kt
@@ -72,6 +72,11 @@ data class BrowseUiState(
     val isAppending: Boolean = false,
     val hasMore: Boolean = true,
     val error: String? = null,
+    /** #1588 — true when [error] is specifically an auth-required failure (the
+     *  source needs sign-in), not a transient network/rate-limit/server error.
+     *  Source empty states key off this so, e.g., a Google Drive network blip
+     *  doesn't render the misleading "Connect Google Drive" prompt. */
+    val authRequired: Boolean = false,
     val filterState: FilterState = FilterState(),
     val filterDimensions: List<FilterDimension> = emptyList(),
     val palaceFilter: MemPalaceFilter = MemPalaceFilter(),
@@ -117,6 +122,7 @@ private data class PaginatorView(
     val isAppending: Boolean,
     val hasMore: Boolean,
     val error: String?,
+    val authRequired: Boolean = false,
 )
 
 /** Bundled view of the user-controllable knobs. */
@@ -512,6 +518,11 @@ class BrowseViewModel @Inject constructor(
                 p.error,
             ) { items, loading, appending, more, error ->
                 PaginatorView(items, loading, appending, more, error)
+            }.combine(p.authRequired) { view, authReq ->
+                // #1588 — folded in via a nested combine (the 5-flow combine
+                // overload is maxed out) so the empty-state gate can see the
+                // auth-required axis, not just the collapsed error string.
+                view.copy(authRequired = authReq)
             }
             combine(paginatorView, controls, _palaceWings, notionAnonymousActive) { view, c, wings, notionAnon ->
                 val dims = registry.byId(c.sourceId)?.source?.filterDimensions().orEmpty()
@@ -524,6 +535,7 @@ class BrowseViewModel @Inject constructor(
                     isAppending = view.isAppending,
                     hasMore = view.hasMore,
                     error = view.error,
+                    authRequired = view.authRequired,
                     filterState = c.filterState,
                     filterDimensions = dims,
                     palaceFilter = c.palaceFilter,

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/RealBrowsePaginator.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/browse/RealBrowsePaginator.kt
@@ -34,6 +34,7 @@ class RealBrowsePaginator(
     private val _isAppending = MutableStateFlow(false)
     private val _hasMore = MutableStateFlow(true)
     private val _error = MutableStateFlow<String?>(null)
+    private val _authRequired = MutableStateFlow(false)
     private var nextPage = 1
     private val mutex = Mutex()
 
@@ -42,6 +43,7 @@ class RealBrowsePaginator(
     override val isAppending: Flow<Boolean> = _isAppending.asStateFlow()
     override val hasMore: Flow<Boolean> = _hasMore.asStateFlow()
     override val error: Flow<String?> = _error.asStateFlow()
+    override val authRequired: Flow<Boolean> = _authRequired.asStateFlow()
 
     override suspend fun loadNext() = mutex.withLock {
         if (!_hasMore.value || _isAppending.value || _isLoading.value) return@withLock
@@ -54,10 +56,16 @@ class RealBrowsePaginator(
                     _hasMore.value = res.value.hasNext
                     nextPage++
                     _error.value = null
+                    _authRequired.value = false
                 }
                 is FictionResult.Failure -> {
                     android.util.Log.w("storyvox", "Browse fetch failed: ${res.message}", res.cause)
                     _error.value = res.message
+                    // #1588 — preserve the failure axis the String error erases,
+                    // so an unconnected source can surface a "connect" CTA while a
+                    // transient network/server error falls through to the generic
+                    // error state.
+                    _authRequired.value = res is FictionResult.AuthRequired
                     // do NOT bump nextPage — next near-end retries the same page
                 }
             }
@@ -71,6 +79,7 @@ class RealBrowsePaginator(
         _items.value = emptyList()
         _hasMore.value = true
         _error.value = null
+        _authRequired.value = false
         nextPage = 1
     }
 }

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/browse/RealBrowsePaginatorTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/browse/RealBrowsePaginatorTest.kt
@@ -177,6 +177,59 @@ class RealBrowsePaginatorTest {
         assertNull(p.error.first())
     }
 
+    // -- #1588 authRequired axis ------------------------------------------------
+
+    @Test fun `AuthRequired failure raises authRequired alongside the error`() = runTest {
+        val fetch = RecordingFetch().apply {
+            queue(FictionResult.AuthRequired())
+        }
+        val p = RealBrowsePaginator(fetch())
+
+        p.loadNext()
+        assertTrue("AuthRequired must set authRequired", p.authRequired.first())
+        assertNotNull("AuthRequired still surfaces an error string", p.error.first())
+    }
+
+    @Test fun `non-auth Failure leaves authRequired false`() = runTest {
+        val fetch = RecordingFetch().apply {
+            queue(FictionResult.NetworkError("boom"))
+        }
+        val p = RealBrowsePaginator(fetch())
+
+        p.loadNext()
+        assertEquals(false, p.authRequired.first())
+        assertNotNull(p.error.first())
+    }
+
+    @Test fun `Success after AuthRequired clears the authRequired flag`() = runTest {
+        val fetch = RecordingFetch().apply {
+            queue(
+                FictionResult.AuthRequired(),
+                page(listOf(summary("a")), page = 1, hasNext = false),
+            )
+        }
+        val p = RealBrowsePaginator(fetch())
+
+        p.loadNext()
+        assertTrue(p.authRequired.first())
+
+        p.loadNext()
+        assertEquals(false, p.authRequired.first())
+    }
+
+    @Test fun `refresh clears the authRequired flag`() = runTest {
+        val fetch = RecordingFetch().apply {
+            queue(FictionResult.AuthRequired())
+        }
+        val p = RealBrowsePaginator(fetch())
+
+        p.loadNext()
+        assertTrue(p.authRequired.first())
+
+        p.refresh()
+        assertEquals(false, p.authRequired.first())
+    }
+
     @Test fun `loading flags are cleared in finally even on Failure`() = runTest {
         val fetch = RecordingFetch().apply {
             queue(FictionResult.NetworkError("boom"))


### PR DESCRIPTION
## What

Post-#1579/#1530 Google Drive OAuth hardening — the two verified Gemini HIGHs from #1588.

### 1. ANR risk — blocking disk I/O on the main thread
`GoogleDriveOAuthManager.beginConnect()` was non-suspending but persisted the PKCE verifier + CSRF `state` to `EncryptedSharedPreferences` **synchronously** (Tink crypto, ~50–200ms on first touch), invoked from `BrowseViewModel`'s `rememberCoroutineScope()` (Main dispatcher) on the Connect tap.

- `beginConnect()` → `suspend` + `withContext(Dispatchers.IO)`.
- `handleCallback()` is the same bug class (runs on `MainActivity.lifecycleScope` = Main): its encrypted reads/writes + token exchange now run on IO; the `Outcome` resumes on Main for the Toast.
- `GoogleDriveConfigImpl.state` → `flowOn(IO)`, `current()` → `withContext(IO)`, so the encrypted decrypt never lands on the collector's thread (covers `SourceConfigContributors`, `GoogleDriveSource.token()`).

### 2. Misleading empty state — no error-type guard
`BrowseScreen` rendered `GoogleDriveConnectEmptyState` on **any** `state.error`. `RealBrowsePaginator` collapses every `FictionResult.Failure` into a single error `String`, so a network / server / rate-limit blip showed "Connect Google Drive" to an already-connected user.

- Surface the auth axis the string erased: `BrowsePaginator` gains a **defaulted** `authRequired: Flow<Boolean>` (default → zero fake/impl churn), `RealBrowsePaginator` sets it from `res is FictionResult.AuthRequired`, it flows through `BrowseUiState.authRequired`, and the Connect branch is gated on `(error == null || authRequired)`.
- Bonus: correctly **re-surfaces** Connect when a stored token later expires (source returns `AuthRequired` again) — a plain "connected?" flag would not.

## Tests
4 new `RealBrowsePaginatorTest` cases: `authRequired` set on `AuthRequired`, cleared on `Success`/`refresh`, and false for `NetworkError`.

## Blast radius
- **:app** — `GoogleDriveOAuthManager`, `GoogleDriveConfigImpl`, `SettingsRepositoryUiImpl` (doc only)
- **:feature** — `BrowsePaginator` contract, `RealBrowsePaginator`, `BrowseViewModel`, `BrowseScreen`
- No Hilt graph changes · no new resource refs (non-transitive-R safe) · interface default keeps the ~fakes green.

Closes #1588

🤖 Generated with [Claude Code](https://claude.com/claude-code)
