### PR TITLE
fix(cache): revalidate stale chapter LISTS on parse-logic bump — CHAPTER_PLAN_VERSION (#1621)

### DIFF
--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/StoryvoxDatabase.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/StoryvoxDatabase.kt
@@ -102,7 +102,14 @@ import `in`.jphe.storyvox.data.db.entity.TeleprompterScript
     // user-authored teleprompter scripts (save/edit/organize). Purely additive
     // new table; no FK (scripts are independent of fiction/chapter). See
     // MIGRATION_17_18.
-    version = 18,
+    //
+    // v19 (#1621 chapter-plan version) — adds `fiction.chapterPlanVersion`,
+    // stamping which chapter-LIST planning version a row was cached under so
+    // a source's list-logic improvement (e.g. #1508's Notion child_page
+    // split) force-revalidates pre-improvement caches on next open instead of
+    // serving a structurally-stale list. Purely additive NOT NULL DEFAULT 0
+    // column. See MIGRATION_18_19.
+    version = 19,
     exportSchema = true,
 )
 @TypeConverters(Converters::class)

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/FictionDao.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/dao/FictionDao.kt
@@ -241,6 +241,11 @@ interface FictionDao {
                 // poll worker writes this column. Preserve so a browse
                 // upsert doesn't reset the cheap-poll state.
                 lastSeenRevision = existing.lastSeenRevision,
+                // #1621 — the chapter-plan version stamps the chapter LIST
+                // structure, which a listing doesn't re-plan. Preserve it so
+                // a browse upsert doesn't spuriously mark a detail-fetched
+                // row plan-stale and trigger a needless re-fetch on open.
+                chapterPlanVersion = existing.chapterPlanVersion,
             )
         }
         upsertMany(merged)

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/entity/Fiction.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/entity/Fiction.kt
@@ -121,7 +121,7 @@ data class Fiction(
      */
     val playbackSpeed: Float? = null,
     /**
-     * Issue #1621 — the [in.jphe.storyvox.data.repository.FictionRepositoryImpl.CHAPTER_PLAN_VERSION]
+     * Issue #1621 — the [in.jphe.storyvox.data.repository.CHAPTER_PLAN_VERSION]
      * this row's cached chapter LIST was planned under.
      *
      * When a source's chapter-list planning logic improves (e.g. #1508

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/entity/Fiction.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/entity/Fiction.kt
@@ -120,6 +120,27 @@ data class Fiction(
      * browse-listing upserts in [FictionDao.upsertAllPreservingUserState].
      */
     val playbackSpeed: Float? = null,
+    /**
+     * Issue #1621 — the [in.jphe.storyvox.data.repository.FictionRepositoryImpl.CHAPTER_PLAN_VERSION]
+     * this row's cached chapter LIST was planned under.
+     *
+     * When a source's chapter-list planning logic improves (e.g. #1508
+     * taught Notion to split `child_page` sub-pages into chapters), lists
+     * cached by the older logic are structurally stale — even though
+     * chapter *bodies* self-heal on logic changes via `CHUNKER_VERSION`
+     * (baked into the PCM cache key) and `bodyChecksum`. The chapter LIST
+     * had no such stamp, so a pre-improvement cache kept showing the old
+     * structure (e.g. JP's shorts collapsed to 1 chapter) until the #1314
+     * TTL lapsed and a refresh happened to fire.
+     *
+     * `refreshDetail` force-revalidates any row whose stamp is below the
+     * current version (bypassing the TTL), so a pre-improvement cache
+     * re-fetches once on next open and re-plans. Defaults to 0 (the
+     * implicit pre-stamp version) so every existing row revalidates once
+     * after the migration. Preserved across browse-listing upserts — a
+     * listing doesn't re-plan chapters, so it must not reset the stamp.
+     */
+    val chapterPlanVersion: Int = 0,
 ) {
     companion object {
         /**

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/db/migration/Migrations.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/db/migration/Migrations.kt
@@ -551,6 +551,19 @@ val MIGRATION_17_18: Migration = object : Migration(17, 18) {
     }
 }
 
+// v19 (#1621 chapter-plan version) — additive column stamping which
+// CHAPTER_PLAN_VERSION a row's cached chapter LIST was planned under.
+// Default 0 (the implicit pre-stamp version) marks every existing row
+// plan-stale, so it revalidates once on next open and re-plans its chapter
+// list (e.g. picking up #1508's Notion child_page split). Purely additive.
+val MIGRATION_18_19: Migration = object : Migration(18, 19) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            "ALTER TABLE `fiction` ADD COLUMN `chapterPlanVersion` INTEGER NOT NULL DEFAULT 0",
+        )
+    }
+}
+
 val ALL_MIGRATIONS: Array<Migration> = arrayOf(
     MIGRATION_1_2,
     MIGRATION_2_3,
@@ -569,4 +582,5 @@ val ALL_MIGRATIONS: Array<Migration> = arrayOf(
     MIGRATION_15_16,
     MIGRATION_16_17,
     MIGRATION_17_18,
+    MIGRATION_18_19,
 )

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
@@ -602,22 +602,6 @@ class FictionRepositoryImpl @Inject constructor(
          * manual Retry button pass `force = true` to bypass it entirely.
          */
         const val METADATA_TTL_MS: Long = 5 * 60 * 1000L
-
-        /**
-         * Issue #1621 — version of the chapter-LIST planning logic
-         * (`FictionDetail.chapters`), across all sources. **Bump this in the
-         * same change that alters how any source builds its chapter list**
-         * (e.g. #1508's Notion `child_page` split). A row whose
-         * [Fiction.chapterPlanVersion] is below this is force-revalidated by
-         * [refreshDetail] on next open (bypassing [METADATA_TTL_MS]), so a
-         * list cached under the old logic re-fetches once and re-plans — the
-         * structural-list analog of `CHUNKER_VERSION` for body audio.
-         *
-         * Started at 1: pre-existing rows carry the migration default 0 and
-         * so revalidate once after this ships (fixing #1621's shorts and any
-         * other pre-#1508 cached list).
-         */
-        const val CHAPTER_PLAN_VERSION: Int = 1
     }
 
     // ─── helpers ──────────────────────────────────────────────────────────
@@ -761,6 +745,23 @@ internal fun Fiction.toSummary(supportsFollow: Boolean = false): FictionSummary 
 )
 
 /**
+ * Issue #1621 — version of the chapter-LIST planning logic
+ * (`FictionDetail.chapters`), across all sources. **Bump this in the same
+ * change that alters how any source builds its chapter list** (e.g. #1508's
+ * Notion `child_page` split). A row whose [Fiction.chapterPlanVersion] is
+ * below this is force-revalidated by [FictionRepositoryImpl.refreshDetail]
+ * on next open (bypassing the metadata TTL), so a list cached under the old
+ * logic re-fetches once and re-plans — the structural-list analog of
+ * `CHUNKER_VERSION` for body audio.
+ *
+ * Top-level (like `CHUNKER_VERSION`) so the pure [shouldServeCachedDetail]
+ * guard, the `toEntity` stamp, and tests can read it without widening the
+ * repository's private companion. Started at 1: pre-existing rows carry the
+ * migration default 0 and revalidate once after this ships.
+ */
+internal const val CHAPTER_PLAN_VERSION: Int = 1
+
+/**
  * Issue #1314 / #1621 — the stale-while-revalidate skip decision for
  * [FictionRepositoryImpl.refreshDetail], extracted pure so the exact guard
  * conditions are unit-testable without standing up the whole repository.
@@ -846,7 +847,7 @@ internal fun FictionDetail.toEntity(existing: Fiction?, now: Long): Fiction {
         // #1621 — stamp the plan version only on a real hydrate (same gate
         // as metadataFetchedAt): the chapter list we just wrote was planned
         // by the current logic, so it's no longer plan-stale.
-        chapterPlanVersion = if (hydrated) FictionRepositoryImpl.CHAPTER_PLAN_VERSION else base.chapterPlanVersion,
+        chapterPlanVersion = if (hydrated) CHAPTER_PLAN_VERSION else base.chapterPlanVersion,
     )
 }
 

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/FictionRepository.kt
@@ -338,8 +338,19 @@ class FictionRepositoryImpl @Inject constructor(
         // next open re-fetches and repopulates the chapter rows.
         val chaptersOrphan = existing != null && existing.chapterCount > 0 &&
             chapterDao.chapterIdsForFiction(id).isEmpty()
-        if (!force && !chaptersOrphan && existing != null && existing.metadataFetchedAt > 0L &&
-            System.currentTimeMillis() - existing.metadataFetchedAt < METADATA_TTL_MS
+        // #1621 — a row whose chapter LIST was planned by an older
+        // CHAPTER_PLAN_VERSION is structurally stale (e.g. a pre-#1508
+        // Notion list that collapsed sub-pages into one chapter). Force a
+        // re-plan even within the TTL — same bypass shape as `chaptersOrphan`.
+        val planStale = existing != null && existing.chapterPlanVersion < CHAPTER_PLAN_VERSION
+        if (existing != null && shouldServeCachedDetail(
+                force = force,
+                chaptersOrphan = chaptersOrphan,
+                planStale = planStale,
+                metadataFetchedAt = existing.metadataFetchedAt,
+                ageMs = System.currentTimeMillis() - existing.metadataFetchedAt,
+                ttlMs = METADATA_TTL_MS,
+            )
         ) {
             return@withContext FictionResult.Success(Unit)
         }
@@ -591,6 +602,22 @@ class FictionRepositoryImpl @Inject constructor(
          * manual Retry button pass `force = true` to bypass it entirely.
          */
         const val METADATA_TTL_MS: Long = 5 * 60 * 1000L
+
+        /**
+         * Issue #1621 — version of the chapter-LIST planning logic
+         * (`FictionDetail.chapters`), across all sources. **Bump this in the
+         * same change that alters how any source builds its chapter list**
+         * (e.g. #1508's Notion `child_page` split). A row whose
+         * [Fiction.chapterPlanVersion] is below this is force-revalidated by
+         * [refreshDetail] on next open (bypassing [METADATA_TTL_MS]), so a
+         * list cached under the old logic re-fetches once and re-plans — the
+         * structural-list analog of `CHUNKER_VERSION` for body audio.
+         *
+         * Started at 1: pre-existing rows carry the migration default 0 and
+         * so revalidate once after this ships (fixing #1621's shorts and any
+         * other pre-#1508 cached list).
+         */
+        const val CHAPTER_PLAN_VERSION: Int = 1
     }
 
     // ─── helpers ──────────────────────────────────────────────────────────
@@ -733,6 +760,28 @@ internal fun Fiction.toSummary(supportsFollow: Boolean = false): FictionSummary 
     backfillFailed = metadataBackfillFailedAt != null,
 )
 
+/**
+ * Issue #1314 / #1621 — the stale-while-revalidate skip decision for
+ * [FictionRepositoryImpl.refreshDetail], extracted pure so the exact guard
+ * conditions are unit-testable without standing up the whole repository.
+ *
+ * Serve the cached detail (skip the network round-trip) iff ALL hold: the
+ * caller didn't [force]; the chapter rows aren't orphaned (#1433
+ * [chaptersOrphan]); the cached list isn't from an older plan version
+ * (#1621 [planStale]); the row is fully hydrated ([metadataFetchedAt] > 0,
+ * excluding #981 placeholders); and that hydrate is younger than the TTL
+ * ([ageMs] < [ttlMs]). [ageMs] may be negative under clock skew, which is
+ * still < TTL and safely skips (don't hammer the source).
+ */
+internal fun shouldServeCachedDetail(
+    force: Boolean,
+    chaptersOrphan: Boolean,
+    planStale: Boolean,
+    metadataFetchedAt: Long,
+    ageMs: Long,
+    ttlMs: Long,
+): Boolean = !force && !chaptersOrphan && !planStale && metadataFetchedAt > 0L && ageMs < ttlMs
+
 internal fun FictionSummary.toEntity(now: Long): Fiction = Fiction(
     id = id,
     sourceId = sourceId,
@@ -794,6 +843,10 @@ internal fun FictionDetail.toEntity(existing: Fiction?, now: Long): Fiction {
         followers = followers ?: base.followers,
         lastUpdatedAt = lastUpdatedAt ?: base.lastUpdatedAt,
         metadataFetchedAt = if (hydrated) now else base.metadataFetchedAt,
+        // #1621 — stamp the plan version only on a real hydrate (same gate
+        // as metadataFetchedAt): the chapter list we just wrote was planned
+        // by the current logic, so it's no longer plan-stale.
+        chapterPlanVersion = if (hydrated) FictionRepositoryImpl.CHAPTER_PLAN_VERSION else base.chapterPlanVersion,
     )
 }
 

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/ShouldServeCachedDetailTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/ShouldServeCachedDetailTest.kt
@@ -1,0 +1,86 @@
+package `in`.jphe.storyvox.data.repository
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the stale-while-revalidate skip decision (#1314) + the #1621
+ * plan-version bypass. Pure JVM — no Room, no repository wiring.
+ */
+class ShouldServeCachedDetailTest {
+
+    private val ttl = FictionRepositoryImpl.METADATA_TTL_MS
+    private val fresh = 1_000L // age well within the TTL
+
+    @Test fun `serves cache when hydrated, current plan, within TTL`() {
+        assertTrue(
+            shouldServeCachedDetail(
+                force = false, chaptersOrphan = false, planStale = false,
+                metadataFetchedAt = 1L, ageMs = fresh, ttlMs = ttl,
+            ),
+        )
+    }
+
+    @Test fun `1621 — does NOT serve a plan-stale cache, even within TTL`() {
+        // The core #1621 fix: a list cached under an older CHAPTER_PLAN_VERSION
+        // must re-fetch on next open regardless of the 5-min TTL.
+        assertFalse(
+            shouldServeCachedDetail(
+                force = false, chaptersOrphan = false, planStale = true,
+                metadataFetchedAt = 1L, ageMs = fresh, ttlMs = ttl,
+            ),
+        )
+    }
+
+    @Test fun `does not serve when forced`() {
+        assertFalse(
+            shouldServeCachedDetail(
+                force = true, chaptersOrphan = false, planStale = false,
+                metadataFetchedAt = 1L, ageMs = fresh, ttlMs = ttl,
+            ),
+        )
+    }
+
+    @Test fun `does not serve when chapter rows are orphaned`() {
+        assertFalse(
+            shouldServeCachedDetail(
+                force = false, chaptersOrphan = true, planStale = false,
+                metadataFetchedAt = 1L, ageMs = fresh, ttlMs = ttl,
+            ),
+        )
+    }
+
+    @Test fun `does not serve a placeholder row (metadataFetchedAt 0)`() {
+        assertFalse(
+            shouldServeCachedDetail(
+                force = false, chaptersOrphan = false, planStale = false,
+                metadataFetchedAt = 0L, ageMs = fresh, ttlMs = ttl,
+            ),
+        )
+    }
+
+    @Test fun `does not serve past the TTL`() {
+        assertFalse(
+            shouldServeCachedDetail(
+                force = false, chaptersOrphan = false, planStale = false,
+                metadataFetchedAt = 1L, ageMs = ttl + 1, ttlMs = ttl,
+            ),
+        )
+    }
+
+    @Test fun `serves under negative age (clock skew) — safe direction`() {
+        assertTrue(
+            shouldServeCachedDetail(
+                force = false, chaptersOrphan = false, planStale = false,
+                metadataFetchedAt = 1L, ageMs = -5_000L, ttlMs = ttl,
+            ),
+        )
+    }
+
+    @Test fun `CHAPTER_PLAN_VERSION is positive so migration-default-0 rows revalidate once`() {
+        // The v19 migration adds the column with DEFAULT 0; every pre-existing
+        // row must read as older-than-current (planStale) so it re-plans once.
+        assertTrue(0 < FictionRepositoryImpl.CHAPTER_PLAN_VERSION)
+    }
+}

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/ShouldServeCachedDetailTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/repository/ShouldServeCachedDetailTest.kt
@@ -10,7 +10,7 @@ import org.junit.Test
  */
 class ShouldServeCachedDetailTest {
 
-    private val ttl = FictionRepositoryImpl.METADATA_TTL_MS
+    private val ttl = 300_000L // mirrors METADATA_TTL_MS; the guard takes it as a param
     private val fresh = 1_000L // age well within the TTL
 
     @Test fun `serves cache when hydrated, current plan, within TTL`() {
@@ -81,6 +81,6 @@ class ShouldServeCachedDetailTest {
     @Test fun `CHAPTER_PLAN_VERSION is positive so migration-default-0 rows revalidate once`() {
         // The v19 migration adds the column with DEFAULT 0; every pre-existing
         // row must read as older-than-current (planStale) so it re-plans once.
-        assertTrue(0 < FictionRepositoryImpl.CHAPTER_PLAN_VERSION)
+        assertTrue(0 < CHAPTER_PLAN_VERSION)
     }
 }


### PR DESCRIPTION
## Root cause (confirmed on-device)

JP force-refreshed his Notion shorts and **1 chapter → 21** — proving the collapse was a **stale cached chapter LIST**, not a parse/split bug (the fresh fetch splits correctly). When a source's chapter-**list** planning logic improves (e.g. #1508 taught Notion to split `child_page` sub-pages), lists cached by the *old* logic stay structurally stale. Chapter **bodies** self-heal on logic changes via `CHUNKER_VERSION` (baked into the PCM cache key) + `bodyChecksum` — but the chapter **list** had no analogous stamp, so a pre-improvement cache kept serving the old structure until the #1314 TTL happened to lapse.

## Fix — the structural-list analog of `CHUNKER_VERSION`

- **`Fiction.chapterPlanVersion`** (Room **v19**, additive `ALTER TABLE`, default 0) — stamps which plan version a row's cached list was built under.
- **`FictionRepositoryImpl.CHAPTER_PLAN_VERSION = 1`** — bump this in the same change that alters *any* source's chapter-list planning.
- **`refreshDetail`'s SWR guard** treats `cached < current` as plan-stale → force-revalidate (bypassing the 5-min TTL), the same bypass shape as the #1433 `chaptersOrphan` guard. The skip decision is extracted to a pure, unit-tested **`shouldServeCachedDetail(...)`**.
- **`toEntity`** stamps the current version on a real hydrate; the **browse-listing upsert preserves it** (a listing doesn't re-plan chapters, so it must not reset the stamp).

## Effect

Existing rows carry the migration-default `0`, so every pre-fix cache **re-plans exactly once on next open** — automatically self-healing JP's shorts (and anyone with a pre-#1508 cached list) *without* a manual refresh — then honors the 5-min TTL normally (no refetch loop; verified by the guard test). General fix across all sources. Minimal blast radius on the shared #1314 path (one added `&& !planStale` clause).

## Verification

- Pure unit test `ShouldServeCachedDetailTest` pins the guard (incl. the plan-stale bypass + boundaries).
- On-device (post-merge): open the shorts book *without* a manual refresh → it should now list all chapters on its own (`chapterPlanVersion 0 < 1` → auto-revalidate). JP's manual-refresh already proved the underlying refetch yields 21.
- Room schema JSON for v19 backfills on the next full build (`exportSchema` writes it); the migration is an additive `ALTER TABLE`, low-risk.

Closes #1621

🤖 Generated with [Claude Code](https://claude.com/claude-code)