### PR TITLE
revert: drop the v1.12.2 sleep-timer Log.w diagnostics (#1604) — sleep verified fixed

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/StoryvoxPlaybackService.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/StoryvoxPlaybackService.kt
@@ -200,7 +200,7 @@ class StoryvoxPlaybackService : MediaSessionService() {
                     // read doesn't block the accelerometer callback.
                     // `currentShakeExtendMinutes` falls back to 15 (the
                     // legacy value) when the store hasn't emitted yet.
-                    Log.w(TAG, "Shake-to-extend: shake detected in fade tail (remaining=${remaining}ms) — extending")
+                    Log.i(TAG, "Shake-to-extend: shake detected in fade tail (remaining=${remaining}ms) — extending")
                     scope.launch {
                         val minutes = sleepExtendConfig.currentShakeExtendMinutes()
                         controller.startSleepTimer(SleepTimerMode.Duration(minutes))
@@ -212,7 +212,7 @@ class StoryvoxPlaybackService : MediaSessionService() {
                     // if it shows NO shake lines at all while the fade-tail
                     // "accelerometer registered" line is present, the
                     // gesture isn't crossing the detector threshold.
-                    Log.w(TAG, "Shake-to-extend: shake ignored — not in fade tail (remaining=${remaining}ms)")
+                    Log.d(TAG, "Shake-to-extend: shake ignored — not in fade tail (remaining=${remaining}ms)")
                 }
             },
         )
@@ -228,7 +228,7 @@ class StoryvoxPlaybackService : MediaSessionService() {
                     if (inFadeWindow && !shakeListening) {
                         val started = shakeDetector?.start() ?: false
                         shakeListening = true
-                        Log.w(
+                        Log.i(
                             TAG,
                             "Shake-to-extend: fade tail entered (remaining=${remaining}ms) — " +
                                 "accelerometer ${if (started) "registered" else "FAILED to register"}",
@@ -236,7 +236,7 @@ class StoryvoxPlaybackService : MediaSessionService() {
                     } else if (!inFadeWindow && shakeListening) {
                         shakeDetector?.stop()
                         shakeListening = false
-                        Log.w(TAG, "Shake-to-extend: fade tail exited — accelerometer released")
+                        Log.d(TAG, "Shake-to-extend: fade tail exited — accelerometer released")
                     }
                 }
         }
@@ -267,7 +267,7 @@ class StoryvoxPlaybackService : MediaSessionService() {
                 // MediaSession shows PLAYING — so if this logs isPlaying=false
                 // during audible playback, that's a *new* finding.)
                 val arm = shouldArmBedtimeSleep(dndActive, playing, timerRunning)
-                Log.w(
+                Log.i(
                     TAG,
                     "Bedtime auto-sleep: filter changed (filter=$filter dndActive=$dndActive " +
                         "isPlaying=$playing timerRunning=$timerRunning) → arm=$arm",
@@ -276,7 +276,7 @@ class StoryvoxPlaybackService : MediaSessionService() {
                     scope.launch {
                         val minutes = sleepExtendConfig.currentShakeExtendMinutes()
                         controller.startSleepTimer(SleepTimerMode.Duration(minutes))
-                        Log.w(TAG, "Bedtime auto-sleep: armed ${minutes}min (DND filter=$filter)")
+                        Log.i(TAG, "Bedtime auto-sleep: armed ${minutes}min (DND filter=$filter)")
                     }
                 }
             }
@@ -305,11 +305,11 @@ class StoryvoxPlaybackService : MediaSessionService() {
                             Log.w(TAG, "Bedtime auto-sleep: registerReceiver failed: ${it.message}")
                         }.isSuccess
                         dndReceiverRegistered = ok
-                        Log.w(TAG, "Bedtime auto-sleep: receiver ${if (ok) "registered" else "registration FAILED"}")
+                        Log.i(TAG, "Bedtime auto-sleep: receiver ${if (ok) "registered" else "registration FAILED"}")
                     } else if (!enabled && dndReceiverRegistered) {
                         runCatching { unregisterReceiver(dndReceiver) }
                         dndReceiverRegistered = false
-                        Log.w(TAG, "Bedtime auto-sleep: receiver unregistered (setting off)")
+                        Log.i(TAG, "Bedtime auto-sleep: receiver unregistered (setting off)")
                     }
                 }
         }

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/sleep/ShakeDetector.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/sleep/ShakeDetector.kt
@@ -6,7 +6,6 @@ import android.hardware.SensorEvent
 import android.hardware.SensorEventListener
 import android.hardware.SensorManager
 import android.os.SystemClock
-import android.util.Log
 import kotlin.math.sqrt
 
 /**
@@ -47,11 +46,6 @@ class ShakeDetector(
     private var lastFireUptime: Long = 0L
     private val refireGuardMs: Long = 1_500L
 
-    /** #1595 diagnostic — peak linear-accel magnitude (m/s²) seen since the
-     *  detector armed or last fired. Logged so an on-device repro shows how
-     *  close a shake got to [thresholdMps2]. */
-    private var maxMagMps2: Float = 0f
-
     fun start(): Boolean {
         if (sensorManager != null) return true
         val sm = context.getSystemService(Context.SENSOR_SERVICE) as? SensorManager ?: return false
@@ -59,7 +53,6 @@ class ShakeDetector(
         sensorManager = sm
         accelerometer = sensor
         recentPeaks.clear()
-        maxMagMps2 = 0f
         return sm.registerListener(this, sensor, SensorManager.SENSOR_DELAY_UI)
     }
 
@@ -81,23 +74,6 @@ class ShakeDetector(
         val x = event.values[0]; val y = event.values[1]; val z = event.values[2]
         val magnitude = sqrt(x * x + y * y + z * z) - SensorManager.GRAVITY_EARTH
 
-        // #1595 diagnostic — log above-baseline samples (skip at-rest jitter
-        // so it isn't a firehose) so an on-device repro shows how close a
-        // shake got to firing: current magnitude, running max, the fire
-        // threshold, and the peak count in the window. Log.w to survive the
-        // release Log.i/d strip (#1276). Content-free — magnitudes + counts
-        // only. Revert with the rest of the sleep diagnostics once #1595 is
-        // root-caused.
-        if (magnitude >= LOG_BASELINE_MPS2) {
-            if (magnitude > maxMagMps2) maxMagMps2 = magnitude
-            Log.w(
-                TAG,
-                "Shake sample: mag=%.1f maxMag=%.1f thr=%.0f peaks=%d/%d".format(
-                    magnitude, maxMagMps2, thresholdMps2, recentPeaks.size, minPeaks,
-                ),
-            )
-        }
-
         if (magnitude < thresholdMps2) return
         val now = SystemClock.uptimeMillis()
         recentPeaks.addLast(now)
@@ -109,24 +85,9 @@ class ShakeDetector(
         if (recentPeaks.size >= minPeaks && now - lastFireUptime > refireGuardMs) {
             lastFireUptime = now
             recentPeaks.clear()
-            maxMagMps2 = 0f
             onShake()
         }
     }
 
     override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) = Unit
-
-    private companion object {
-        // Same tag as StoryvoxPlaybackService on purpose: the #1595 repro
-        // filters `logcat -s StoryvoxPlaybackService:*`, so co-locating keeps
-        // the whole shake narrative (fade-tail arm → samples → fire) in one
-        // stream instead of hiding these lines under a separate tag.
-        private const val TAG = "StoryvoxPlaybackService"
-
-        /** #1595 diagnostic — only log samples above this linear-accel floor
-         *  (m/s²). At-rest magnitude is ~0 after gravity subtraction, so a
-         *  low floor captures real motion (including near-misses below the
-         *  fire threshold) without logging idle jitter. */
-        private const val LOG_BASELINE_MPS2 = 4f
-    }
 }


### PR DESCRIPTION
Reverts #1604 (commit 1cceb058). The diagnostics did their job — the whole sleep saga is verified on-device (v1.12.3, R5CRB0W66MK):
- **#1574** auto-sleep arms correctly (`armed 15min` on DND-during-playback)
- **#1606/#1609** timer fire no longer crashes (Player pause main-marshalled)
- **#1595** shake-to-extend works (shake peaked 23.4 m/s² vs the 12 threshold — no tune needed)

This restores the diagnostic breadcrumbs to `Log.i`/`Log.d` (release-stripped again, no logcat noise) and removes the `ShakeDetector` peak logging. Clean base for the v1.12.4 finalize.

Prepared by the orchestrator (Sandman) after lucid-sleep's session hit a 401 auth expiry mid-finalize. Refs #1595, #1606, #1574.