### PR TITLE
fix(epub): preserve paragraph structure in real EPUB chapters (#1623)

### DIFF
--- a/source-epub/build.gradle.kts
+++ b/source-epub/build.gradle.kts
@@ -28,6 +28,9 @@ kotlin {
 dependencies {
     implementation(project(":core-data"))
     implementation(libs.kotlinx.coroutines.android)
+    // #1623 — parse real EPUB chapter XHTML into paragraph-preserving
+    // plaintext. Already the chapter-HTML→text tool in source-royalroad.
+    implementation(libs.jsoup)
 
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)

--- a/source-epub/src/main/kotlin/in/jphe/storyvox/source/epub/EpubSource.kt
+++ b/source-epub/src/main/kotlin/in/jphe/storyvox/source/epub/EpubSource.kt
@@ -21,6 +21,11 @@ import `in`.jphe.storyvox.source.epub.parse.EpubParseException
 import `in`.jphe.storyvox.source.epub.parse.EpubParser
 import javax.inject.Inject
 import javax.inject.Singleton
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Element
+import org.jsoup.nodes.Node
+import org.jsoup.nodes.TextNode
+import org.jsoup.select.NodeVisitor
 
 /**
  * Issue #235 — local EPUB files as a fiction backend. Each indexed
@@ -183,9 +188,10 @@ internal class EpubSource @Inject constructor(
                 htmlBody = chapter.htmlBody,
                 // #1619 — prefer a source-provided plaintext body when the
                 // chapter carries one (the plaintext-import path sets it so
-                // paragraph/line structure survives). Real EPUB chapters
-                // leave it null and fall back to the HTML stripper.
-                plainBody = chapter.plainBody ?: chapter.htmlBody.stripHtml(),
+                // paragraph/line structure survives). #1623 — real EPUB
+                // chapters leave it null and fall back to the jsoup HTML→text
+                // parser, which preserves paragraph structure from the XHTML.
+                plainBody = chapter.plainBody ?: chapter.htmlBody.htmlToPlainText(),
             ),
         )
     }
@@ -232,12 +238,13 @@ internal class EpubSource @Inject constructor(
  *     chunker, and paragraph-nav all consume `ChapterContent.plainBody`.
  *
  *  #1619: the original code left plainBody to be derived by running the
- *  `<pre>` htmlBody through [String.stripHtml], whose `\s+`→" " collapse
+ *  `<pre>` htmlBody through the old HTML stripper, whose `\s+`→" " collapse
  *  flattened every newline to a space (run-on blob — fatal for scripts,
- *  verse, teleprompter) and, because stripHtml never decodes entities,
- *  leaked literal `&amp;`/`&lt;`/`&gt;` into the prose. We now derive
- *  plainBody straight from the raw file via [normalizePlainText] so the
- *  file's paragraph and line structure survives untouched. */
+ *  verse, teleprompter) and, because it never decoded entities, leaked
+ *  literal `&amp;`/`&lt;`/`&gt;` into the prose. We now derive plainBody
+ *  straight from the raw file via [normalizePlainText] so the file's
+ *  paragraph and line structure survives untouched. (The real-EPUB path's
+ *  stripper was itself replaced with [String.htmlToPlainText] in #1623.) */
 private fun textBook(entry: EpubFileEntry, bytes: ByteArray): EpubBook {
     val text = bytes.toString(Charsets.UTF_8)
     val title = entry.displayName
@@ -308,17 +315,79 @@ private fun EpubFileEntry.toSummary(): FictionSummary = FictionSummary(
     status = FictionStatus.COMPLETED,
 )
 
-/** Naive HTML strip mirroring RssSource — the EngineStreamingSource
- *  applies further normalization downstream. */
-private fun String.stripHtml(): String =
-    replace(Regex("<[^>]+>"), " ")
-        .replace(Regex("\\s+"), " ")
+/**
+ * Issue #1623 — parse a real EPUB chapter's XHTML into paragraph-preserving
+ * plaintext for the reader, the TTS `SentenceChunker`, and paragraph-level
+ * navigation (all read `ChapterContent.plainBody`).
+ *
+ * A real EPUB `htmlBody` is the ENTIRE chapter XHTML document
+ * (`EpubParser` stores `String(bodyBytes)` — `<html><head><style>…</body>`).
+ * The previous naive stripper (`<tag>`→" ", `\s+`→" ") collapsed the whole
+ * chapter into one run-on line, leaked `<head>`/`<style>`/`<script>` text
+ * into the prose, and never decoded HTML entities (curly quotes, em-dashes,
+ * accents all showed as `&…;`).
+ *
+ * jsoup — already this repo's chapter-HTML→text tool (`source-royalroad`) —
+ * parses to a DOM so we can drop non-content nodes and add a blank line
+ * (`\n\n`) after each block element, which is exactly the signal
+ * `paragraphHeadIndices` keys on. `<br>` becomes a single `\n` (soft line).
+ * Entities decode natively. Plaintext-import chapters never reach this: #1619
+ * gives them a precomputed `plainBody`, so this is the real-EPUB path only.
+ *
+ * Known limitation: whitespace INSIDE `<pre>` is collapsed like ordinary
+ * prose (jsoup `TextNode.text()` normalizes it). EPUB prose rarely uses
+ * `<pre>`; preserving it verbatim is a follow-up if a real book needs it.
+ */
+internal fun String.htmlToPlainText(): String {
+    if (isBlank()) return ""
+    val doc = Jsoup.parse(this)
+    // Non-content: strip so their text never reaches the narration.
+    doc.select("head, script, style, noscript, svg, title").remove()
+    val sb = StringBuilder()
+    doc.body().traverse(object : NodeVisitor {
+        override fun head(node: Node, depth: Int) {
+            when {
+                node is TextNode -> sb.append(node.text())
+                node is Element && node.normalName() == "br" -> sb.append('\n')
+            }
+        }
+
+        override fun tail(node: Node, depth: Int) {
+            // Blank line after each block so paragraph-nav sees the break;
+            // runs of block-closes collapse to one gap in normalization.
+            if (node is Element && node.normalName() in HTML_BLOCK_TAGS) {
+                sb.append("\n\n")
+            }
+        }
+    })
+    return sb.toString().normalizeChapterWhitespace()
+}
+
+/** Block-level tags whose close introduces a paragraph break. Inline tags
+ *  (`<em>`, `<strong>`, `<a>`, …) are intentionally absent so their text
+ *  stays on the same line. */
+private val HTML_BLOCK_TAGS: Set<String> = setOf(
+    "p", "div", "section", "article", "header", "footer", "aside", "main",
+    "blockquote", "pre", "figure", "figcaption",
+    "h1", "h2", "h3", "h4", "h5", "h6",
+    "ul", "ol", "li", "dl", "dt", "dd",
+    "table", "tr", "hr",
+)
+
+/** Collapse horizontal whitespace, trim each line's edges, cap blank runs,
+ *  and trim — while preserving `\n` (line) and `\n\n` (paragraph). Mirrors
+ *  #1619's plaintext normalization for jsoup-extracted text. */
+private fun String.normalizeChapterWhitespace(): String =
+    replace('\r', '\n')
+        .replace(Regex("[ \\t\\x0B\\u000C]+"), " ")
+        .replace(Regex(" *\n *"), "\n")
+        .replace(Regex("\n{3,}"), "\n\n")
         .trim()
 
-/** Word count from raw HTML — strip tags, split on whitespace.
+/** Word count from raw HTML — strip to plaintext, split on whitespace.
  *  Cheap heuristic for surfacing chapter length in the picker. */
 private fun String.estimatedWordCount(): Int {
-    val plain = stripHtml()
+    val plain = htmlToPlainText()
     if (plain.isEmpty()) return 0
     return plain.split(Regex("\\s+")).size
 }

--- a/source-epub/src/main/kotlin/in/jphe/storyvox/source/epub/parse/EpubModels.kt
+++ b/source-epub/src/main/kotlin/in/jphe/storyvox/source/epub/parse/EpubModels.kt
@@ -53,8 +53,9 @@ data class EpubChapter(
      * whitespace-collapsing stripper flattened every newline to a space
      * (#1619) and leaked literal `&`-entities from the `<pre>` escaping.
      *
-     * Real EPUB chapters leave this null and keep the byte-for-byte
-     * `stripHtml` behaviour — this change does not touch that path.
+     * Real EPUB chapters leave this null and let `EpubSource.chapter` derive
+     * plainBody from the XHTML via the HTML→text parser (`htmlToPlainText`,
+     * jsoup-based since #1623) — #1619 does not touch that fallback path.
      */
     val plainBody: String? = null,
 )

--- a/source-epub/src/test/kotlin/in/jphe/storyvox/source/epub/HtmlToPlainTextTest.kt
+++ b/source-epub/src/test/kotlin/in/jphe/storyvox/source/epub/HtmlToPlainTextTest.kt
@@ -1,0 +1,149 @@
+package `in`.jphe.storyvox.source.epub
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1623 — real EPUB chapters used to collapse to one run-on paragraph.
+ *
+ * A real EPUB `htmlBody` is the ENTIRE chapter XHTML document, and the old
+ * naive stripper (`<tag>`->" ", `\s+`->" ") flattened the whole chapter into
+ * one line, leaked `<head>`/`<style>`/`<script>` text into the prose, and
+ * never decoded entities. The reader, the TTS `SentenceChunker`, and
+ * paragraph-level navigation all consume `plainBody`, and paragraph nav keys
+ * on blank lines (`\n\n`) — so the collapse killed paragraph structure.
+ *
+ * [String.htmlToPlainText] replaces that stripper with a jsoup DOM parse
+ * that drops non-content nodes, inserts `\n\n` after each block element and
+ * `\n` for `<br>`, and decodes entities natively.
+ *
+ * These are pure-function tests over realistic full-XHTML-document fixtures —
+ * i.e. real EPUB chapter HTML, not plaintext. (An end-to-end pass through
+ * [`in`.jphe.storyvox.source.epub.parse.EpubParser] would drag Robolectric
+ * in, since the parser reads the OPF via `android.util.Xml`; the transform
+ * under test is HTML->text, which this covers directly.)
+ */
+class HtmlToPlainTextTest {
+
+    /** Blank-line-separated paragraph count — the signal paragraph-nav uses. */
+    private fun paragraphCount(body: String): Int =
+        body.split(Regex("\n[ \t]*\n")).count { it.isNotBlank() }
+
+    @Test
+    fun `full XHTML document drops head, style, and title text`() {
+        val html = """
+            <html><head><title>Book Title</title>
+            <style>.c{color:red}</style></head>
+            <body><p>Hello world.</p></body></html>
+        """.trimIndent()
+        val out = html.htmlToPlainText()
+
+        assertEquals("Hello world.", out)
+        assertFalse("title text leaked", out.contains("Book Title"))
+        assertFalse("css leaked", out.contains("color"))
+    }
+
+    @Test
+    fun `script content is dropped`() {
+        val out = "<body><script>alert('boom')</script><p>Real content.</p></body>"
+            .htmlToPlainText()
+        assertFalse(out.contains("alert"))
+        assertFalse(out.contains("boom"))
+        assertTrue(out.contains("Real content."))
+    }
+
+    @Test
+    fun `consecutive paragraphs are separated by a blank line`() {
+        val out = "<body><p>First paragraph.</p><p>Second paragraph.</p></body>"
+            .htmlToPlainText()
+        assertEquals("First paragraph.\n\nSecond paragraph.", out)
+        assertEquals(2, paragraphCount(out))
+    }
+
+    @Test
+    fun `br becomes a single soft line break, not a paragraph break`() {
+        val out = "<body><p>Line one<br>Line two</p></body>".htmlToPlainText()
+        assertEquals("Line one\nLine two", out)
+    }
+
+    @Test
+    fun `headings are separated from the following paragraph`() {
+        val out = "<body><h1>Chapter One</h1><p>The story begins.</p></body>"
+            .htmlToPlainText()
+        assertEquals("Chapter One\n\nThe story begins.", out)
+    }
+
+    @Test
+    fun `nested blocks do not stack up extra blank lines`() {
+        val out = "<body><div><p>Inside.</p></div><p>After.</p></body>".htmlToPlainText()
+        // <p> close + <div> close would emit two blank lines; capped to one.
+        assertEquals("Inside.\n\nAfter.", out)
+    }
+
+    @Test
+    fun `inline tags stay on the same line`() {
+        val out = "<body><p>a <em>b</em> c <strong>d</strong></p></body>".htmlToPlainText()
+        assertFalse("inline tags must not introduce line breaks", out.contains("\n"))
+        assertTrue(out.contains("b"))
+        assertTrue(out.contains("d"))
+    }
+
+    @Test
+    fun `named and numeric entities are decoded, not leaked`() {
+        val out = "<body><p>Tom &amp; Jerry &rsquo;quote&rsquo; &mdash; end&hellip;</p></body>"
+            .htmlToPlainText()
+        assertTrue(out.contains("Tom & Jerry"))
+        assertTrue("right single quote decoded", out.contains("’"))
+        assertTrue("em-dash decoded", out.contains("—"))
+        assertTrue("ellipsis decoded", out.contains("…"))
+        assertFalse(out.contains("&amp;"))
+        assertFalse(out.contains("&rsquo;"))
+        assertFalse(out.contains("&mdash;"))
+        assertFalse(out.contains("&hellip;"))
+    }
+
+    @Test
+    fun `blank and empty inputs yield empty string`() {
+        assertEquals("", "".htmlToPlainText())
+        assertEquals("", "   \n\t ".htmlToPlainText())
+        assertEquals("", "<body></body>".htmlToPlainText())
+    }
+
+    @Test
+    fun `single paragraph produces no spurious line breaks`() {
+        val out = "<body><p>Just one paragraph here.</p></body>".htmlToPlainText()
+        assertEquals("Just one paragraph here.", out)
+        assertFalse(out.contains("\n"))
+    }
+
+    @Test
+    fun `realistic EPUB chapter keeps paragraphs, decodes entities, drops style`() {
+        val html = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <!DOCTYPE html>
+            <html xmlns="http://www.w3.org/1999/xhtml"><head>
+            <title>Ch 1</title>
+            <link rel="stylesheet" type="text/css" href="../css/style.css"/>
+            <style>p{text-indent:1em}</style>
+            </head>
+            <body>
+            <h1>Chapter 1</h1>
+            <p>It was a bright cold day in April, and the clocks were striking thirteen.</p>
+            <p>Winston Smith, his chin nuzzled into his breast&#8217;s warmth, slipped
+            quickly through the glass doors.</p>
+            </body></html>
+        """.trimIndent()
+        val out = html.htmlToPlainText()
+
+        assertEquals("three paragraphs preserved", 3, paragraphCount(out))
+        assertTrue(out.contains("Chapter 1"))
+        assertTrue("entity decoded to curly apostrophe", out.contains("breast’s"))
+        // Intra-paragraph source newline is HTML whitespace -> single space.
+        assertTrue(out.contains("slipped quickly"))
+        assertFalse("css never reaches prose", out.contains("text-indent"))
+        assertFalse("head title never reaches prose", out.contains("Ch 1"))
+        assertFalse(out.contains("&#8217;"))
+    }
+}


### PR DESCRIPTION
## What & why

Follow-up to #1619 (filed as #1623). #1619 fixed **plaintext** import; **real `.epub` chapters** still collapse to one run-on paragraph in the reader/TTS, because they take the fallback HTML-stripper path. Fixes #1623.

## Root cause

A real EPUB `htmlBody` is the **entire chapter XHTML document** — `EpubParser` stores `htmlBody = String(bodyBytes)` (`<html><head><style>…</body>`). `EpubSource.chapter()` derived `plainBody` from it via a naive stripper:

```kotlin
private fun String.stripHtml() =
    replace(Regex("<[^>]+>"), " ").replace(Regex("\\s+"), " ").trim()
```

That `\s+`→`" "` collapse flattened the whole chapter to one line (killing the `\n\n` paragraph-nav keys on), left `<head>`/`<style>`/`<script>` **text** in the prose, and never decoded entities (curly quotes / em-dashes / accents narrated as `&…;`).

## Fix

Replace `stripHtml()` with a jsoup-based `String.htmlToPlainText()`:
- drops `head, script, style, noscript, svg, title`;
- traverses the DOM inserting `\n\n` after each **block** element (the exact signal `paragraphHeadIndices` uses) and `\n` for `<br>`;
- decodes entities natively (jsoup) — the hand-rolled regex entity tables in other sources (Wikisource/Plos) miss `&rsquo;`/`&ldquo;`/numeric refs common in published EPUBs;
- `normalizeChapterWhitespace()` then collapses horizontal whitespace and caps blank runs while keeping `\n`/`\n\n`.

`estimatedWordCount()` now counts real prose instead of CSS tokens. `stripHtml()` is removed (no other callers).

## Why jsoup (parser vs regex — the flagged tradeoff)

**jsoup is already a dependency** and **already this repo's chapter-HTML→text tool** (`source-royalroad/parser/ChapterParser` uses the same remove/traverse surface). This just adds `implementation(libs.jsoup)` to `source-epub`. API surface verified against the resolved `jsoup-1.22.2.jar` via `javap`. Regex was rejected: brittle on nested/malformed publisher XHTML and weak entity coverage.

## Not broken

- **#1619 plaintext import** — untouched: those chapters carry a precomputed `plainBody`, so `chapter.plainBody ?: …htmlToPlainText()` never calls the new path for them.
- **TTS segmentation** — `SentenceChunker` trims each utterance and skips empties, so block-boundary `\n`/`\n\n` never create empty/garbled utterances.

## Tests

`HtmlToPlainTextTest` — pure-fn coverage over realistic **full-XHTML-document** fixtures (real EPUB chapter HTML, not plaintext): head/style/script dropped, `<p>`→blank line, `<br>`→soft line, headings separated, nested blocks don't stack blank lines, inline tags stay inline, **named + numeric entities decoded**, blank/empty → `""`, single-paragraph regression, and a full Orwell-style chapter fixture (paragraph count + entity + style-drop + intra-paragraph-newline-collapse).

**Why no epub-zip end-to-end test:** `EpubParser` reads the OPF/container via `android.util.Xml`, which would force Robolectric (Java 21) into a currently-pure module. The transform under test is HTML→text, covered directly above.

## Known limitation

Whitespace inside `<pre>` is collapsed like ordinary prose (jsoup `TextNode.text()` normalizes it). EPUB prose rarely uses `<pre>`; verbatim preservation is a follow-up if a real book needs it.

Closes #1623
