### PR TITLE
fix(import): preserve line & paragraph breaks when importing a text file (#1619)

### DIFF
--- a/source-epub/src/main/kotlin/in/jphe/storyvox/source/epub/EpubSource.kt
+++ b/source-epub/src/main/kotlin/in/jphe/storyvox/source/epub/EpubSource.kt
@@ -181,7 +181,11 @@ internal class EpubSource @Inject constructor(
             ChapterContent(
                 info = info,
                 htmlBody = chapter.htmlBody,
-                plainBody = chapter.htmlBody.stripHtml(),
+                // #1619 — prefer a source-provided plaintext body when the
+                // chapter carries one (the plaintext-import path sets it so
+                // paragraph/line structure survives). Real EPUB chapters
+                // leave it null and fall back to the HTML stripper.
+                plainBody = chapter.plainBody ?: chapter.htmlBody.stripHtml(),
             ),
         )
     }
@@ -217,11 +221,23 @@ internal class EpubSource @Inject constructor(
     }
 }
 
-/** Issue #1000 — wrap a plaintext file's bytes into a one-chapter
- *  [EpubBook]. The body is HTML-escaped and dropped into a `<pre>`
- *  block so the downstream HTML→plaintext stripper (which the engine
- *  feeds from) round-trips it without mangling angle brackets or
- *  collapsing the prose. Title is the filename sans extension. */
+/** Issue #1000 / #1619 — wrap a plaintext file's bytes into a one-chapter
+ *  [EpubBook]. Title is the filename sans extension.
+ *
+ *  Two bodies, two consumers:
+ *   - [EpubChapter.htmlBody] keeps the HTML-escaped text in a `<pre>` block
+ *     purely for export fidelity (`ExportFictionToEpubUseCase` prefers
+ *     htmlBody, and `<pre>` preserves whitespace in the exported EPUB).
+ *   - [EpubChapter.plainBody] is what actually gets read — reader, TTS
+ *     chunker, and paragraph-nav all consume `ChapterContent.plainBody`.
+ *
+ *  #1619: the original code left plainBody to be derived by running the
+ *  `<pre>` htmlBody through [String.stripHtml], whose `\s+`→" " collapse
+ *  flattened every newline to a space (run-on blob — fatal for scripts,
+ *  verse, teleprompter) and, because stripHtml never decodes entities,
+ *  leaked literal `&amp;`/`&lt;`/`&gt;` into the prose. We now derive
+ *  plainBody straight from the raw file via [normalizePlainText] so the
+ *  file's paragraph and line structure survives untouched. */
 private fun textBook(entry: EpubFileEntry, bytes: ByteArray): EpubBook {
     val text = bytes.toString(Charsets.UTF_8)
     val title = entry.displayName
@@ -240,10 +256,41 @@ private fun textBook(entry: EpubFileEntry, bytes: ByteArray): EpubBook {
                 title = title,
                 index = 0,
                 htmlBody = "<pre>$escaped</pre>",
+                plainBody = normalizePlainText(text),
             ),
         ),
     )
 }
+
+/**
+ * Issue #1619 — normalize a raw imported text file into the plaintext
+ * chapter body the reader, the TTS `SentenceChunker`, and paragraph-level
+ * navigation all read (`ChapterContent.plainBody`).
+ *
+ * What it preserves (the whole point): a lone `\n` stays a line break;
+ * a blank line (`\n\n`) stays a paragraph break — `paragraphHeadIndices`
+ * keys on exactly that. Leading/interior spaces and tabs are left intact
+ * so verse and script indentation survives; the `SentenceChunker` trims
+ * each utterance anyway, so indentation never reaches the synthesizer.
+ *
+ * What it normalizes (cosmetic, structure-safe):
+ *  - CRLF / lone CR → LF, so blank-line detection (which counts `\n`) is
+ *    independent of the file's origin OS.
+ *  - Trailing spaces/tabs per line are dropped.
+ *  - Runs of 3+ newlines collapse to a single blank line, so an oddly
+ *    spaced file doesn't open with a wall of empty space.
+ *  - Leading/trailing blank lines are trimmed.
+ *
+ * Deliberately does NOT collapse interior horizontal whitespace — unlike
+ * an HTML stripper, a raw text file's spacing is authorial intent.
+ */
+internal fun normalizePlainText(raw: String): String =
+    raw.replace("\r\n", "\n")
+        .replace('\r', '\n')
+        .lineSequence()
+        .joinToString("\n") { it.trimEnd(' ', '\t') }
+        .replace(Regex("\n{3,}"), "\n\n")
+        .trim('\n')
 
 /** Compose a stable chapter id from the fictionId + the per-EPUB
  *  spine idref. Keeps chapter ids unique across books. */

--- a/source-epub/src/main/kotlin/in/jphe/storyvox/source/epub/config/EpubConfig.kt
+++ b/source-epub/src/main/kotlin/in/jphe/storyvox/source/epub/config/EpubConfig.kt
@@ -52,8 +52,10 @@ enum class EpubEntryKind {
     Epub,
 
     /** A plaintext file — synthesise a one-chapter book from the UTF-8
-     *  body (the reader/engine pipeline downstream is HTML-tolerant, so
-     *  the body is wrapped in a `<pre>` block). */
+     *  body. The reader + TTS read `ChapterContent.plainBody`, which the
+     *  text path derives straight from the raw file so paragraph/line
+     *  structure survives (#1619); the `<pre>`-wrapped htmlBody is kept
+     *  only for export fidelity (#1000). */
     Text,
 }
 

--- a/source-epub/src/main/kotlin/in/jphe/storyvox/source/epub/parse/EpubModels.kt
+++ b/source-epub/src/main/kotlin/in/jphe/storyvox/source/epub/parse/EpubModels.kt
@@ -38,4 +38,23 @@ data class EpubChapter(
     val index: Int,
     /** Sanitized HTML body of the chapter file. */
     val htmlBody: String,
+    /**
+     * Issue #1619 — optional pre-computed plaintext body. When non-null,
+     * [`in`.jphe.storyvox.source.epub.EpubSource.chapter] uses it verbatim
+     * as [`in`.jphe.storyvox.data.source.model.ChapterContent.plainBody]
+     * instead of running [htmlBody] through the tag-stripper.
+     *
+     * The reader, the TTS `SentenceChunker`, and paragraph-level navigation
+     * (`paragraphHeadIndices`) all consume `plainBody`, and paragraph nav
+     * infers paragraph breaks from blank lines (`\n\n`) in that string. The
+     * plaintext-import path (#1000) sets this straight from the raw UTF-8
+     * file so paragraph and hard line breaks — the whole point of scripts,
+     * verse, and teleprompter text — survive. Routing plaintext through the
+     * whitespace-collapsing stripper flattened every newline to a space
+     * (#1619) and leaked literal `&`-entities from the `<pre>` escaping.
+     *
+     * Real EPUB chapters leave this null and keep the byte-for-byte
+     * `stripHtml` behaviour — this change does not touch that path.
+     */
+    val plainBody: String? = null,
 )

--- a/source-epub/src/test/kotlin/in/jphe/storyvox/source/epub/TextImportPlainBodyTest.kt
+++ b/source-epub/src/test/kotlin/in/jphe/storyvox/source/epub/TextImportPlainBodyTest.kt
@@ -1,0 +1,163 @@
+package `in`.jphe.storyvox.source.epub
+
+import `in`.jphe.storyvox.data.source.model.FictionResult
+import `in`.jphe.storyvox.source.epub.config.EpubConfig
+import `in`.jphe.storyvox.source.epub.config.EpubEntryKind
+import `in`.jphe.storyvox.source.epub.config.EpubFileEntry
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1619 — importing a `.txt` used to strip ALL line breaks: a
+ * script / verse / teleprompter file collapsed into one run-on blob.
+ *
+ * Root cause: [EpubSource.chapter] derived `plainBody` by running the
+ * `<pre>`-wrapped htmlBody through the tag-stripper, whose `\s+`→" "
+ * collapse flattened every `\n`. The reader, the TTS `SentenceChunker`,
+ * and paragraph-level navigation all consume `plainBody`, and paragraph
+ * nav infers breaks from blank lines (`\n\n`) in it — so the collapse
+ * silently killed paragraph nav for imported text too.
+ *
+ * Fix: the plaintext-import path now sets [EpubChapter.plainBody] straight
+ * from the raw file via [normalizePlainText]; real EPUB chapters leave it
+ * null and keep the byte-for-byte stripHtml behaviour.
+ *
+ * These tests drive the real render path end-to-end
+ * ([EpubSource.fictionDetail] → [EpubSource.chapter]) so they assert what
+ * the reader/engine actually receive, plus the pure [normalizePlainText]
+ * contract. Paragraph-break counting here mirrors the blank-line rule that
+ * `ParagraphBoundariesTest` (core-playback) pins for the nav layer itself.
+ */
+class TextImportPlainBodyTest {
+
+    private class FakeEpubConfig(
+        private val entry: EpubFileEntry,
+        private val bytes: ByteArray,
+    ) : EpubConfig {
+        override val folderUriString: Flow<String?> = flowOf("folder://test")
+        override suspend fun snapshot(): String? = "folder://test"
+        override val books: Flow<List<EpubFileEntry>> = flowOf(listOf(entry))
+        override suspend fun books(): List<EpubFileEntry> = listOf(entry)
+        override suspend fun readBookBytes(uriString: String): ByteArray? =
+            if (uriString == entry.uriString) bytes else null
+    }
+
+    /** Imports [raw] as a plaintext file and returns the resulting
+     *  chapter's `plainBody` — the exact string the reader and TTS read. */
+    private fun importedPlainBody(displayName: String, raw: String): String = runBlocking {
+        val fictionId = "epub:txt:test"
+        val entry = EpubFileEntry(
+            fictionId = fictionId,
+            uriString = "uri://$displayName",
+            displayName = displayName,
+            kind = EpubEntryKind.Text,
+        )
+        val source = EpubSource(FakeEpubConfig(entry, raw.toByteArray(Charsets.UTF_8)))
+
+        val detail = source.fictionDetail(fictionId)
+        assertTrue("fictionDetail should succeed", detail is FictionResult.Success)
+        val chapterId = (detail as FictionResult.Success).value.chapters.single().id
+
+        val content = source.chapter(fictionId, chapterId)
+        assertTrue("chapter should succeed", content is FictionResult.Success)
+        (content as FictionResult.Success).value.plainBody
+    }
+
+    /** Count blank-line-separated paragraphs — the same signal
+     *  `paragraphHeadIndices` keys on. */
+    private fun paragraphCount(body: String): Int =
+        body.split(Regex("\n[ \t]*\n")).count { it.isNotBlank() }
+
+    // ── end-to-end: the reported bug ────────────────────────────────
+
+    @Test
+    fun `blank-line paragraphs survive import as paragraph breaks`() {
+        val script = "TITLE CARD\n\nFADE IN:\n\nINT. ROOM - DAY\n\nBob waves."
+        val body = importedPlainBody("scene.txt", script)
+
+        assertTrue("paragraph breaks (\\n\\n) must survive", body.contains("\n\n"))
+        assertEquals("all four paragraphs preserved", 4, paragraphCount(body))
+    }
+
+    @Test
+    fun `hard line breaks within a paragraph survive import`() {
+        // A soft line break (single \n) inside one paragraph — verse /
+        // stage directions rely on these. Pre-fix this became a space.
+        val verse = "Roses are red,\nViolets are blue,\nSugar is sweet."
+        val body = importedPlainBody("poem.txt", verse)
+
+        assertEquals("verse kept as three lines", verse, body)
+        assertTrue(body.contains("red,\nViolets"))
+        assertFalse("newlines must NOT collapse to spaces", body.contains("red, Violets"))
+    }
+
+    @Test
+    fun `whole file no longer collapses to a single line`() {
+        val raw = "Line one.\nLine two.\n\nNew paragraph."
+        val body = importedPlainBody("notes.txt", raw)
+        // The pre-fix output was "Line one. Line two. New paragraph."
+        assertTrue("must contain at least one newline", body.contains("\n"))
+        assertFalse(
+            "must not be the old single-line collapse",
+            body == "Line one. Line two. New paragraph.",
+        )
+    }
+
+    // ── end-to-end: latent entity-leak bug fixed alongside ──────────
+
+    @Test
+    fun `ampersand and angle brackets stay literal, not HTML entities`() {
+        // The old path escaped these into a <pre> block then stripped tags
+        // WITHOUT decoding, leaking literal "&amp;" / "&lt;" into the prose.
+        val raw = "Tom & Jerry\n\nif x < y > z"
+        val body = importedPlainBody("chars.txt", raw)
+
+        assertTrue(body.contains("Tom & Jerry"))
+        assertTrue(body.contains("if x < y > z"))
+        assertFalse("no &amp; leak", body.contains("&amp;"))
+        assertFalse("no &lt; leak", body.contains("&lt;"))
+        assertFalse("no &gt; leak", body.contains("&gt;"))
+    }
+
+    // ── normalizePlainText: pure contract ───────────────────────────
+
+    @Test
+    fun `single newline is a soft wrap and is preserved`() {
+        assertEquals("a\nb", normalizePlainText("a\nb"))
+    }
+
+    @Test
+    fun `crlf and lone cr normalize to lf`() {
+        assertEquals("a\n\nb", normalizePlainText("a\r\n\r\nb"))
+        assertEquals("a\nb", normalizePlainText("a\rb"))
+    }
+
+    @Test
+    fun `runs of three or more newlines collapse to one blank line`() {
+        assertEquals("a\n\nb", normalizePlainText("a\n\n\n\nb"))
+    }
+
+    @Test
+    fun `leading and trailing blank lines are trimmed`() {
+        assertEquals("body", normalizePlainText("\n\n\nbody\n\n\n"))
+    }
+
+    @Test
+    fun `trailing horizontal whitespace is trimmed but indentation is kept`() {
+        // Leading indent is authorial intent (verse / script) → keep it.
+        // Trailing spaces/tabs are noise → drop them.
+        assertEquals("    indented\nnext", normalizePlainText("    indented   \nnext\t"))
+    }
+
+    @Test
+    fun `interior horizontal whitespace inside a line is preserved`() {
+        // Aligned columns in a script must not be collapsed the way an
+        // HTML stripper would.
+        assertEquals("NAME:    Bob", normalizePlainText("NAME:    Bob"))
+    }
+}


### PR DESCRIPTION
## What & why

Importing a `.txt` via **Library → "Import a file…"** stripped **all** line breaks — a script / verse / teleprompter file collapsed into one run-on blob, and paragraph-level navigation silently broke. Fixes #1619 (helps #1239 / #1367 teleprompter).

## Root cause

The plaintext-import path (`source-epub`, #1000) wraps the raw text in `<pre>…</pre>` and lets `EpubSource.chapter()` derive `plainBody` via `stripHtml()`, whose `.replace(Regex("\\s+"), " ")` collapses **every** `\n` to a space.

The render path is `ChapterContent.plainBody` for **all three** consumers:
- **Reader** — `ReaderViewModel` maps rows → `ChapterBody(..., it.plainBody)`.
- **TTS** — `SentenceChunker.chunk(plainBody)` → `EngineStreamingSource` (which consumes already-segmented `Sentence`s; it does *not* strip HTML itself).
- **Paragraph nav** — `paragraphHeadIndices` / `blankLinePrecedes` infer paragraphs from blank lines (`\n\n`) in that same string.

So the collapse broke readability **and** paragraph nav for imported text. `htmlBody` is never rendered as HTML (export + word-count only). The `<pre>`→`stripHtml` round-trip also leaked literal `&amp;`/`&lt;`/`&gt;` into the prose, since `stripHtml` never decodes entities.

## Fix (surgical — zero real-`.epub` blast radius)

- `EpubChapter` gains an optional `plainBody: String? = null`.
- The text-import path sets it straight from the raw file via a new `normalizePlainText()`: LF-normalize (CRLF/CR → LF), trim trailing horizontal whitespace per line, collapse runs of 3+ newlines to one blank line, trim leading/trailing blank lines. **Preserves** paragraph breaks (`\n\n`), soft line breaks (`\n`), and interior/leading indentation (authorial intent for verse/scripts).
- `EpubSource.chapter()` now does `chapter.plainBody ?: chapter.htmlBody.stripHtml()` — **real EPUB chapters are byte-for-byte unchanged** (parser sets no `plainBody`).

## Not broken

- **TTS segmentation** — `SentenceChunker` trims each utterance (`raw.trim()`) and skips empties (`sentenceText.isNotEmpty()`), so extra `\n`/`\n\n` never create empty/garbled utterances; ICU's `BreakIterator` actually uses newlines as boundary hints.
- **Real `.epub` import** — untouched (fallback path).
- **Other HTML sources (RSS etc.)** — each source has its own stripper; `EpubSource.stripHtml()` is file-private, so nothing else is affected.

## Tests

`source-epub/…/TextImportPlainBodyTest.kt` — drives the real render path end-to-end (`fictionDetail → chapter`) asserting paragraph + hard-line-break survival and the entity fix, plus the pure `normalizePlainText` contract (soft-wrap kept, CRLF, 3+-newline cap, trailing-trim vs indentation).

## Follow-up (out of scope)

Real `.epub` chapters still collapse to one paragraph in the reader (their `plainBody` also goes through `stripHtml`, which flattens block structure and leaks entities). Fixing that safely needs `<body>` extraction + `<style>`/`<script>` removal + entity decoding — a separate change with its own regression surface. Flagged, not attempted here.

Closes #1619


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plain-text EPUB imports now preserve paragraph breaks and line breaks more accurately.
  * Chapter content can now use a dedicated plain-text body when available, improving reading output.

* **Bug Fixes**
  * Fixed HTML entity leakage in imported text such as `&`, `<`, and `>`.
  * Prevented plain-text files from collapsing into a single line.
  * Improved whitespace and newline handling for cleaner, more readable imported prose.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->