### PR TITLE
fix(notion): flattenNested child_page descent guard + prove official child_page decode (#1621)

### DIFF
--- a/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/net/NotionApi.kt
+++ b/source-notion/src/main/kotlin/in/jphe/storyvox/source/notion/net/NotionApi.kt
@@ -410,6 +410,15 @@ internal suspend fun flattenNested(
         for (block in blocks) {
             out.add(block.copy(depth = depth))
             if (!block.hasChildren) continue
+            // #1621 — a child_page sub-page is a CHAPTER boundary, not inline
+            // content. Keep its marker (added above, so planChapters still
+            // splits on it) but do NOT descend: its body is fetched lazily
+            // when the chapter opens (NotionPATSource.chapter → pageBlocks on
+            // the child id). Without this guard, listing a page of N sub-pages
+            // eagerly fetched every short's body and spliced it into the lead,
+            // bloating the "Introduction" chapter with every short's full text
+            // and risking the MAX_CHILD_REQUESTS ceiling on the list call.
+            if (block.type == "child_page") continue
             if (depth >= maxDepth) continue
             if (requests >= maxRequests) continue
             requests++

--- a/source-notion/src/test/kotlin/in/jphe/storyvox/source/notion/NotionChildPageDeserializeTest.kt
+++ b/source-notion/src/test/kotlin/in/jphe/storyvox/source/notion/NotionChildPageDeserializeTest.kt
@@ -1,0 +1,122 @@
+package `in`.jphe.storyvox.source.notion
+
+import `in`.jphe.storyvox.source.notion.net.NotionBlock
+import `in`.jphe.storyvox.source.notion.net.NotionBlockList
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #1621 — prove the official-API (`GET /v1/blocks/{id}/children`) JSON
+ * decodes `child_page` blocks correctly, using the SAME `Json` config
+ * `NotionApi` uses (`ignoreUnknownKeys + isLenient + coerceInputValues`)
+ * against the EXACT wire shape observed on JP's shorts page.
+ *
+ * The pre-existing [NotionChildPageChapterTest] builds [NotionBlock]
+ * objects directly, so it never exercised raw-JSON → `NotionBlock`
+ * deserialization for `child_page` — the untested gap that made a
+ * "deserialization drops child_page" hypothesis plausible. This closes
+ * it: if `type == "child_page"` survives the decode and [planChapters]
+ * splits, the collapse-to-one-chapter symptom is NOT a parse bug.
+ */
+class NotionChildPageDeserializeTest {
+
+    /** Byte-for-byte the config in `NotionApi` (net/NotionApi.kt). */
+    private val apiJson = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+        coerceInputValues = true
+    }
+
+    /**
+     * A realistic `blocks/{id}/children` body: two `child_page` sub-pages
+     * (the shorts) + a lead paragraph + a heading_2, each carrying the
+     * full complement of common Notion block fields the model does NOT
+     * declare (`object`, `parent`, `created_time`, `created_by`,
+     * `in_trash`, …) — exactly what `ignoreUnknownKeys` must swallow.
+     * The `child_page` block matches the shape captured on-device:
+     * `{type:"child_page", has_children:true, child_page:{title}}`.
+     */
+    private val rawChildrenResponse = """
+        {
+          "object": "list",
+          "results": [
+            {
+              "object": "block",
+              "id": "392a4ee6-9520-81a3-8813-c8fb40860001",
+              "parent": { "type": "page_id", "page_id": "392a4ee6-9520-81a3-a813-c8fb40860572" },
+              "created_time": "2024-01-01T00:00:00.000Z",
+              "last_edited_time": "2024-01-02T00:00:00.000Z",
+              "created_by": { "object": "user", "id": "u-1" },
+              "last_edited_by": { "object": "user", "id": "u-1" },
+              "has_children": false,
+              "archived": false,
+              "in_trash": false,
+              "type": "paragraph",
+              "paragraph": { "rich_text": [ { "type": "text", "text": { "content": "Lead notes." } } ] }
+            },
+            {
+              "object": "block",
+              "id": "392a4ee6-9520-8121-8fe8-ca62aa7ed899",
+              "parent": { "type": "page_id", "page_id": "392a4ee6-9520-81a3-a813-c8fb40860572" },
+              "created_time": "2024-01-01T00:00:00.000Z",
+              "last_edited_time": "2024-01-02T00:00:00.000Z",
+              "created_by": { "object": "user", "id": "u-1" },
+              "last_edited_by": { "object": "user", "id": "u-1" },
+              "has_children": true,
+              "archived": false,
+              "in_trash": false,
+              "type": "child_page",
+              "child_page": { "title": "01 A Family of Four Making Sixty-Six Thousand Can Still Qualify" }
+            },
+            {
+              "object": "block",
+              "id": "392a4ee6-9520-8188-8000-ca62aa7ed900",
+              "parent": { "type": "page_id", "page_id": "392a4ee6-9520-81a3-a813-c8fb40860572" },
+              "created_time": "2024-01-01T00:00:00.000Z",
+              "last_edited_time": "2024-01-02T00:00:00.000Z",
+              "created_by": { "object": "user", "id": "u-1" },
+              "last_edited_by": { "object": "user", "id": "u-1" },
+              "has_children": true,
+              "archived": false,
+              "in_trash": false,
+              "type": "child_page",
+              "child_page": { "title": "02 Getting Connected" }
+            }
+          ],
+          "next_cursor": null,
+          "has_more": false
+        }
+    """.trimIndent()
+
+    @Test fun `official-API child_page blocks decode with type child_page and title`() {
+        val list = apiJson.decodeFromString<NotionBlockList>(rawChildrenResponse)
+
+        assertEquals("all 3 blocks decode", 3, list.results.size)
+        val children = list.results.filter { it.type == "child_page" }
+        assertEquals("both sub-pages recognized as child_page", 2, children.size)
+        // The nested child_page payload must populate so planChapters can
+        // read the title.
+        assertEquals(
+            "01 A Family of Four Making Sixty-Six Thousand Can Still Qualify",
+            childPageTitle(children[0]),
+        )
+        assertEquals("02 Getting Connected", childPageTitle(children[1]))
+    }
+
+    @Test fun `decoded child_page blocks drive planChapters into intro plus one per short`() {
+        val list = apiJson.decodeFromString<NotionBlockList>(rawChildrenResponse)
+
+        val plans = planChapters(list.results)
+
+        // Lead paragraph → Introduction; the two child_page sub-pages →
+        // one Child chapter each. This is the split the shorts book should
+        // show; a collapse-to-1 therefore cannot originate in this decode.
+        assertEquals("intro + 2 shorts", 3, plans.size)
+        assertTrue(plans[0] is NotionChapterPlan.Section)
+        assertEquals("Introduction", plans[0].title)
+        assertTrue(plans.drop(1).all { it is NotionChapterPlan.Child })
+        assertEquals("02 Getting Connected", plans[2].title)
+    }
+}

--- a/source-notion/src/test/kotlin/in/jphe/storyvox/source/notion/NotionNestedBlocksTest.kt
+++ b/source-notion/src/test/kotlin/in/jphe/storyvox/source/notion/NotionNestedBlocksTest.kt
@@ -73,6 +73,22 @@ class NotionNestedBlocksTest {
     }
 
     @Test
+    fun `flattenNested keeps a child_page marker but does not descend into it`() = runTest {
+        // #1621 — a child_page sub-page has has_children=true, but it's a
+        // chapter boundary: its body is fetched lazily when the chapter is
+        // opened, NOT spliced into the parent listing. flattenNested must
+        // keep the marker (so planChapters splits on it) and NOT fetch its
+        // children at list time.
+        val subPage = container("child_page", "short1", hasChildren = true)
+        val lead = paragraph("Lead", "p1")
+        var fetches = 0
+        val flat = flattenNested(listOf(subPage, lead)) { fetches++; emptyList() }
+        assertEquals(listOf("short1", "p1"), flat.map { it.id })
+        assertEquals("child_page body must NOT be fetched at list time", 0, fetches)
+        assertTrue("child_page marker survives the flatten", flat.any { it.type == "child_page" })
+    }
+
+    @Test
     fun `flattenNested honours the depth cap`() = runTest {
         // A chain deeper than the cap: each level claims a child.
         val root = container("toggle", "d0", hasChildren = true)


### PR DESCRIPTION
Two verified pieces of the #1621 investigation (Notion shorts — page of `child_page` sub-pages — collapsing to 1 chapter). **Does not close #1621 yet** — see "still open" below.

## ② `flattenNested` child_page descent guard (approved fix)

A `child_page` sub-page has `has_children=true`, so `flattenNested` was descending **into** each one at `fictionDetail`/list time — eagerly fetching every short's body and splicing it into the flat block list. Consequences: `planChapters`' Introduction (all non-child_page blocks) absorbed **every short's full text** (bloat + duplication, since each short also renders as its own chapter), and a page of N sub-pages meant N list-time child fetches against the `MAX_CHILD_REQUESTS` cap. `child_page` is a **chapter boundary**; its body is fetched lazily when the chapter opens (`NotionPATSource.chapter`). Guard keeps the marker (so `planChapters` still splits) and skips the descent. + a `NotionNestedBlocksTest` case.

## Parse proof (refutes the "deserialization drops child_page" hypothesis)

`NotionChildPageDeserializeTest` decodes the **exact on-device wire shape** (a `child_page` block plus the realistic `object`/`parent`/`created_time`/… fields) through **NotionApi's own `Json` config** (`ignoreUnknownKeys + isLenient + coerceInputValues`) and asserts `type=="child_page"` survives and `planChapters` splits intro + N. `NotionBlock` is a plain data class with a plain `String type` field — no discriminator/polymorphism to mis-map — so the official/PAT path parses these correctly. (The prior child_page test built `NotionBlock`s directly; raw-JSON decode was the untested gap this closes.)

## Still open — the collapse root cause (①)

Proven from code that a present `child_page` marker always reaches `planChapters` (flattenNested adds before descending), AND that a parse *failure* would error the book rather than show 1 chapter. So the collapse means the app isn't running the PAT/`planChapters` path for this book — most likely the **TechEmpower/anonymous delegate** (which never calls `planChapters`), or a stale Room cache. Pending the on-device datum: the shorts book's request URL / fictionId prefix (`api.notion.com/v1` = PAT vs `notion.so/api/v3` = unofficial). The collapse fix lands on this branch once that's known → then this closes #1621.

Refs #1621.

🤖 Generated with [Claude Code](https://claude.com/claude-code)