### PR TITLE
fix(ui): Inbox tab badge overlap (#1600) + library chip gap + TechEmpower Browse icon

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
@@ -27,7 +27,6 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.DocumentScanner
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Badge
-import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -457,19 +456,33 @@ fun LibraryScreen(
                             },
                             text = {
                                 // Issue #383 — Inbox tab carries an unread-count
-                                // badge. BadgedBox positions the badge at the
-                                // top-right of the label without disturbing the
-                                // tab row's alignment. Zero unread = no badge
-                                // (same convention as FollowsScreen #290).
+                                // badge. Issue #1600 — the badge used to ride in
+                                // a BadgedBox, which anchors the badge to the
+                                // top-END corner of its content and offsets it
+                                // partly OVER the trailing glyphs. That's the
+                                // intended look over an icon, but over a text
+                                // label it painted the count on top of the last
+                                // letters — the tab read "Inbo②" instead of
+                                // "Inbox ②". Lay the label and the count out
+                                // inline in a Row so the count sits AFTER the
+                                // label with a gap — the same side-by-side Badge
+                                // convention FollowsScreen (#1153) already uses.
+                                // Zero unread = no badge (FollowsScreen #290).
                                 if (tab == LibraryTab.Inbox && state.inboxUnreadCount > 0) {
-                                    BadgedBox(
-                                        badge = {
-                                            Badge(
-                                                containerColor = MaterialTheme.colorScheme.primary,
-                                                contentColor = MaterialTheme.colorScheme.onPrimary,
-                                            ) {
-                                                Text(state.inboxUnreadCount.toString())
-                                            }
+                                    // a11y (#1153 pattern) — fold the otherwise
+                                    // bare count into one curated stop so
+                                    // TalkBack speaks "Inbox, 3 unread" rather
+                                    // than the label and a context-free "3".
+                                    val unreadCd = stringResource(
+                                        R.string.library_inbox_tab_unread_cd,
+                                        tab.label,
+                                        state.inboxUnreadCount,
+                                    )
+                                    Row(
+                                        verticalAlignment = Alignment.CenterVertically,
+                                        horizontalArrangement = Arrangement.spacedBy(spacing.xs),
+                                        modifier = Modifier.clearAndSetSemantics {
+                                            contentDescription = unreadCd
                                         },
                                     ) {
                                         Text(
@@ -478,6 +491,12 @@ fun LibraryScreen(
                                             maxLines = 1,
                                             softWrap = false,
                                         )
+                                        Badge(
+                                            containerColor = MaterialTheme.colorScheme.primary,
+                                            contentColor = MaterialTheme.colorScheme.onPrimary,
+                                        ) {
+                                            Text(state.inboxUnreadCount.toString())
+                                        }
                                     }
                                 } else {
                                     Text(
@@ -530,9 +549,22 @@ fun LibraryScreen(
                         // ShelfChipRow takes `weight(1f)` so its horizontal
                         // scroll can grow into the available width without
                         // pushing the sort chip off-screen.
+                        // #793 layered the sort chip trailing in this row and
+                        // gave the ShelfChipRow weight(1f) so the two never
+                        // truly overlap — each owns a slot. But the row had no
+                        // gap between them, so on a narrow width (Flip3 cover)
+                        // the weighted scroll region clipped its last chip
+                        // ("Wishlist") flush against the sort chip, reading as
+                        // if "Title" was crowding on top of "Wishlist".
+                        // spacedBy reserves a real gap between the scroll slot
+                        // and the sort chip, so the clip lands as a clean
+                        // partial-chip "scroll for more →" hint (same
+                        // discoverability idiom as the tab row #532) instead of
+                        // a jammed overlap.
                         Row(
                             modifier = Modifier.fillMaxWidth(),
                             verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(spacing.sm),
                         ) {
                             ShelfChipRow(
                                 selected = state.filter,

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/TechEmpowerHomeScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/TechEmpowerHomeScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Badge
 import androidx.compose.material.icons.filled.CalendarMonth
+import androidx.compose.material.icons.filled.Explore
 import androidx.compose.material.icons.filled.FactCheck
 import androidx.compose.material.icons.filled.Forum
 import androidx.compose.material.icons.filled.Info
@@ -174,10 +175,18 @@ fun TechEmpowerHomeScreen(
                 )
             }
             item {
+                // Issue #1600 assessment — this card used to pass icon = null.
+                // The original rationale ("a card without an icon balances the
+                // grid") held when the grid was four cards; it has since grown
+                // to nine and every sibling carries a leading icon, so the lone
+                // icon-less card read as broken rather than balanced. Explore
+                // (the compass) is the app's canonical Browse glyph — it's the
+                // Browse bottom-nav destination's icon — so it doubles as a
+                // preview of where this card lands (onOpenBrowse).
                 TechEmpowerCard(
                     title = "Browse Resources",
                     body = "Free tech guides, EBT support, and digital safety — read or listen.",
-                    icon = null,
+                    icon = Icons.Filled.Explore,
                     onClick = onOpenBrowse,
                 )
             }
@@ -340,10 +349,11 @@ private fun TechEmpowerHero() {
  * shouting; same vocabulary as the brass-edged cards on the Settings
  * hub and Plugin manager landing.
  *
- * The accompanying [icon] is optional — Browse Resources has no
- * single-icon analogue (it's "all of TechEmpower's content"), and a
- * card without an icon balances the grid layout. The other three
- * cards have a leading icon that anchors the affordance.
+ * The [icon] param stays nullable so previews / future cards can opt
+ * out, but every card in the live grid now supplies a leading glyph
+ * that anchors the affordance — an icon-less card among icon'd
+ * siblings reads as broken, not balanced (see #1600 assessment on the
+ * Browse Resources card, which was the last holdout).
  */
 @Composable
 private fun TechEmpowerCard(

--- a/feature/src/main/res/values-es/strings.xml
+++ b/feature/src/main/res/values-es/strings.xml
@@ -282,4 +282,8 @@
     <string name="form_fill_tool_text">Texto</string>
     <string name="library_fill_form">Completar un formulario (foto → PDF)</string>
     <!-- /#1512 -->
+    <!-- Issue #1600 — accesibilidad de la insignia de no leídos en la pestaña
+         Bandeja de entrada. Une la etiqueta y el conteo en una sola lectura de
+         TalkBack, p. ej. "Inbox, 3 sin leer". %1$s = etiqueta, %2$d = conteo. -->
+    <string name="library_inbox_tab_unread_cd">%1$s, %2$d sin leer</string>
 </resources>

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -351,6 +351,10 @@
     <string name="library_title">Library</string>
     <string name="library_resume">Resume</string>
     <string name="library_mark_all_read">Mark all read</string>
+    <!-- Issue #1600 — Inbox tab unread-badge a11y. Folds the tab label and
+         the otherwise context-free count into one curated TalkBack stop, e.g.
+         "Inbox, 3 unread". %1$s = tab label, %2$d = unread count. -->
+    <string name="library_inbox_tab_unread_cd">%1$s, %2$d unread</string>
     <string name="library_shelf_all">All</string>
     <string name="library_add_by_url_label">URL</string>
     <string name="library_add_by_url_placeholder">https://…</string>


### PR DESCRIPTION
## Summary
UI-fix sprint from QA-testing v1.12.0. One filed bug + two assessment items from the same pass.

### #1600 (PRIMARY) — Inbox tab unread badge overlaps the label
The Library top-tab **Inbox** unread badge rendered *on top of* the label — the tab read **`Inbo②`** instead of **`Inbox ②`**.

**Root cause:** the badge rode in a `BadgedBox`, which by design anchors the badge to the **top-END corner of its content and offsets it partly over the trailing glyphs**. That's the intended look over an *icon*, but over a *text label* it painted the count on top of the last letters.

**Fix:** lay the label + count out inline in a `Row` — the same side-by-side `Badge` convention `FollowsScreen` (#1153) already uses — so the count sits **after** the label with a gap. Also folds the otherwise context-free count into a curated `contentDescription` so TalkBack speaks **"Inbox, 3 unread"** rather than the label followed by a bare "3". New string added in **EN + ES**.

### Assessment 1 — Library shelf-chip row / sort chip crowding → **FIXED**
The trailing sort chip and the scrollable shelf chips each already own a `weight(1f)` slot, so there's **no true overlap** — but the row had **no gap** between them. On a narrow width (Flip3 cover) the scroll slot clipped its last chip (**"Wishlist"**) flush against the sort chip, reading as if "Title" was crowding on top of it. Added `Arrangement.spacedBy` so the clip lands as a clean partial-chip *"scroll for more →"* hint (same discoverability idiom as the tab row #532) instead of a jammed overlap.

### Assessment 2 — TechEmpower "Browse Resources" card missing icon → **FIXED**
"Browse Resources" was the **lone icon-less card among eight icon'd siblings**. The code documented this as intentional ("a card without an icon balances the grid"), but that rationale predates the grid growing from **four cards to nine** — the holdout now reads as broken, not balanced. Added `Icons.Filled.Explore`, the app's canonical **Browse-destination** glyph (matches the Browse bottom-nav tab), so the icon also previews where the card navigates (`onOpenBrowse`).

## Files
- `feature/.../library/LibraryScreen.kt` — badge Row + a11y CD; chip-row gap
- `feature/.../techempower/TechEmpowerHomeScreen.kt` — Browse Resources icon + kdoc
- `feature/src/main/res/values/strings.xml` + `values-es/` — `library_inbox_tab_unread_cd` (EN/ES)

## Testing
No local gradle — CI `Build APK` is the compile gate. Team-lead verifies all three on-device after CI.

Closes #1600

🤖 Generated with [Claude Code](https://claude.com/claude-code)