### PR TITLE
fix(sleep): marshal timer-fire pause to Main — stop Player-wrong-thread crash (#1606)

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackController.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackController.kt
@@ -716,7 +716,17 @@ class DefaultPlaybackController @Inject constructor(
         // chapters need the ExoPlayer's playWhenReady=false branch.
         // (Not named `pause()` on EnginePlayer to avoid colliding with
         // the BasePlayer override.)
-        player?.pauseRouted()
+        //
+        // #1606 — pause() is invoked both from Main (UI, media button, focus
+        // loss) AND from the SleepTimer fire path on Dispatchers.Default
+        // (SleepTimer.fadeAndPause → PauseAction → here). Media3's Player is
+        // Main-thread-confined (verifyApplicationThread), so a direct call
+        // from Default crashed the process every time a sleep timer expired.
+        // Marshal the player op to Main — Main.immediate runs inline when the
+        // caller is already on Main (no reordering for the UI path) and hops
+        // only for the off-main sleep-timer caller. Same class of fix as the
+        // #553 advanceChapter Main-hop above.
+        scope.launch(Dispatchers.Main.immediate) { player?.pauseRouted() }
     }
 
     override fun resume() {


### PR DESCRIPTION
## Crash (HIGH) — every sleep-timer expiry

```
FATAL EXCEPTION: DefaultDispatcher-worker-N
java.lang.IllegalStateException: Player is accessed on the wrong thread.
Current thread: 'DefaultDispatcher-worker-N'   Expected thread: 'main'
```
On-device (v1.12.2): `armed 15min` → 15 min later `fade tail entered` → **FATAL** ~10s later → process death → restart. This is the real user-facing "auto sleep timer not working" symptom (#1574): the arm works, but the **fire kills the app**.

## Root cause (traced)

`SleepTimer.fadeAndPause()` runs on the timer's `Dispatchers.Default` scope (`SleepTimer.kt:34`) → `PauseAction` (`PlaybackModule.kt:61` = `{ controller.get().pause() }`) → `PlaybackController.pause()` → `player?.pauseRouted()` on the **Media3 Player, off the main thread**. Media3's Player is Main-thread-confined (`verifyApplicationThread`) → crash.

## Provenance — pre-existing, newly reached

- `SleepTimer` has **always** paused on `Dispatchers.Default` (last touched by #1190; untouched by #1602/#1603). UI callers of `pause()` are on Main, so it never surfaced.
- **#1596** (default bedtime auto-sleep ON) made timers actually fire on real devices → newly reached this path. My #1602/#1603 did **not** move Player access.

## Fix

Marshal the player op to `Dispatchers.Main.immediate` — runs **inline** for the Main callers (UI, media button, focus loss; no reordering) and **hops** to Main only for the off-main sleep-timer caller. One line. Same class of fix as the #553 `advanceChapter` Main-hop already in this file (~line 581), which fixed the identical "wrong thread" crash.

## Verification

This is a threading crash, not a pure-JVM-testable decision — verification is **on-device: arm → let the timer fire → no crash** (@team-lead running it on the fix build). The fix is code-provable and matches the #553 precedent; I'll reopen if it recurs.

**Keeps #1604's diagnostics intact** so the same fix build serves the fire re-test **and** the #1595 shake test. The #1604 revert + any #1595 threshold tune ship in a follow-up once the shake data is in.

Closes #1606
Closes #1574

🤖 Generated with [Claude Code](https://claude.com/claude-code)