### PR TITLE
fix(sleep): fix shake-toggle clobber + instrument DND auto-arm & shake-extend (#1574 #1595)

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackController.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackController.kt
@@ -344,7 +344,11 @@ class DefaultPlaybackController @Inject constructor(
                 // subsequent play() reuse the stale chapter id without an
                 // explicit retry. Don't clear the id here — the sibling
                 // UI uses it to render "Couldn't play '$chapterTitle'."
-                _state.value = update.copy(sleepTimerRemainingMs = sleepTimer.remainingMs.value)
+                // #1595 — preserve controller-owned fields (shakeToExtendEnabled)
+                // that the engine leaves at data-class defaults; a naive
+                // update.copy(...) clobbered the user's toggle back to true on
+                // every poll. See PlaybackState.withEngineUpdate.
+                _state.value = prev.withEngineUpdate(update, sleepTimer.remainingMs.value)
                 // #524 — if the engine reports BookFinished via the events
                 // channel (collected below), the listener pipeline goes idle.
                 // We additionally watch for an authoritative isPlaying=false

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackState.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackState.kt
@@ -224,3 +224,31 @@ fun PlaybackState.extrapolatedScrubProgress(elapsedSinceBeaconMs: Long): Float {
 
 const val SPEED_BASELINE_WPM = 150f
 const val SPEED_BASELINE_CHARS_PER_SECOND = SPEED_BASELINE_WPM * 5f / 60f
+
+/**
+ * #1595 corollary — merge a fresh engine [PlaybackState] into the
+ * controller's previous state while preserving the fields the controller
+ * owns and the engine never sets.
+ *
+ * [in.jphe.storyvox.playback.tts.EnginePlayer] emits a full
+ * [PlaybackState] but only ever writes the playback-engine fields
+ * (`isPlaying`, `isBuffering`, sentence range, voice, error, …). Fields
+ * the *controller* owns — notably [shakeToExtendEnabled], which is driven
+ * from Settings via `AppBindings` — sit at their data-class defaults in
+ * the engine's copy. A naive `engine.copy(...)` therefore clobbered the
+ * user's shake-to-extend choice back to the default `true` on every
+ * ~50 ms engine poll, so turning the toggle **off** never stuck (found
+ * during the #1595 investigation). Preserve it from `this` (the prior
+ * controller state).
+ *
+ * [sleepTimerRemainingMs] is passed explicitly because it is owned by a
+ * third writer (the `SleepTimer` collector) and must reflect the timer's
+ * live value, not the engine copy's stale default.
+ */
+internal fun PlaybackState.withEngineUpdate(
+    engine: PlaybackState,
+    sleepTimerRemainingMs: Long?,
+): PlaybackState = engine.copy(
+    sleepTimerRemainingMs = sleepTimerRemainingMs,
+    shakeToExtendEnabled = this.shakeToExtendEnabled,
+)

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/SleepTimerDecisions.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/SleepTimerDecisions.kt
@@ -1,0 +1,71 @@
+package `in`.jphe.storyvox.playback
+
+/**
+ * Pure, Android-free decision functions for the sleep-timer auto-arm
+ * (#1574) and shake-to-extend (#150 / #595 / #1595) paths.
+ *
+ * Extracted from [StoryvoxPlaybackService] so the exact gating logic is
+ * unit-testable without instantiating the service (which needs Hilt, a
+ * `MediaSession`, and a live process). The service stays a thin Android
+ * shell that reads system state, calls these, and logs the decision; the
+ * *rules* live here where a JVM test can pin them.
+ */
+
+/**
+ * #1574 — should entering Do Not Disturb auto-arm the sleep timer?
+ *
+ * True iff DND just became active AND we're actively playing AND no
+ * timer is already running.
+ *
+ * @param dndActive the interruption filter moved away from
+ *   `INTERRUPTION_FILTER_ALL` (DND / Bedtime / Sleep turned on). The
+ *   caller derives this from `NotificationManager.currentInterruptionFilter`
+ *   so this function stays Android-free — and so the raw filter Int can
+ *   be logged at the call site (see the #1574 ② instrumentation).
+ * @param isPlaying playback is active. NOTE (#557 invariant): the engine
+ *   keeps `isPlaying = true` through buffering / synth gaps and only the
+ *   MediaSession surface flips to `STATE_BUFFERING` — so a genuine
+ *   `PLAYING(3)` media state implies this is `true`. It is therefore
+ *   **not** the cause of a missed arm when the phone shows PLAYING; that
+ *   refutes the original #1574 ② hypothesis.
+ * @param sleepTimerRunning a timer is already counting down; re-arming
+ *   would reset the user's countdown, so we skip.
+ */
+fun shouldArmBedtimeSleep(
+    dndActive: Boolean,
+    isPlaying: Boolean,
+    sleepTimerRunning: Boolean,
+): Boolean = dndActive && isPlaying && !sleepTimerRunning
+
+/**
+ * #150 / #1595 — should the accelerometer be listening for a
+ * shake-to-extend gesture right now?
+ *
+ * True iff the user hasn't opted out AND an armed timer is inside its
+ * fade tail (`0 <= remaining <= fadeWindowMs`). Outside the fade tail the
+ * sensor stays off so long playback sessions don't drain battery. A
+ * `null` remaining (no timer) maps to "not listening".
+ *
+ * The [shakeEnabled] gate is why the #1595 investigation's clobber fix
+ * matters: if the engine-state merge resets the toggle to its default,
+ * this gate can never observe the user's OFF choice (it was stuck true).
+ */
+fun shouldListenForShake(
+    sleepTimerRemainingMs: Long?,
+    shakeEnabled: Boolean,
+    fadeWindowMs: Long,
+): Boolean = shakeEnabled && (sleepTimerRemainingMs ?: -1L) in 0L..fadeWindowMs
+
+/**
+ * #150 / #1595 — when a shake fires, should it extend the timer?
+ *
+ * Guards the re-arm to the fade tail so a shake registered a beat after
+ * the timer already paused (or while no timer is running) is ignored.
+ * Mirrors [shouldListenForShake] without the enable gate — the detector
+ * only runs while enabled, so a fired callback is already past that
+ * check.
+ */
+fun shouldExtendOnShake(
+    sleepTimerRemainingMs: Long?,
+    fadeWindowMs: Long,
+): Boolean = (sleepTimerRemainingMs ?: -1L) in 0L..fadeWindowMs

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/StoryvoxPlaybackService.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/StoryvoxPlaybackService.kt
@@ -12,6 +12,7 @@ import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.app.TaskStackBuilder
+import androidx.core.content.ContextCompat
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
@@ -188,33 +189,54 @@ class StoryvoxPlaybackService : MediaSessionService() {
         shakeDetector = ShakeDetector(
             context = applicationContext,
             onShake = {
-                if (controller.state.value.sleepTimerRemainingMs?.let { it <= SHAKE_FADE_WINDOW_MS } == true) {
-                    // Issue #595 — read the user-tunable extend
-                    // duration from the config contract instead of the
-                    // legacy hardcoded constant. Off-main launch so the
-                    // suspend read doesn't block the accelerometer
-                    // callback. `currentShakeExtendMinutes` falls back
-                    // to 15 (the legacy value) when the store hasn't
-                    // emitted yet.
+                val remaining = controller.state.value.sleepTimerRemainingMs
+                // Issue #1595 — gate the re-arm to the fade tail via the
+                // pure [shouldExtendOnShake] decision so a jolt landing a
+                // beat after the timer paused is ignored.
+                if (shouldExtendOnShake(remaining, SHAKE_FADE_WINDOW_MS)) {
+                    // Issue #595 — read the user-tunable extend duration
+                    // from the config contract instead of the legacy
+                    // hardcoded constant. Off-main launch so the suspend
+                    // read doesn't block the accelerometer callback.
+                    // `currentShakeExtendMinutes` falls back to 15 (the
+                    // legacy value) when the store hasn't emitted yet.
+                    Log.i(TAG, "Shake-to-extend: shake detected in fade tail (remaining=${remaining}ms) — extending")
                     scope.launch {
                         val minutes = sleepExtendConfig.currentShakeExtendMinutes()
                         controller.startSleepTimer(SleepTimerMode.Duration(minutes))
                     }
+                } else {
+                    // #1595 instrumentation — a shake fired but outside the
+                    // fade tail. If an on-device repro shows this line but
+                    // no "extending", the detector is armed too early/late;
+                    // if it shows NO shake lines at all while the fade-tail
+                    // "accelerometer registered" line is present, the
+                    // gesture isn't crossing the detector threshold.
+                    Log.d(TAG, "Shake-to-extend: shake ignored — not in fade tail (remaining=${remaining}ms)")
                 }
             },
         )
         shakeJob = scope.launch {
             controller.state
-                .map { (it.sleepTimerRemainingMs ?: -1L) to it.shakeToExtendEnabled }
+                .map { it.sleepTimerRemainingMs to it.shakeToExtendEnabled }
                 .distinctUntilChanged()
                 .collect { (remaining, enabled) ->
-                    val inFadeWindow = enabled && remaining in 0L..SHAKE_FADE_WINDOW_MS
+                    // Issue #1595 — pure [shouldListenForShake] gate: listen
+                    // only while the user opted in AND an armed timer is in
+                    // its 10s fade tail.
+                    val inFadeWindow = shouldListenForShake(remaining, enabled, SHAKE_FADE_WINDOW_MS)
                     if (inFadeWindow && !shakeListening) {
-                        shakeDetector?.start()
+                        val started = shakeDetector?.start() ?: false
                         shakeListening = true
+                        Log.i(
+                            TAG,
+                            "Shake-to-extend: fade tail entered (remaining=${remaining}ms) — " +
+                                "accelerometer ${if (started) "registered" else "FAILED to register"}",
+                        )
                     } else if (!inFadeWindow && shakeListening) {
                         shakeDetector?.stop()
                         shakeListening = false
+                        Log.d(TAG, "Shake-to-extend: fade tail exited — accelerometer released")
                     }
                 }
         }
@@ -229,11 +251,28 @@ class StoryvoxPlaybackService : MediaSessionService() {
             override fun onReceive(context: Context, intent: Intent?) {
                 if (intent?.action != NotificationManager.ACTION_INTERRUPTION_FILTER_CHANGED) return
                 val nm = context.getSystemService(NotificationManager::class.java)
-                val filter = nm.currentInterruptionFilter
-                if (filter != NotificationManager.INTERRUPTION_FILTER_ALL &&
-                    controller.state.value.isPlaying &&
-                    controller.state.value.sleepTimerRemainingMs == null
-                ) {
+                // Null nm → treat as ALL so we don't spuriously arm.
+                val filter = nm?.currentInterruptionFilter
+                    ?: NotificationManager.INTERRUPTION_FILTER_ALL
+                val dndActive = filter != NotificationManager.INTERRUPTION_FILTER_ALL
+                val playing = controller.state.value.isPlaying
+                val timerRunning = controller.state.value.sleepTimerRemainingMs != null
+                // #1574 ② — entry-level breadcrumb. The prior code only
+                // logged INSIDE the arm branch, so an on-device repro could
+                // not distinguish "onReceive never fired" (delivery problem:
+                // NO line at all) from "fired but a gate failed" (this line
+                // present with armed=false). Logs the raw filter Int + all
+                // three gate inputs so the failing condition is unambiguous.
+                // (The #557 invariant means `isPlaying` is true whenever the
+                // MediaSession shows PLAYING — so if this logs isPlaying=false
+                // during audible playback, that's a *new* finding.)
+                val arm = shouldArmBedtimeSleep(dndActive, playing, timerRunning)
+                Log.i(
+                    TAG,
+                    "Bedtime auto-sleep: filter changed (filter=$filter dndActive=$dndActive " +
+                        "isPlaying=$playing timerRunning=$timerRunning) → arm=$arm",
+                )
+                if (arm) {
                     scope.launch {
                         val minutes = sleepExtendConfig.currentShakeExtendMinutes()
                         controller.startSleepTimer(SleepTimerMode.Duration(minutes))
@@ -247,14 +286,30 @@ class StoryvoxPlaybackService : MediaSessionService() {
                 .distinctUntilChanged()
                 .collect { enabled ->
                     if (enabled && !dndReceiverRegistered) {
-                        registerReceiver(
-                            dndReceiver,
-                            IntentFilter(NotificationManager.ACTION_INTERRUPTION_FILTER_CHANGED),
-                        )
-                        dndReceiverRegistered = true
+                        // #1218 / #1574 hygiene — target SDK 36 requires an
+                        // explicit export flag; ContextCompat picks
+                        // RECEIVER_NOT_EXPORTED on T+ and no-ops below it.
+                        // Wrapped in runCatching because Samsung One UI has
+                        // thrown SecurityException on notification-policy
+                        // APIs (#1218); a throw here previously killed the
+                        // collector coroutine so the receiver silently never
+                        // registered even with the setting ON.
+                        val ok = runCatching {
+                            ContextCompat.registerReceiver(
+                                this@StoryvoxPlaybackService,
+                                dndReceiver,
+                                IntentFilter(NotificationManager.ACTION_INTERRUPTION_FILTER_CHANGED),
+                                ContextCompat.RECEIVER_NOT_EXPORTED,
+                            )
+                        }.onFailure {
+                            Log.w(TAG, "Bedtime auto-sleep: registerReceiver failed: ${it.message}")
+                        }.isSuccess
+                        dndReceiverRegistered = ok
+                        Log.i(TAG, "Bedtime auto-sleep: receiver ${if (ok) "registered" else "registration FAILED"}")
                     } else if (!enabled && dndReceiverRegistered) {
-                        unregisterReceiver(dndReceiver)
+                        runCatching { unregisterReceiver(dndReceiver) }
                         dndReceiverRegistered = false
+                        Log.i(TAG, "Bedtime auto-sleep: receiver unregistered (setting off)")
                     }
                 }
         }
@@ -427,7 +482,9 @@ class StoryvoxPlaybackService : MediaSessionService() {
         shakeDetector = null
         shakeJob = null
         if (dndReceiverRegistered) {
-            unregisterReceiver(dndReceiver)
+            // runCatching: unregister can throw if the receiver never
+            // fully registered (e.g. a SecurityException swallowed above).
+            runCatching { unregisterReceiver(dndReceiver) }
             dndReceiverRegistered = false
         }
         dndReceiver = null

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/PlaybackStateTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/PlaybackStateTest.kt
@@ -1,9 +1,50 @@
 package `in`.jphe.storyvox.playback
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class PlaybackStateTest {
+
+    // ── #1595 — engine-state merge preserves controller-owned fields ──
+
+    @Test fun `withEngineUpdate preserves the user's shake-to-extend OFF choice`() {
+        // Regression for the #1595 clobber: the engine never sets
+        // shakeToExtendEnabled, so its copy carries the data-class default
+        // (true). A naive engine.copy(...) reset the user's OFF back to ON
+        // on every ~50ms poll. withEngineUpdate must keep the controller's
+        // value from `prev`.
+        val prev = PlaybackState(shakeToExtendEnabled = false, isPlaying = false)
+        val engine = PlaybackState(shakeToExtendEnabled = true, isPlaying = true)
+
+        val merged = prev.withEngineUpdate(engine, sleepTimerRemainingMs = null)
+
+        assertFalse("user OFF must survive the engine merge", merged.shakeToExtendEnabled)
+    }
+
+    @Test fun `withEngineUpdate keeps ON when the user has it enabled`() {
+        val prev = PlaybackState(shakeToExtendEnabled = true)
+        val engine = PlaybackState(shakeToExtendEnabled = true)
+        assertTrue(prev.withEngineUpdate(engine, sleepTimerRemainingMs = null).shakeToExtendEnabled)
+    }
+
+    @Test fun `withEngineUpdate takes engine-owned playback fields from the engine copy`() {
+        val prev = PlaybackState(isPlaying = false, isBuffering = false, voiceId = "old")
+        val engine = PlaybackState(isPlaying = true, isBuffering = true, voiceId = "new")
+
+        val merged = prev.withEngineUpdate(engine, sleepTimerRemainingMs = 5_000L)
+
+        assertTrue(merged.isPlaying)
+        assertTrue(merged.isBuffering)
+        assertEquals("new", merged.voiceId)
+    }
+
+    @Test fun `withEngineUpdate uses the explicitly-passed sleep timer value, not the engine default`() {
+        val prev = PlaybackState(sleepTimerRemainingMs = 123L)
+        val engine = PlaybackState(sleepTimerRemainingMs = null) // engine's stale default
+        assertEquals(9_000L, prev.withEngineUpdate(engine, sleepTimerRemainingMs = 9_000L).sleepTimerRemainingMs)
+    }
 
     @Test fun `scrubProgress is zero when duration is zero`() {
         assertEquals(0f, PlaybackState().scrubProgress(), 0f)

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/SleepTimerAutoArmTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/SleepTimerAutoArmTest.kt
@@ -1,0 +1,94 @@
+package `in`.jphe.storyvox.playback
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pinned decision tables for the sleep-timer auto-arm (#1574) and
+ * shake-to-extend (#1595) gates. Pure JVM — no Hilt, no MediaSession,
+ * no sherpa — so the exact rules the service depends on are verifiable
+ * on the CI test-compile path.
+ */
+class SleepTimerAutoArmTest {
+
+    // ── #1574 — DND auto-arm ───────────────────────────────────────
+
+    @Test fun `arms when DND active, playing, and no timer running`() {
+        assertTrue(shouldArmBedtimeSleep(dndActive = true, isPlaying = true, sleepTimerRunning = false))
+    }
+
+    @Test fun `does not arm when DND is not active`() {
+        // The #1574 ② live suspect: currentInterruptionFilter read back as
+        // INTERRUPTION_FILTER_ALL (stale) at onReceive time → dndActive
+        // false → no arm. Instrumentation now logs the raw filter so an
+        // on-device repro can confirm/deny this without a code change.
+        assertFalse(shouldArmBedtimeSleep(dndActive = false, isPlaying = true, sleepTimerRunning = false))
+    }
+
+    @Test fun `does not arm when not playing`() {
+        assertFalse(shouldArmBedtimeSleep(dndActive = true, isPlaying = false, sleepTimerRunning = false))
+    }
+
+    @Test fun `does not re-arm when a timer is already running`() {
+        assertFalse(shouldArmBedtimeSleep(dndActive = true, isPlaying = true, sleepTimerRunning = true))
+    }
+
+    @Test fun `isPlaying true is the whole gate — refutes the buffering-gap hypothesis`() {
+        // #557 invariant: the engine keeps isPlaying=true through buffering
+        // gaps (the MediaSession flips to STATE_BUFFERING, isPlaying does
+        // not). So when the phone shows PLAYING(3), isPlaying is true here
+        // and — given DND active + no timer — the arm fires. The gate could
+        // not have silently blocked the arm at PLAYING(3).
+        assertTrue(shouldArmBedtimeSleep(dndActive = true, isPlaying = true, sleepTimerRunning = false))
+    }
+
+    // ── #1595 — shake listen window ────────────────────────────────
+
+    private val fade = 10_000L
+
+    @Test fun `does not listen when no timer is armed`() {
+        assertFalse(shouldListenForShake(sleepTimerRemainingMs = null, shakeEnabled = true, fadeWindowMs = fade))
+    }
+
+    @Test fun `listens at the top of the fade tail (boundary)`() {
+        assertTrue(shouldListenForShake(sleepTimerRemainingMs = 10_000L, shakeEnabled = true, fadeWindowMs = fade))
+    }
+
+    @Test fun `listens at the very end of the fade tail (boundary)`() {
+        assertTrue(shouldListenForShake(sleepTimerRemainingMs = 0L, shakeEnabled = true, fadeWindowMs = fade))
+    }
+
+    @Test fun `does not listen just above the fade tail (still counting down)`() {
+        assertFalse(shouldListenForShake(sleepTimerRemainingMs = 10_001L, shakeEnabled = true, fadeWindowMs = fade))
+    }
+
+    @Test fun `does not listen mid-countdown`() {
+        assertFalse(shouldListenForShake(sleepTimerRemainingMs = 900_000L, shakeEnabled = true, fadeWindowMs = fade))
+    }
+
+    @Test fun `does not listen when the user disabled shake-to-extend`() {
+        // Only reachable now that the engine-state clobber is fixed
+        // (PlaybackState.withEngineUpdate): before the fix, shakeEnabled
+        // was force-reset to true every ~50ms so this branch was dead.
+        assertFalse(shouldListenForShake(sleepTimerRemainingMs = 5_000L, shakeEnabled = false, fadeWindowMs = fade))
+    }
+
+    // ── #1595 — shake extend gate ──────────────────────────────────
+
+    @Test fun `extends when a shake fires inside the fade tail`() {
+        assertTrue(shouldExtendOnShake(sleepTimerRemainingMs = 5_000L, fadeWindowMs = fade))
+    }
+
+    @Test fun `ignores a shake when no timer is running`() {
+        assertFalse(shouldExtendOnShake(sleepTimerRemainingMs = null, fadeWindowMs = fade))
+    }
+
+    @Test fun `ignores a shake fired above the fade tail`() {
+        assertFalse(shouldExtendOnShake(sleepTimerRemainingMs = 10_001L, fadeWindowMs = fade))
+    }
+
+    @Test fun `extends at the fade-tail end boundary`() {
+        assertTrue(shouldExtendOnShake(sleepTimerRemainingMs = 0L, fadeWindowMs = fade))
+    }
+}


### PR DESCRIPTION
Root-cause investigation of the two on-device sleep-timer reports (#1574, #1595). **Iron law: no blind patches.** The happy-path wiring for both features is correct on paper, so this PR ships the *provable* fixes plus the instrumentation needed to root-cause the remaining device-timing failures on-device.

## #1595 — shake-to-extend · REAL DEFECT FIXED (the engine-state clobber)

`DefaultPlaybackController` merged fresh `EnginePlayer` state with a naive `update.copy(sleepTimerRemainingMs = …)` (PlaybackController.kt:347). `EnginePlayer` **never** sets `shakeToExtendEnabled`, so its state copy carries the data-class default (`true`). The merge therefore **overwrote the user's toggle back to ON on every ~50 ms engine poll** — turning shake-to-extend *off* never stuck.

Fixed via `PlaybackState.withEngineUpdate(...)`, which preserves controller-owned fields from the prior state.

⚠️ Because the clobber forced the flag **ON**, it is **not** the cause of the reported "doesn't extend" symptom — but it is a genuine correctness bug (dead OFF toggle) and it made the `shakeEnabled` gate impossible to exercise. Verdict comment on #1595 with the full trace.

## #1574 — auto sleep timer · finding ① resolved, finding ② needs on-device repro

- **Finding ① (original report — toggle off-by-default + undiscoverable):** already resolved on `main` by #1596 (default `false`→`true`) and #1587/#1594 (naming/discoverability).
- **Finding ② (arm didn't fire even when fully enabled):** JP's prime suspect — `isPlaying` reading false during a synth/buffer gap — is **REFUTED**. The #557 invariant keeps `isPlaying = true` through buffering (only `isBuffering` flips) and `getState()` emits `STATE_BUFFERING` whenever silent (EnginePlayer.kt:4962-4965). So `MediaSession = PLAYING(3)` ⟹ `isPlaying = true`, and the controller's `state.isPlaying` tracks the engine's truth. The arm's `isPlaying` gate **cannot** have silently blocked at PLAYING(3).
- **Remaining suspects (device-timing, need instrumented repro):** (A) the `ACTION_INTERRUPTION_FILTER_CHANGED` broadcast isn't delivered to the dynamic receiver on Samsung One UI; (B) `currentInterruptionFilter` reads back stale-`ALL` at `onReceive` time → `dndActive=false` → no arm.

## What ships

| Change | Purpose |
|---|---|
| `SleepTimerDecisions.kt` — `shouldArmBedtimeSleep` / `shouldListenForShake` / `shouldExtendOnShake` | Extract the three gates as pure, JVM-testable fns; document the exact conditions |
| onReceive **entry** breadcrumb (raw filter Int + all 3 gate inputs + arm decision) | Prior code logged only *inside* the arm branch — a repro couldn't tell "never fired" from "gate failed". Now unambiguous. |
| Shake arm/disarm + shake-fire/extend logs | A repro shows whether the accelerometer registers and whether shakes are detected/gated |
| `ContextCompat.registerReceiver(RECEIVER_NOT_EXPORTED)` + `runCatching` | SDK-36 registration hygiene, matching `AudioOutputMonitor` (#1218). Downgraded per JP's on-device note (not the live bug on the Z Flip3) but correct. |
| `PlaybackState.withEngineUpdate` | The #1595 clobber fix |
| `SleepTimerAutoArmTest` + `PlaybackStateTest` additions | Pure tests: gate decision tables (incl. the refuted-`isPlaying` case + fade-window boundaries) and the preserved-OFF-choice regression |

## Next step (blocks closing either issue)

Install this build and run the instrumented repro (steps in the #1574 / #1595 verdict comments) → the logcat pinpoints finding ②'s failing condition and whether the shake detector arms. **Refs** #1574, #1595 — deliberately *not* `Closes`, pending that confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)