### PR TITLE
chore(screener): drift-check + docs to keep the app corpus in sync with /qualify

### DIFF
--- a/.github/workflows/screener-drift-check.yml
+++ b/.github/workflows/screener-drift-check.yml
@@ -1,0 +1,44 @@
+name: Screener drift check
+
+# Advisory drift detector for the OFFLINE benefits screener (#1517, #1605).
+#
+# Candela bundles the /qualify rules as an on-device asset
+# (feature/src/main/assets/techempower/screener_corpus.json). The live web
+# screener at techempower.org/qualify is edited continuously; the two silently
+# drift. This job fetches the web corpus, extracts a COARSE fingerprint (newest
+# verified date, corpus size, question set), and compares it to the bundled
+# asset — surfacing drift as GitHub annotations.
+#
+# ADVISORY BY DESIGN: it runs the checker WITHOUT --strict, so it never fails a
+# run and is not a required check (only "Build APK" gates merges). Benefits
+# content is TechEmpower-supplied (epic #1520 "verified or silent"); a stale
+# corpus is a signal for a human, not a build breakage. The checker never writes
+# or copies rules — see docs/screener-sync.md.
+
+on:
+  pull_request:
+    paths:
+      - 'feature/src/main/assets/techempower/screener_corpus.json'
+      - 'scripts/screener-drift-check.py'
+      - '.github/workflows/screener-drift-check.yml'
+  schedule:
+    # Weekly, Mondays 06:31 UTC — catches web-side updates between app releases.
+    - cron: '31 6 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: screener-drift-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  drift:
+    runs-on: [self-hosted, linux]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check screener corpus drift vs techempower.org/qualify
+        run: |
+          python3 --version
+          # Advisory: emits ::error::/::warning::/::notice:: annotations but
+          # always exits 0 so it never blocks a merge.
+          python3 scripts/screener-drift-check.py | tee "$GITHUB_STEP_SUMMARY"

--- a/docs/screener-sync.md
+++ b/docs/screener-sync.md
@@ -1,0 +1,190 @@
+# Keeping the offline screener in sync with techempower.org/qualify
+
+**Status:** investigation + drift-detection shipped; content sync is a documented
+manual step gated on the production corpus (#1586). Tracking: **#1605**.
+
+Candela bundles an **offline benefits screener** (#1517): a "Do I qualify?" flow
+that runs with zero connectivity, reading a bundled JSON asset instead of the
+network. The same rules power the live web screener at **techempower.org/qualify**,
+which the team edits continuously. This doc records where each corpus lives, how
+they differ, and the mechanism that keeps them from silently diverging.
+
+> **Invariant (epic #1520 #3 — "verified or silent").** Benefits *content* is
+> TechEmpower-supplied from an adversarial fact-check pipeline, carries a
+> verified-date, and is never authored or paraphrased in this repo. Any sync
+> mechanism must **preserve provenance/verified-date stamping and never invent
+> eligibility facts.** That constraint is why we *detect* drift here but do not
+> *auto-copy* rules.
+
+---
+
+## 1. The app corpus (what ships on-device)
+
+| | |
+|---|---|
+| **Asset** | `feature/src/main/assets/techempower/screener_corpus.json` |
+| **Schema** | `feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/screener/ScreenerCorpus.kt` |
+| **Parser** | `ScreenerCorpusParser.kt` (pure, kotlinx.serialization, `ignoreUnknownKeys`) |
+| **Loader** | `ScreenerViewModel.load()` — reads the asset, no network, no analytics |
+| **Eligibility** | `ScreenerEligibility.kt` — pure, declarative criteria → LIKELY/MAYBE/UNLIKELY |
+| **Program ids** | `ScreenerProgramIds.kt` — cross-lane id constants (wallet #1514, autofill #1519) |
+
+**Schema (v1) shape:**
+
+```
+metadata { schemaVersion, provenance, verifiedDate, source, note }
+questions[] { id, type(boolean|single_select), prompt{en,es}, options[]{id,label{en,es}} }
+programs[]  { id, org, category, name{en,es}, summary{en,es}, phone, applyUrl,
+              verifiedDate, sourceNote{en,es}, criteria[]{questionId, op, value} }
+```
+
+- `metadata.provenance` gates the UI's "sample data" banner. `"seed-sample"`
+  (or anything ≠ `"techempower-verified"`) → the app loudly says the data is
+  un-verified. Flip to `"techempower-verified"` and the banner disappears.
+- **What ships today: a SEED SAMPLE.** `provenance: "seed-sample"`, **4 programs**
+  (LIHEAP/Project GO, NID water discount, FREED battery backup, 211), 5 generic
+  boolean/select questions. Its own `metadata.note` says: *"NOT the production
+  corpus … The production corpus (33 verified programs, EN/ES) replaces this file
+  wholesale."* The production corpus has **not landed** (tracked by **#1586**).
+
+> ⚠️ **Doc accuracy bug:** `CHANGELOG.md` and #1517 describe the screener as
+> "the client-side /qualify (33 programs) bundled on-device." The shipped asset
+> has **4 seed programs**. Correct the copy when the production corpus lands (or
+> sooner) — do not claim 33 while shipping 4.
+
+---
+
+## 2. The web source of truth (techempower.org/qualify)
+
+Investigated 2026-07-05 (see #1605). Findings:
+
+- **It's a Next.js static export.** `__NEXT_DATA__` is empty (162 B) — the rules
+  are **not** in the SSG data payload. They are **baked into a minified,
+  content-hash-named client chunk**: `/_next/static/chunks/pages/qualify-<hash>.js`
+  (~320 KB). The hash changes on every deploy (observed changing *twice within
+  one session* — the corpus is actively redeployed).
+- **No published canonical JSON / API.** Probed `/qualify/corpus.json`,
+  `/qualify.json`, `/api/qualify`, `/api/screener`, `list.techempower.org/…` etc.
+  — all 404 → SPA fallback. The minified bundle is the only machine artifact.
+- **The web schema is richer and different** from the app's:
+  - `provenance` is an **array of claim objects**:
+    `[{ claim, source: "https://…", verifiedAt: "YYYY-MM-DD", via: "<pipeline tag>" }]`
+    — e.g. `via: "wave-1 research + oracle (verbatim)"`, `"ep3 wave: cf-ssi-seniors"`,
+    `"ep4 wave: psps"`. (The app's `provenance` is a single string.)
+  - FPL-based **income tables** per household size (`limitsMonthly:{1:…,2:…,increment:…}`).
+  - ~17 questions (income, housing, county, and flags: pge, nid, vehicle, smog,
+    pregnant, medicare, disability, student, homeless) vs the app's 5.
+  - **67 provenance blocks**, `verifiedAt` dates spanning **2026-05-30 →
+    2026-07-05** (current), all citing authoritative `.gov` sources
+    (aspe.hhs.gov FPL guidelines, calfresh.dss.ca.gov, cdss.ca.gov, csd.ca.gov
+    LIHEAP, bar.ca.gov CAP, headstart.gov, myfamily.wic.ca.gov, …) with
+    `web.archive.org` snapshots for permanence.
+
+**Conclusion:** the web corpus is large, professionally fact-checked, actively
+maintained — and only available as a minified bundle with a schema that does not
+match the app's. The *real* source of truth is the pipeline that generates the
+site (repo or Notion CMS), not the bundle.
+
+---
+
+## 3. Current drift
+
+| Dimension | App (shipped) | Web (live) |
+|---|---|---|
+| Provenance | `seed-sample` (un-verified) | verified, per-claim sources |
+| Programs | 4 (county-local placeholders) | ~33 (67 provenance blocks) |
+| Questions | 5 boolean/select | ~17 incl. FPL income tables |
+| Newest verified | 2026-07-04 (placeholder) | 2026-07-05 (moves ~daily) |
+| Schema | simplified string-provenance | array-of-claims + income tables |
+| Program overlap | LIHEAP id only; otherwise **none** | — |
+
+The app is not "slightly drifting" — it was **seeded and never replaced**. As the
+team edits the web corpus, the gap only widens. Because the schemas differ, a
+byte-for-byte copy is impossible and any ad-hoc transform risks **silently
+dropping or mis-mapping a verified eligibility fact** — the exact failure the
+"verified or silent" invariant forbids.
+
+---
+
+## 4. The sync mechanism (recommended + shipped step)
+
+Considered four options:
+
+| Option | Verdict |
+|---|---|
+| (a) Auto-scrape the web bundle → regenerate the asset | **Rejected.** Minified, content-hashed, schema-mismatched; a transform can silently corrupt verified facts. Violates the invariant. |
+| (b) **CI drift-check** (detect + warn) | **Shipped.** Coarse fingerprint is robust to minification; detects staleness without touching content. |
+| (c) **Documented manual sync** from a canonical export | **Recommended** for content — the only invariant-safe way to move verified rules. |
+| (d) Shared source of truth (canonical JSON export) | **Ask TechEmpower for it** — the correct long-term fix (see §6). |
+
+**What shipped in this PR (b):** `scripts/screener-drift-check.py` +
+`.github/workflows/screener-drift-check.yml` (advisory). The checker fetches
+`/qualify`, resolves the current chunk, extracts a **coarse fingerprint** (newest
+`verifiedAt`, provenance-block count, question-id set, pipeline evidence), and
+compares it to the bundled asset — warning when the app is on the seed or is
+stale. It **never parses or copies rules**, so it cannot corrupt content.
+
+### Run it
+
+```bash
+python3 scripts/screener-drift-check.py          # advisory, human-readable
+python3 scripts/screener-drift-check.py --json    # machine-readable
+python3 scripts/screener-drift-check.py --strict  # exit 1 on drift (for gating)
+```
+
+The CI workflow runs it advisory (never blocks a merge; only "Build APK" gates)
+on PRs that touch the corpus/script, weekly, and on manual dispatch. Findings
+appear as GitHub annotations + a step summary.
+
+---
+
+## 5. Manual content sync (when the production corpus is ready — #1586)
+
+The screener surface + reader + drift-check are done; only the *content* is
+pending. When TechEmpower delivers the verified corpus:
+
+1. **Obtain the canonical export** — ideally a clean `screener_corpus.json` from
+   the same pipeline the site consumes (see §6). Do **not** reverse-engineer the
+   web bundle by hand.
+2. **Map web schema → app schema** (v1). Per program, carry over: id, org,
+   category, `name{en,es}`, `summary{en,es}`, `phone` (only if verified — else
+   `null`), `applyUrl`, `criteria`. Collapse the web's `provenance[]` array into
+   the app's single `verifiedDate` (use the **oldest** claim's `verifiedAt` for a
+   program, so the footer never over-states freshness) and preserve the source
+   in `sourceNote`. If a rule needs FPL income tables the v1 criteria model can't
+   express, either extend the schema (bump `schemaVersion`) or omit the program —
+   **never approximate** the threshold.
+3. **Set `metadata.provenance = "techempower-verified"`** and
+   `metadata.verifiedDate` to the corpus's own date. The seed banner disappears
+   automatically.
+4. **Sync `ScreenerProgramIds.kt`** constants + `seedIds` to the real ids
+   (consumers: wallet #1514, autofill #1519).
+5. **Fix the source-count copy** (CHANGELOG, #1517, any "N programs" strings) to
+   the real number — see the Data-Safety serialization-point note; bump once.
+6. **Verify:** `python3 scripts/screener-drift-check.py` should now report no
+   `seed-still-shipping` / `stale-verified-date` findings. Run the airplane-mode
+   acceptance check from #1517 (EN + ES bucketed results, no network requests).
+
+---
+
+## 6. The real fix: ask for a canonical corpus export
+
+The robust long-term mechanism is a **shared source of truth**: TechEmpower
+publishes the pipeline's output as a stable, versioned `screener_corpus.json`
+(the app's schema, or a documented superset) — at a fixed URL or in a repo the
+app can pull. Then sync becomes: download the canonical file → run the drift-check
+→ (optionally) a `scripts/sync-screener.sh` that copies it verbatim into assets
+and flips provenance. No scraping, no schema guessing, invariant preserved.
+
+Until that export exists, keep the drift-check running and treat content sync as
+the documented manual step above.
+
+---
+
+## Links
+
+- #1517 — offline benefits screener (shipped surface)
+- #1520 — benefits paperwork companion epic (invariants)
+- #1586 — verified EN/ES benefits corpora (the pending content)
+- #1605 — this sync mechanism
+- Live: <https://techempower.org/qualify>

--- a/scripts/screener-drift-check.py
+++ b/scripts/screener-drift-check.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""screener-drift-check — detect drift between the bundled offline screener
+corpus and the live web screener at techempower.org/qualify.
+
+WHY THIS EXISTS (issue #1605)
+    Candela bundles an OFFLINE benefits screener (#1517): a "Do I qualify?"
+    flow whose rules live in a bundled JSON asset
+    (feature/src/main/assets/techempower/screener_corpus.json). The SAME rules
+    live on techempower.org/qualify, which the team edits continuously. The two
+    can silently drift as the web corpus is fact-checked and updated.
+
+WHAT IT DOES (detect only — never authors content)
+    Fetches /qualify, resolves the current client JS chunk, and extracts a
+    COARSE FINGERPRINT (newest verified date, corpus size, question-id set,
+    pipeline evidence). Compares it to the bundled asset's metadata and warns
+    when the app is stale or is still shipping the un-verified seed sample.
+
+WHY ONLY A FINGERPRINT (verified-or-silent invariant, epic #1520 #3)
+    The web rules are baked into a minified, content-hash-named webpack bundle
+    with a RICHER, DIFFERENT schema (array-of-claims provenance, FPL income
+    tables). There is no published canonical JSON. This script deliberately does
+    NOT parse or copy rules — a schema-mismatched transform could silently drop
+    or mis-map a verified eligibility fact. It only detects "you are out of
+    date" and tells a human. Regenerating the asset is a human step that
+    consumes TechEmpower's canonical corpus export (see docs/screener-sync.md),
+    not this bundle.
+
+USAGE
+    python3 scripts/screener-drift-check.py            # advisory, human output
+    python3 scripts/screener-drift-check.py --json      # machine output
+    python3 scripts/screener-drift-check.py --strict    # exit 1 if drift found
+
+EXIT CODES
+    0  in sync, or drift found in advisory (default) mode
+    1  drift found AND --strict
+    2  local error (asset missing / unparseable)
+    3  could not reach the web screener AND --strict (advisory mode: exits 0)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import urllib.request
+from pathlib import Path
+
+QUALIFY_URL = "https://techempower.org/qualify"
+CHUNK_RE = re.compile(r'/_next/static/chunks/pages/(qualify-[0-9a-f]+\.js)')
+ASSET_REL = "feature/src/main/assets/techempower/screener_corpus.json"
+UA = "candela-screener-drift-check (+https://github.com/techempower-org/candela/issues/1605)"
+
+
+# ---------- fetch (curl first — Cloudflare-friendly — urllib fallback) ----------
+
+def fetch(url: str, timeout: int = 20) -> str:
+    try:
+        out = subprocess.run(
+            ["curl", "-sSL", "--max-time", str(timeout), "-A", UA, url],
+            capture_output=True, text=True, timeout=timeout + 5,
+        )
+        if out.returncode == 0 and out.stdout:
+            return out.stdout
+    except (FileNotFoundError, subprocess.SubprocessError):
+        pass
+    req = urllib.request.Request(url, headers={"User-Agent": UA})
+    with urllib.request.urlopen(req, timeout=timeout) as r:  # noqa: S310 (https only)
+        return r.read().decode("utf-8", "replace")
+
+
+# ---------- web fingerprint (coarse, stable patterns only) ----------
+
+def web_fingerprint() -> dict:
+    html = fetch(QUALIFY_URL)
+    m = CHUNK_RE.search(html)
+    if not m:
+        raise RuntimeError("could not locate qualify-<hash>.js chunk in /qualify HTML")
+    chunk_url = f"https://techempower.org/_next/static/chunks/pages/{m.group(1)}"
+    js = fetch(chunk_url)
+
+    dates = sorted(set(re.findall(r'verifiedAt":"(\d{4}-\d{2}-\d{2})"', js)))
+    question_ids = sorted(set(re.findall(r'\{id:"(q-[a-z0-9_\-]+)"', js)))
+    return {
+        "chunk": m.group(1),
+        "newest_verified_at": dates[-1] if dates else None,
+        "oldest_verified_at": dates[0] if dates else None,
+        "verified_claim_count": len(re.findall(r'verifiedAt":"', js)),
+        "provenance_block_count": len(re.findall(r'"provenance":\[', js)),
+        "question_ids": question_ids,
+        "question_count": len(question_ids),
+        # sanity: confirms we actually parsed the fact-checked corpus, not a shell
+        "has_pipeline_evidence": bool(re.search(r'"via":"[^"]*(wave|oracle|ep\d)', js)),
+    }
+
+
+# ---------- app fingerprint (bundled asset) ----------
+
+def find_asset() -> Path:
+    here = Path(__file__).resolve()
+    for base in [here.parent.parent, *here.parents]:
+        cand = base / ASSET_REL
+        if cand.is_file():
+            return cand
+    raise FileNotFoundError(f"could not find {ASSET_REL} above {here}")
+
+
+def app_fingerprint() -> dict:
+    path = find_asset()
+    corpus = json.loads(path.read_text(encoding="utf-8"))
+    meta = corpus.get("metadata", {})
+    programs = corpus.get("programs", [])
+    questions = corpus.get("questions", [])
+    return {
+        "path": str(path),
+        "provenance": meta.get("provenance"),
+        "verified_date": meta.get("verifiedDate"),
+        "schema_version": meta.get("schemaVersion"),
+        "is_verified": meta.get("provenance") == "techempower-verified",
+        "program_ids": sorted(p.get("id") for p in programs if p.get("id")),
+        "program_count": len(programs),
+        "question_ids": sorted(q.get("id") for q in questions if q.get("id")),
+        "question_count": len(questions),
+    }
+
+
+# ---------- compare ----------
+
+def compare(app: dict, web: dict) -> list[dict]:
+    findings: list[dict] = []
+
+    if not app["is_verified"]:
+        findings.append({
+            "level": "critical",
+            "code": "seed-still-shipping",
+            "msg": (f"app corpus provenance is {app['provenance']!r}, not "
+                    f"'techempower-verified' — the app is still shipping the "
+                    f"un-verified SEED sample ({app['program_count']} programs). "
+                    f"The production corpus ({web['provenance_block_count']} "
+                    f"verified provenance blocks on the web) has not landed "
+                    f"(tracked by #1586)."),
+        })
+
+    aw, ww = app["verified_date"], web["newest_verified_at"]
+    if aw and ww and aw < ww:
+        findings.append({
+            "level": "warn",
+            "code": "stale-verified-date",
+            "msg": (f"app verifiedDate {aw} is older than the web's newest "
+                    f"verifiedAt {ww} — the web corpus has been fact-checked "
+                    f"more recently."),
+        })
+
+    if web["has_pipeline_evidence"] and not app["is_verified"]:
+        findings.append({
+            "level": "info",
+            "code": "schema-lineage-gap",
+            "msg": ("web corpus carries per-claim provenance (source + "
+                    "verifiedAt + pipeline 'via' tags); the app's simplified "
+                    "schema does not. A regen must transform, not copy — see "
+                    "docs/screener-sync.md."),
+        })
+
+    if web["question_count"] and app["question_count"] != web["question_count"]:
+        findings.append({
+            "level": "info",
+            "code": "question-set-divergence",
+            "msg": (f"app has {app['question_count']} screening questions; the "
+                    f"web has {web['question_count']}. Different question sets "
+                    f"produce different eligibility results."),
+        })
+
+    return findings
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Detect app<->web benefits-screener drift.")
+    ap.add_argument("--json", action="store_true", help="machine-readable output")
+    ap.add_argument("--strict", action="store_true", help="exit 1 on any drift")
+    args = ap.parse_args()
+
+    try:
+        app = app_fingerprint()
+    except (FileNotFoundError, json.JSONDecodeError, OSError) as e:
+        print(f"ERROR reading bundled corpus: {e}", file=sys.stderr)
+        return 2
+
+    try:
+        web = web_fingerprint()
+    except Exception as e:  # noqa: BLE001 — network/parse; advisory tool
+        note = f"could not fetch/parse web screener: {e}"
+        if args.json:
+            print(json.dumps({"ok": False, "note": note, "app": app}, indent=2))
+        else:
+            print(f"NOTE  {note}")
+            print("      (advisory: skipping web comparison this run)")
+        return 3 if args.strict else 0
+
+    findings = compare(app, web)
+
+    if args.json:
+        print(json.dumps({
+            "ok": len(findings) == 0,
+            "app": app, "web": web, "findings": findings,
+        }, indent=2))
+    else:
+        print("screener drift check — techempower.org/qualify  vs  bundled asset")
+        print(f"  web : chunk {web['chunk']}  newest_verified {web['newest_verified_at']}  "
+              f"{web['provenance_block_count']} provenance blocks  {web['question_count']} questions")
+        print(f"  app : provenance {app['provenance']!r}  verified {app['verified_date']}  "
+              f"{app['program_count']} programs  {app['question_count']} questions")
+        print(f"  asset: {app['path']}")
+        if not findings:
+            print("\n  ✓ no drift detected — app corpus is verified and current.")
+        else:
+            print()
+            for f in findings:
+                tag = {"critical": "✗ CRITICAL", "warn": "! WARN", "info": "· INFO"}[f["level"]]
+                print(f"  {tag}  [{f['code']}] {f['msg']}")
+            # GitHub Actions annotations (harmless locally)
+            for f in findings:
+                gh = {"critical": "error", "warn": "warning", "info": "notice"}[f["level"]]
+                print(f"::{gh} title=screener-drift::{f['code']}: {f['msg']}")
+
+    return 1 if (findings and args.strict) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What & why

JP asked: make sure the app's **offline benefits screener** stays up to date with the team's edits to **techempower.org/qualify**.

Investigation (full writeup in `docs/screener-sync.md`, tracked by #1605):

- The app bundles a **4-program SEED sample** (`provenance: "seed-sample"`); the production corpus has **never landed** (that's #1586).
- The live web `/qualify` ships the **real verified corpus**: **67 provenance blocks**, per-claim `.gov` sources + `web.archive.org` snapshots, EN/ES, `verifiedAt` dates running to **today** (the chunk hash changed *twice during investigation* — it's redeployed continuously).
- The web has **no published canonical JSON** — rules are baked into a minified, content-hash-named Next.js chunk with a **richer, different schema**. A byte-copy is impossible; an ad-hoc transform could silently drop a verified eligibility fact → violates the *verified-or-silent* invariant (#1520).

So this PR **detects drift; it does not author content:**

| File | Role |
|---|---|
| `scripts/screener-drift-check.py` | Fetches `/qualify`, resolves the current chunk, extracts a coarse fingerprint (newest `verifiedAt`, corpus size, question set) and compares to the bundled asset. `--json` / `--strict`. Never parses or copies rules. |
| `.github/workflows/screener-drift-check.yml` | Advisory CI (PR-on-corpus-change · weekly · dispatch). Annotations only; never blocks a merge (only *Build APK* gates). |
| `docs/screener-sync.md` | Corpus map + schema, web source-of-truth, drift table, the invariant-safe **manual content-sync** process (gated on #1586), and the canonical-export ask. |

## Sample output (live)

```
web : chunk qualify-9c44f54492840469.js  newest_verified 2026-07-05  67 provenance blocks  17 questions
app : provenance 'seed-sample'  verified 2026-07-04  4 programs  5 questions
  ✗ CRITICAL [seed-still-shipping] app still shipping the un-verified SEED sample (4 programs) …
  ! WARN     [stale-verified-date] app 2026-07-04 older than web 2026-07-05 …
```

## Notes
- **No gradle run** — CI is the compile gate (this PR touches no Kotlin).
- Follow-up (not in this PR): `CHANGELOG.md`/#1517 claim "33 programs" while the app ships 4 — correct when the production corpus lands.
- This is a mechanism/visibility PR; the verified **content** is #1586.

Refs #1605

🤖 Generated with [Claude Code](https://claude.com/claude-code)
