### PR TITLE
fix(sources): shared jsoup HTML→text util; fix RSS & Standard Ebooks paragraph/entity loss (#1626, #1627)

### DIFF
--- a/core-data/build.gradle.kts
+++ b/core-data/build.gradle.kts
@@ -75,6 +75,9 @@ dependencies {
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.kotlinx.serialization.json)
 
+    // #1628 — shared HTML→plaintext (htmlToPlainText) for chapter bodies.
+    implementation(libs.jsoup)
+
     // Android KTX (provides SharedPreferences.edit { ... })
     implementation(libs.androidx.core.ktx)
 

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/text/HtmlPlainText.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/text/HtmlPlainText.kt
@@ -1,0 +1,80 @@
+package `in`.jphe.storyvox.data.text
+
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Element
+import org.jsoup.nodes.Node
+import org.jsoup.nodes.TextNode
+import org.jsoup.select.NodeVisitor
+
+/**
+ * Issue #1628 — the single, shared HTML → plaintext conversion for chapter /
+ * content bodies. Every source should use this instead of a hand-rolled
+ * regex stripper.
+ *
+ * The reader, the TTS `SentenceChunker`, and paragraph-level navigation all
+ * consume `ChapterContent.plainBody`, and paragraph-nav infers paragraph
+ * breaks from blank lines (`\n\n`) in that string. A source that flattens
+ * its HTML to a single line (the #1619 / #1623 / #1626 / #1627 class)
+ * produces a run-on blob, silently breaks paragraph navigation, and — if it
+ * doesn't decode entities — leaks `&amp;` / `&#8217;` / `&rsquo;` into the
+ * reader and, worse, into TTS narration.
+ *
+ * Implementation: parse to a DOM (jsoup — robust on the malformed markup
+ * real RSS feeds and scraped chapters emit, where regex strippers break),
+ * drop non-content nodes, append a blank line after each block element (the
+ * exact signal `paragraphHeadIndices` keys on) and a single `\n` for `<br>`,
+ * and let jsoup decode entities natively (covering curly quotes, em-dashes,
+ * numeric refs — which the per-source regex entity tables miss).
+ *
+ * Handles both full XHTML documents (EPUB chapter files, `<html><head>…`)
+ * and bare fragments (RSS item bodies, scraped chapter HTML): jsoup wraps a
+ * fragment in a `<body>`, and a fragment simply has no head/style to drop.
+ *
+ * Known limitation: whitespace inside `<pre>` is normalized like ordinary
+ * prose (jsoup `TextNode.text()`); rare in prose content, a verbatim-`<pre>`
+ * mode is a follow-up if a real book ever needs it.
+ */
+fun String.htmlToPlainText(): String {
+    if (isBlank()) return ""
+    val doc = Jsoup.parse(this)
+    // Non-content: strip so their text never reaches the reader / narration.
+    doc.select("head, script, style, noscript, svg, title").remove()
+    val sb = StringBuilder()
+    doc.body().traverse(object : NodeVisitor {
+        override fun head(node: Node, depth: Int) {
+            when {
+                node is TextNode -> sb.append(node.text())
+                node is Element && node.normalName() == "br" -> sb.append('\n')
+            }
+        }
+
+        override fun tail(node: Node, depth: Int) {
+            // Blank line after each block so paragraph-nav sees the break;
+            // runs of block-closes collapse to one gap in normalization.
+            if (node is Element && node.normalName() in HTML_BLOCK_TAGS) {
+                sb.append("\n\n")
+            }
+        }
+    })
+    return sb.toString().normalizeBlockWhitespace()
+}
+
+/** Block-level tags whose close introduces a paragraph break. Inline tags
+ *  (`<em>`, `<strong>`, `<a>`, …) are intentionally absent so their text
+ *  stays on the same line. */
+private val HTML_BLOCK_TAGS: Set<String> = setOf(
+    "p", "div", "section", "article", "header", "footer", "aside", "main",
+    "blockquote", "pre", "figure", "figcaption",
+    "h1", "h2", "h3", "h4", "h5", "h6",
+    "ul", "ol", "li", "dl", "dt", "dd",
+    "table", "tr", "hr",
+)
+
+/** Collapse horizontal whitespace, trim each line's edges, cap blank runs,
+ *  and trim — while preserving `\n` (line) and `\n\n` (paragraph). */
+private fun String.normalizeBlockWhitespace(): String =
+    replace('\r', '\n')
+        .replace(Regex("[ \\t\\x0B\\u000C]+"), " ")
+        .replace(Regex(" *\n *"), "\n")
+        .replace(Regex("\n{3,}"), "\n\n")
+        .trim()

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/text/HtmlPlainTextTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/text/HtmlPlainTextTest.kt
@@ -1,0 +1,168 @@
+package `in`.jphe.storyvox.data.text
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1628 — shared HTML → plaintext conversion, consumed by every source
+ * for `ChapterContent.plainBody`.
+ *
+ * Content that flattens to one line (the #1619 / #1623 / #1626 / #1627 class)
+ * produces a run-on blob, breaks paragraph-level navigation (which keys on
+ * blank lines), and — without entity decoding — leaks `&…;` codes into the
+ * reader and TTS narration. [htmlToPlainText] parses to a DOM, drops
+ * non-content nodes, inserts `\n\n` after each block element and `\n` for
+ * `<br>`, and decodes entities natively.
+ *
+ * Pure-function tests over both full XHTML documents (EPUB chapter files) and
+ * bare fragments (RSS item bodies / scraped chapter HTML).
+ */
+class HtmlPlainTextTest {
+
+    /** Blank-line-separated paragraph count — the signal paragraph-nav uses. */
+    private fun paragraphCount(body: String): Int =
+        body.split(Regex("\n[ \t]*\n")).count { it.isNotBlank() }
+
+    // ── full XHTML documents (EPUB chapter files) ───────────────────
+
+    @Test
+    fun `full XHTML document drops head, style, and title text`() {
+        val html = """
+            <html><head><title>Book Title</title>
+            <style>.c{color:red}</style></head>
+            <body><p>Hello world.</p></body></html>
+        """.trimIndent()
+        val out = html.htmlToPlainText()
+
+        assertEquals("Hello world.", out)
+        assertFalse("title text leaked", out.contains("Book Title"))
+        assertFalse("css leaked", out.contains("color"))
+    }
+
+    @Test
+    fun `script content is dropped`() {
+        val out = "<body><script>alert('boom')</script><p>Real content.</p></body>"
+            .htmlToPlainText()
+        assertFalse(out.contains("alert"))
+        assertFalse(out.contains("boom"))
+        assertTrue(out.contains("Real content."))
+    }
+
+    @Test
+    fun `realistic EPUB chapter keeps paragraphs, decodes entities, drops style`() {
+        val html = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <!DOCTYPE html>
+            <html xmlns="http://www.w3.org/1999/xhtml"><head>
+            <title>Ch 1</title>
+            <link rel="stylesheet" type="text/css" href="../css/style.css"/>
+            <style>p{text-indent:1em}</style>
+            </head>
+            <body>
+            <h1>Chapter 1</h1>
+            <p>It was a bright cold day in April, and the clocks were striking thirteen.</p>
+            <p>Winston Smith, his chin nuzzled into his breast&#8217;s warmth, slipped
+            quickly through the glass doors.</p>
+            </body></html>
+        """.trimIndent()
+        val out = html.htmlToPlainText()
+
+        assertEquals("three paragraphs preserved", 3, paragraphCount(out))
+        assertTrue(out.contains("Chapter 1"))
+        assertTrue("entity decoded to curly apostrophe", out.contains("breast’s"))
+        // Intra-paragraph source newline is HTML whitespace -> single space.
+        assertTrue(out.contains("slipped quickly"))
+        assertFalse("css never reaches prose", out.contains("text-indent"))
+        assertFalse("head title never reaches prose", out.contains("Ch 1"))
+        assertFalse(out.contains("&#8217;"))
+    }
+
+    // ── bare fragments (RSS item bodies, scraped chapter HTML) ──────
+
+    @Test
+    fun `bare fragment without html or body wrapper keeps paragraphs`() {
+        // RSS content:encoded / Standard Ebooks chapter fragment shape.
+        val out = "<p>First para.</p><p>Second para.</p>".htmlToPlainText()
+        assertEquals("First para.\n\nSecond para.", out)
+        assertEquals(2, paragraphCount(out))
+    }
+
+    @Test
+    fun `fragment with mixed block levels and entities`() {
+        val out = ("<h2>Heading</h2><p>Body with &amp; an &rsquo;entity&rsquo; " +
+            "and a<br>soft break.</p>").htmlToPlainText()
+        assertEquals(2, paragraphCount(out))
+        assertTrue(out.contains("Body with & an ’entity’"))
+        assertTrue("br is a soft line break", out.contains("a\nsoft break."))
+        assertFalse(out.contains("&amp;"))
+        assertFalse(out.contains("&rsquo;"))
+    }
+
+    // ── general block / inline / entity / whitespace contract ───────
+
+    @Test
+    fun `consecutive paragraphs are separated by a blank line`() {
+        val out = "<body><p>First paragraph.</p><p>Second paragraph.</p></body>"
+            .htmlToPlainText()
+        assertEquals("First paragraph.\n\nSecond paragraph.", out)
+        assertEquals(2, paragraphCount(out))
+    }
+
+    @Test
+    fun `br becomes a single soft line break, not a paragraph break`() {
+        val out = "<body><p>Line one<br>Line two</p></body>".htmlToPlainText()
+        assertEquals("Line one\nLine two", out)
+    }
+
+    @Test
+    fun `headings are separated from the following paragraph`() {
+        val out = "<body><h1>Chapter One</h1><p>The story begins.</p></body>"
+            .htmlToPlainText()
+        assertEquals("Chapter One\n\nThe story begins.", out)
+    }
+
+    @Test
+    fun `nested blocks do not stack up extra blank lines`() {
+        val out = "<body><div><p>Inside.</p></div><p>After.</p></body>".htmlToPlainText()
+        // <p> close + <div> close would emit two blank lines; capped to one.
+        assertEquals("Inside.\n\nAfter.", out)
+    }
+
+    @Test
+    fun `inline tags stay on the same line`() {
+        val out = "<body><p>a <em>b</em> c <strong>d</strong></p></body>".htmlToPlainText()
+        assertFalse("inline tags must not introduce line breaks", out.contains("\n"))
+        assertTrue(out.contains("b"))
+        assertTrue(out.contains("d"))
+    }
+
+    @Test
+    fun `named and numeric entities are decoded, not leaked`() {
+        val out = "<body><p>Tom &amp; Jerry &rsquo;quote&rsquo; &mdash; end&hellip;</p></body>"
+            .htmlToPlainText()
+        assertTrue(out.contains("Tom & Jerry"))
+        assertTrue("right single quote decoded", out.contains("’"))
+        assertTrue("em-dash decoded", out.contains("—"))
+        assertTrue("ellipsis decoded", out.contains("…"))
+        assertFalse(out.contains("&amp;"))
+        assertFalse(out.contains("&rsquo;"))
+        assertFalse(out.contains("&mdash;"))
+        assertFalse(out.contains("&hellip;"))
+    }
+
+    @Test
+    fun `blank and empty inputs yield empty string`() {
+        assertEquals("", "".htmlToPlainText())
+        assertEquals("", "   \n\t ".htmlToPlainText())
+        assertEquals("", "<body></body>".htmlToPlainText())
+    }
+
+    @Test
+    fun `single paragraph produces no spurious line breaks`() {
+        val out = "<body><p>Just one paragraph here.</p></body>".htmlToPlainText()
+        assertEquals("Just one paragraph here.", out)
+        assertFalse(out.contains("\n"))
+    }
+}

--- a/source-rss/src/main/kotlin/in/jphe/storyvox/source/rss/RssSource.kt
+++ b/source-rss/src/main/kotlin/in/jphe/storyvox/source/rss/RssSource.kt
@@ -16,6 +16,7 @@ import `in`.jphe.storyvox.data.source.model.FictionSummary
 import `in`.jphe.storyvox.data.source.model.ListPage
 import `in`.jphe.storyvox.data.source.model.SearchOrder
 import `in`.jphe.storyvox.data.source.model.SearchQuery
+import `in`.jphe.storyvox.data.text.htmlToPlainText
 import `in`.jphe.storyvox.source.rss.config.RssConfig
 import `in`.jphe.storyvox.source.rss.config.RssSubscription
 import `in`.jphe.storyvox.source.rss.net.FetchResult
@@ -286,7 +287,7 @@ internal class RssSource @Inject constructor(
             if (html.isBlank()) null
             else item.toChapterId(fictionId) to ChapterBody(
                 htmlBody = html,
-                plainBody = html.stripHtml(),
+                plainBody = html.htmlToPlainText(),
             )
         }.toMap()
 
@@ -355,7 +356,7 @@ internal class RssSource @Inject constructor(
             ChapterContent(
                 info = info,
                 htmlBody = item.htmlBody,
-                plainBody = item.htmlBody.stripHtml(),
+                plainBody = item.htmlBody.htmlToPlainText(),
             ),
         )
     }
@@ -489,18 +490,7 @@ private fun RssItem.toChapterInfo(index: Int, fictionId: String): ChapterInfo {
     )
 }
 
-/** #1547 review — hoisted out of [stripHtml] so the patterns compile once
- *  at class-load instead of on every call. [stripHtml] runs per feed item
- *  during a detail refresh (#1497), so per-call `Regex(...)` construction
- *  was needless allocation on the hot path. */
-private val HTML_TAG_REGEX = Regex("<[^>]+>")
-private val WHITESPACE_REGEX = Regex("\\s+")
-
-/** Naive HTML strip for the TTS plaintext. EngineStreamingSource
- *  applies further normalization downstream — this just removes
- *  tags and collapses whitespace so the engine doesn't speak
- *  `<p>...</p>`. */
-private fun String.stripHtml(): String =
-    replace(HTML_TAG_REGEX, " ")
-        .replace(WHITESPACE_REGEX, " ")
-        .trim()
+// #1626 / #1628 — HTML→plaintext now uses the shared, paragraph-preserving,
+// entity-decoding `htmlToPlainText` in core-data (jsoup). The old local
+// `stripHtml` collapsed every newline to a space (run-on blob, broke
+// paragraph-nav) and never decoded entities.

--- a/source-standard-ebooks/src/main/kotlin/in/jphe/storyvox/source/standardebooks/StandardEbooksSource.kt
+++ b/source-standard-ebooks/src/main/kotlin/in/jphe/storyvox/source/standardebooks/StandardEbooksSource.kt
@@ -15,6 +15,7 @@ import `in`.jphe.storyvox.data.source.model.FictionSummary
 import `in`.jphe.storyvox.data.source.model.ListPage
 import `in`.jphe.storyvox.data.source.model.SearchOrder
 import `in`.jphe.storyvox.data.source.model.SearchQuery
+import `in`.jphe.storyvox.data.text.htmlToPlainText
 import `in`.jphe.storyvox.data.source.model.map
 import `in`.jphe.storyvox.source.epub.parse.EpubBook
 import `in`.jphe.storyvox.source.epub.parse.EpubParseException
@@ -252,7 +253,7 @@ internal class StandardEbooksSource @Inject constructor(
             ChapterContent(
                 info = info,
                 htmlBody = ch.htmlBody,
-                plainBody = ch.htmlBody.stripTags(),
+                plainBody = ch.htmlBody.htmlToPlainText(),
             ),
         )
     }
@@ -451,11 +452,8 @@ private fun String.slugToDisplay(): String =
         piece.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }
     }
 
-/** Cheap HTML→plaintext for the chapter body the engine receives.
- *  The downstream pipeline normalizes further; this just gets the
- *  visible text out of the wrapper tags so the TTS engine doesn't
- *  read out angle-bracket noise. */
-private fun String.stripTags(): String =
-    Regex("<[^>]+>").replace(this, " ")
-        .replace(Regex("\\s+"), " ")
-        .trim()
+// #1627 / #1628 — chapter-body HTML→plaintext now uses the shared,
+// paragraph-preserving, entity-decoding `htmlToPlainText` in core-data
+// (jsoup). The old local `stripTags` collapsed every newline to a space
+// (run-on blob across a whole literary chapter, broke paragraph-nav) and
+// never decoded entities (curly quotes/em-dashes leaked into narration).


### PR DESCRIPTION
## What & why

Bug-hunt follow-up. RSS (**#1626**) and Standard Ebooks (**#1627**) had the exact content-mangling class as #1619/#1623: chapter `plainBody` came from hand-rolled `stripHtml`/`stripTags` that **collapsed every newline** (`\s+`→`" "`) and **never decoded entities**. The reader, the TTS `SentenceChunker`, and paragraph-level navigation all read `plainBody`, so multi-paragraph posts/books rendered as one run-on blob with literal `&amp;`/`&#8217;` leaking into the reader — and into TTS narration. Standard Ebooks (classic literature, pervasive curly quotes/em-dashes) was hit hardest.

## Approach — shared util (#1628), per the agreed plan

Rather than add per-module jsoup copies, this lifts the #1625 `EpubSource.htmlToPlainText` into **one shared `core-data` util** and migrates the two HIGH sources through it, so #1626/#1627 close **via the shared util directly — no per-module dup to unwind later**.

- **New:** `core-data/.../data/text/HtmlPlainText.kt` — `fun String.htmlToPlainText()`. jsoup DOM parse → drop `head`/`script`/`style`/`svg`/`title` → `\n\n` after each block element (the signal `paragraphHeadIndices` keys on) → `\n` for `<br>` → native entity decode. Handles both full XHTML documents (EPUB) and bare fragments (RSS item bodies, scraped chapters). jsoup is robust on the malformed markup real RSS feeds emit — the win called out in the hunt.
- **core-data** gains `implementation(libs.jsoup)` (already a dep in `source-royalroad`/`source-epub`). jsoup reaches RSS/SE **transitively at runtime** via core-data; neither module references jsoup types directly.
- **source-rss** (#1626) and **source-standard-ebooks** (#1627): migrated to the shared util; local `stripHtml`/`stripTags` deleted.

## Not broken

- `SeHtmlParser.stripTags` (Standard Ebooks **browse-listing** titles/descriptions) is a separate private fn — intentionally untouched.
- RSS's hoisted `HTML_TAG_REGEX`/`WHITESPACE_REGEX` were used only by the deleted `stripHtml` — removed, no dangling refs.
- source-epub is untouched this PR (keeps its local, already-correct copy) — folded into the follow-up below to avoid touching the just-merged #1625 file.

## Tests

`core-data/.../HtmlPlainTextTest` — the transformation is exercised over **full XHTML documents** (EPUB shape) **and bare fragments** (RSS/SE shape): block structure → blank lines, `<br>` → soft break, nested-blocks-don't-stack, inline-tags-stay-inline, **named + numeric entities decoded**, blank/empty. The RSS/SE change itself is a mechanical call-site swap to this tested util (compile-gated by CI). No heavy per-source feed/scrape plumbing test — the fragment fixtures directly simulate RSS/SE content.

## Follow-up (Refs #1628)

One consolidation PR to migrate the remaining strippers to the shared util and delete them: **source-epub** (origin of the lift) + **Wikipedia / PLOS / Wikisource** (which preserve paragraphs but have limited entity tables → curly-quote/numeric-ref leaks, MEDIUM).

Closes #1626
Closes #1627
Refs #1628
