### PR TITLE
fix(playback): atomic _state.update{} at all writers — race-free shake-toggle (#1595 follow-up)

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackController.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackController.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -309,7 +310,10 @@ class DefaultPlaybackController @Inject constructor(
     init {
         scope.launch {
             sleepTimer.remainingMs.collect { remaining ->
-                _state.value = _state.value.copy(sleepTimerRemainingMs = remaining)
+                // Atomic RMW: scope is Dispatchers.Default (multi-threaded)
+                // with three _state writers — a bare value=value.copy() can
+                // lose a concurrent write (Oracle finding, #1595).
+                _state.update { it.copy(sleepTimerRemainingMs = remaining) }
             }
         }
         // #593 / #594 — keep the cached snapshots fresh so skip taps
@@ -347,8 +351,10 @@ class DefaultPlaybackController @Inject constructor(
                 // #1595 — preserve controller-owned fields (shakeToExtendEnabled)
                 // that the engine leaves at data-class defaults; a naive
                 // update.copy(...) clobbered the user's toggle back to true on
-                // every poll. See PlaybackState.withEngineUpdate.
-                _state.value = prev.withEngineUpdate(update, sleepTimer.remainingMs.value)
+                // every poll. See PlaybackState.withEngineUpdate. Atomic
+                // _state.update so a concurrent setShakeToExtendEnabled on
+                // another Default-dispatcher thread isn't lost (Oracle finding).
+                _state.update { current -> current.withEngineUpdate(update, sleepTimer.remainingMs.value) }
                 // #524 — if the engine reports BookFinished via the events
                 // channel (collected below), the listener pipeline goes idle.
                 // We additionally watch for an authoritative isPlaying=false
@@ -887,7 +893,8 @@ class DefaultPlaybackController @Inject constructor(
 
     override fun setShakeToExtendEnabled(enabled: Boolean) {
         if (_state.value.shakeToExtendEnabled == enabled) return
-        _state.value = _state.value.copy(shakeToExtendEnabled = enabled)
+        // Atomic RMW — see the engine-collector note (#1595 / Oracle finding).
+        _state.update { it.copy(shakeToExtendEnabled = enabled) }
     }
 
     override suspend fun speakText(text: String) {


### PR DESCRIPTION
Follow-up to #1602 (merged as `a546e123`). During that PR's review I ran an adversarial read-only verification pass, which surfaced a concurrency finding that the merged fix didn't fully close.

## The finding

`DefaultPlaybackController`'s scope is `Dispatchers.Default` (**multi-threaded**), and `_state` had **three non-atomic read-modify-write writers**:
- the sleep-timer collector (`_state.value = _state.value.copy(sleepTimerRemainingMs = …)`),
- the engine-state collector (`_state.value = prev.withEngineUpdate(…)` — added in #1602),
- `setShakeToExtendEnabled` (`_state.value = _state.value.copy(shakeToExtendEnabled = …)`).

A bare `value = value.copy()` is not atomic, so a concurrent writer on another Default-dispatcher thread can be lost. Concretely: #1602's `withEngineUpdate` reads `prev` then writes, so an engine emission can still clobber a *just-set* `shakeToExtendEnabled` in the window between a user's toggle write and the engine collector's write — i.e. #1602 alone left the dead-OFF-toggle bug reachable under concurrency.

## The fix

Convert all three writers to `MutableStateFlow.update { }` (atomic compare-and-set with retry). `withEngineUpdate` and the `copy()` lambdas are pure, so CAS retries are side-effect-free.

## Not a behavior change elsewhere

Verification also proved this race **cannot** explain #1574's missed auto-arm: with no timer running the sleep-timer collector is quiescent, so only the engine collector writes `isPlaying` and its steady playback ticks self-heal any stale read. This PR is correctness hardening for the #1595 path, not the #1574 fix.

Refs #1595.

🤖 Generated with [Claude Code](https://claude.com/claude-code)