### PR TITLE
feat(settings): Content Sources subscreen — un-bury per-source config (#1630)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -59,6 +59,7 @@ import `in`.jphe.storyvox.feature.settings.AppearanceSettingsScreen
 import `in`.jphe.storyvox.feature.settings.AiSettingsScreen
 import `in`.jphe.storyvox.feature.settings.BookshareSettingsScreen
 import `in`.jphe.storyvox.feature.settings.CloudVoicesSettingsScreen
+import `in`.jphe.storyvox.feature.settings.ContentSourcesSettingsScreen
 import `in`.jphe.storyvox.feature.settings.MemoryPalaceSettingsScreen
 import `in`.jphe.storyvox.feature.settings.PerformanceSettingsScreen
 import `in`.jphe.storyvox.feature.settings.ReadingSettingsScreen
@@ -203,6 +204,10 @@ object StoryvoxRoutes {
      *  Azure plugin row. Hosts the same [AzureSection] composable as the
      *  legacy page, so the two surfaces stay byte-identical. */
     const val SETTINGS_CLOUD_VOICES = "settings/cloud-voices"
+    /** Settings → Content Sources (#1630). Per-source keys/tokens/URLs — the
+     *  generic SourceConfigContributor seam, un-buried from the legacy
+     *  [SETTINGS] monolith into a dedicated route under Content & Sources. */
+    const val SETTINGS_CONTENT_SOURCES = "settings/content-sources"
     /** Settings → Account. Royal Road sign-in, GitHub OAuth + scope. */
     const val SETTINGS_ACCOUNT = "settings/account"
     /** Settings → Memory Palace. Daemon host, API key, test probe. */
@@ -1246,6 +1251,8 @@ private fun StoryvoxNavHostContent(
                     // #1624 — Cloud Voices hub row (screen + route already
                     // existed; the hub just never surfaced it).
                     onOpenCloudVoices = { navController.navigate(StoryvoxRoutes.SETTINGS_CLOUD_VOICES) },
+                    // #1630 — Content Sources subscreen.
+                    onOpenContentSources = { navController.navigate(StoryvoxRoutes.SETTINGS_CONTENT_SOURCES) },
                 )
             }
 
@@ -1511,6 +1518,20 @@ private fun StoryvoxNavHostContent(
                 popExitTransition = popExit,
             ) {
                 CloudVoicesSettingsScreen(
+                    onBack = { navController.popBackStack() },
+                )
+            }
+            // Issue #1630 — Content Sources subscreen (the per-source config
+            // seam), un-buried from the legacy page into the Content & Sources
+            // group. Push transitions like the other Settings drill-downs.
+            composable(
+                StoryvoxRoutes.SETTINGS_CONTENT_SOURCES,
+                enterTransition = pushEnter,
+                exitTransition = pushExit,
+                popEnterTransition = popEnter,
+                popExitTransition = popExit,
+            ) {
+                ContentSourcesSettingsScreen(
                     onBack = { navController.popBackStack() },
                 )
             }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/ContentSourcesScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/ContentSourcesScreen.kt
@@ -1,0 +1,75 @@
+package `in`.jphe.storyvox.feature.settings
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import `in`.jphe.storyvox.feature.R
+import `in`.jphe.storyvox.ui.theme.LocalSpacing
+
+/**
+ * Issue #1630 — Settings → Content Sources subscreen (Wave 1 of the #1624
+ * settings overhaul; lives in the "Content & Sources" hub group).
+ *
+ * Per-source configuration — API keys, tokens, feed-URL overrides, behaviour
+ * toggles — used to be reachable ONLY by scrolling the 4,100-line legacy
+ * "All settings" monolith, so it was invisible to anyone navigating the
+ * grouped hub. This surfaces the SAME generic config-field seam (#1531:
+ * `SourceConfigContributor` → [UiSourceConfigSection], streamed on
+ * `UiSettings.sourceConfigSections`) behind a dedicated, discoverable route.
+ *
+ * It reuses the legacy screen's [SourceConfigSection] field editor verbatim
+ * (widened `private` → `internal` in #1630), so there is exactly ONE
+ * field-editor implementation, not a fork. The seam auto-grows: a new
+ * credentialed source that contributes a `SourceConfigContributor` appears
+ * here with zero edits to this file.
+ *
+ * Scope note (#1630 slice 1): renders every source already on the generic
+ * seam (Reddit, Notion, Prime Gaming, Slack, Matrix). Migrating the remaining
+ * bespoke legacy rows (Telegram, Outline, Google News, Wikipedia) onto the
+ * seam, and the bespoke tail (Discord server-select, Epub/Pdf folder pickers),
+ * are follow-up slices — each an independently shippable contributor.
+ */
+@Composable
+fun ContentSourcesSettingsScreen(
+    onBack: () -> Unit,
+    viewModel: SettingsViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val spacing = LocalSpacing.current
+
+    SettingsSubscreenScaffold(
+        title = stringResource(R.string.settings_hub_content_sources_title),
+        onBack = onBack,
+    ) { padding ->
+        val s = state.settings ?: run {
+            SettingsSkeleton(modifier = Modifier.fillMaxSize().padding(padding).padding(spacing.md))
+            return@SettingsSubscreenScaffold
+        }
+        SettingsSubscreenBody(padding) {
+            if (s.sourceConfigSections.isEmpty()) {
+                // Defensive: the live contributor set (#1531) always registers
+                // the credentialed sources, so this rarely shows — but if a
+                // build ships with none, a bare screen would read as broken.
+                Text(
+                    text = stringResource(R.string.settings_content_sources_empty),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            } else {
+                SettingsGroupCard {
+                    SourceConfigSection(
+                        sections = s.sourceConfigSections,
+                        onValueChange = viewModel::setSourceConfigValue,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsHubScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsHubScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.material.icons.outlined.ChevronRight
 import androidx.compose.material.icons.outlined.Extension
 import androidx.compose.material.icons.outlined.GraphicEq
 import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material.icons.outlined.Key
 import androidx.compose.material.icons.outlined.Description
 import androidx.compose.material.icons.outlined.Insights
 import androidx.compose.material.icons.outlined.Podcasts
@@ -195,6 +196,13 @@ fun SettingsHubScreen(
      * production wiring lives in [`in.jphe.storyvox.navigation.StoryvoxNavHost`].
      */
     onOpenCloudVoices: () -> Unit = {},
+    /**
+     * Issue #1630 — Content Sources subscreen (per-source keys / tokens / URLs,
+     * un-buried from the legacy monolith). Default no-op so existing callers /
+     * smoke tests compile; production wiring lives in
+     * [`in.jphe.storyvox.navigation.StoryvoxNavHost`].
+     */
+    onOpenContentSources: () -> Unit = {},
 ) {
     val spacing = LocalSpacing.current
     var query by remember { mutableStateOf("") }
@@ -330,6 +338,16 @@ fun SettingsHubScreen(
                     icon = Icons.Outlined.Extension,
                     sections = contentSourcesSections,
                 ) {
+                    // #1630 — Content Sources: per-source keys/tokens/URLs,
+                    // un-buried from the legacy monolith into a dedicated
+                    // subscreen (renders the generic sourceConfigSections seam).
+                    SettingsHubRow(
+                        icon = Icons.Outlined.Key,
+                        title = stringResource(R.string.settings_hub_content_sources_title),
+                        subtitle = stringResource(R.string.settings_hub_content_sources_subtitle),
+                        onClick = onOpenContentSources,
+                        keywords = HubKeywords.contentSources,
+                    )
                     SettingsHubRow(
                         icon = Icons.Outlined.Extension,
                         title = stringResource(R.string.settings_hub_plugins_title),
@@ -638,6 +656,12 @@ internal object HubKeywords {
         "sources", "backends", "voice families", "voice bundles", "enable", "disable",
         "reddit", "notion", "prime gaming", "slack", "matrix", "discord", "telegram",
     )
+    // #1630 — Content Sources aggregates every credentialed source's config.
+    val contentSources = listOf(
+        "source config", "credentials", "token", "api key", "discord", "telegram",
+        "outline", "epub", "pdf", "wikipedia", "google news", "reddit", "notion",
+        "slack", "matrix", "prime gaming", "feed url",
+    )
     val pronunciation = listOf("pronunciation", "phonetic", "lexicon", "word override", "ipa")
     val account = listOf("royal road", "github", "sign in", "login", "cloud sync", "oauth")
     val memoryPalace = listOf("mempalace", "memory palace", "daemon", "host", "lan", "probe")
@@ -671,6 +695,9 @@ internal val readingDisplaySections = listOf(
     SettingsHubSection("Accessibility", "TalkBack, contrast, motion, font scale.", HubKeywords.accessibility),
 )
 internal val contentSourcesSections = listOf(
+    // #1630 — Content Sources subscreen (per-source keys/tokens/URLs). Subtitle
+    // matches the rendered R.string.settings_hub_content_sources_subtitle.
+    SettingsHubSection("Content Sources", "Per-source keys, tokens, and options.", HubKeywords.contentSources),
     SettingsHubSection("Plugins", "Toggle backends — Fiction, Audio streams, Voice bundles.", HubKeywords.plugins),
     SettingsHubSection("Account", "Royal Road, GitHub.", HubKeywords.account),
     SettingsHubSection("Memory Palace", "Daemon host, probe, integration.", HubKeywords.memoryPalace),

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
@@ -3486,8 +3486,11 @@ private fun WikipediaLanguageRow(
  * plain editable value (PLAIN), an http(s)-validated URL override (URL, e.g.
  * the Prime Gaming feed override #1535), or a behaviour toggle (TOGGLE).
  */
+// #1630 — internal (was private) so the dedicated Content Sources subscreen
+// ([ContentSourcesSettingsScreen]) renders the same generic seam without
+// duplicating the field editors. Still called from this legacy screen too.
 @Composable
-private fun SourceConfigSection(
+internal fun SourceConfigSection(
     sections: List<UiSourceConfigSection>,
     onValueChange: (sourceId: String, key: String, raw: String) -> Unit,
 ) {
@@ -3544,7 +3547,7 @@ private fun SourceConfigSection(
  */
 @OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
 @Composable
-private fun SourceConfigTextField(
+internal fun SourceConfigTextField(
     sourceId: String,
     field: UiSourceConfigField,
     onValueChange: (sourceId: String, key: String, raw: String) -> Unit,

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -718,6 +718,12 @@
          strings. Bilingual (EN + ES) since it was already a user-facing row. -->
     <string name="settings_hub_briefing_title">Morning Briefing</string>
     <string name="settings_hub_briefing_subtitle">One episode from your sources — HN, arXiv, RSS, GitHub.</string>
+    <!-- #1630 — Content Sources hub row + subscreen (per-source config seam,
+         un-buried from the legacy monolith). EN-only per the #1583 settings-ES
+         track. Subtitle must match the catalog literal in SettingsHubScreen. -->
+    <string name="settings_hub_content_sources_title">Content Sources</string>
+    <string name="settings_hub_content_sources_subtitle">Per-source keys, tokens, and options.</string>
+    <string name="settings_content_sources_empty">No configurable sources yet — enable a source under Plugins to set it up here.</string>
 
     <!-- Settings · Reading subscreen -->
     <string name="settings_reading_title">Reading</string>

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsHubSectionsTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsHubSectionsTest.kt
@@ -42,9 +42,11 @@ class SettingsHubSectionsTest {
         // 20 → 21 in #1624, which grouped the hub and exposed the Cloud
         // Voices row (its subscreen + route already shipped, but the hub
         // had no way in — you had to dig through Plugins → Azure).
+        // 21 → 22 in #1630, which added the Content Sources row (the
+        // per-source config seam, un-buried from the legacy monolith).
         // Adding a new section requires updating both this assertion AND
         // the composable's row list — that drift is the point of pinning.
-        assertEquals(21, SettingsHubSections.size)
+        assertEquals(22, SettingsHubSections.size)
     }
 
     @Test
@@ -76,6 +78,9 @@ class SettingsHubSectionsTest {
             // via Plugins → Azure → Configure). Pin it so a regression can't
             // silently drop it back into invisibility.
             "Cloud Voices",
+            // #1630 — Content Sources subscreen (per-source config seam),
+            // un-buried from the legacy monolith into the Content & Sources group.
+            "Content Sources",
         )
         val actual = SettingsHubSections.map { it.title.lowercase() }.toSet()
         for (expected in expectedSectionTitles) {


### PR DESCRIPTION
## Summary
**Wave-1 of #1624 (closes the biggest "un-bury" gap, #1630).** Per-source configuration — API keys, tokens, feed-URL overrides, behaviour toggles — was reachable **only** by scrolling the 4,100-line legacy "All settings" monolith, so it was invisible to anyone using the grouped hub. This surfaces the **same** generic config-field seam (#1531: `SourceConfigContributor` → `sourceConfigSections`) behind a dedicated, discoverable route in the **Content & Sources** group.

Built on Nebula's verified field spec (`scratch/candela-benefits-wave/content-sources-fields.md`, freshness-checked @ this base).

## What changed
- **New `ContentSourcesScreen`** — `SettingsSubscreenScaffold` + the generic seam. It **reuses the legacy screen's `SourceConfigSection` field editor verbatim** (widened `private`→`internal`), so there is **one** field-editor implementation, not a fork. The 2-keyword visibility change is the *only* touch to the legacy monolith.
- **Hub row** "Content Sources" (`Icons.Outlined.Key`) added to the Content & Sources group + its keyword list; `onOpenContentSources` wired.
- **Nav**: `SETTINGS_CONTENT_SOURCES` route + composable registration (push transitions like the other Settings drill-downs).
- **Empty-state** guard (defensive — the live contributor set always registers the credentialed sources, so it rarely shows, but a bare screen would read as broken).

## Scope (slice 1)
Renders the **5 sources already on the seam** (Reddit, Notion, Prime Gaming, Slack, Matrix) — the immediate un-bury win. **Follow-up slices** (independently shippable, each a contributor): migrate the bespoke legacy rows (Telegram, Outline, Google News, Wikipedia) onto the seam; the bespoke tail (Discord server-select, Epub/Pdf folder pickers) per Nebula §C. Deferred deliberately to keep this PR a clean, bisectable un-bury.

## The seam auto-grows
A new credentialed source that contributes a `SourceConfigContributor` appears here with **zero edits** to this file — that's the #1531 seam's whole point.

## a11y / i18n
Reuses `SettingsSubscreenScaffold` (`heading()` title) + `SettingsRow`'s merged contentDescription in the field editor; both themes. New strings **EN-only** per the #1583 settings-ES wholesale track.

## Tests
`SettingsHubSectionsTest` bumped **21 → 22** + Content Sources pinned in the required-titles list; catalog stays derived from the per-group lists.

## Coordination
Shares two hot files with Morpheus's #1632 (Downloads & Storage): `SettingsHubScreen.kt` (I add a row to the **Content & Sources** group + `contentSourcesSections`; he adds a **new** Downloads group — different regions) and the test count (I take 21→22; he rebases to 22→23, or vice-versa — whoever merges second bumps + rebases). No `SettingsRepositoryUiImpl` change here (renders the existing seam).

## Testing
No local gradle — CI Build APK is the compile gate. On-device (at v1.12.4 cut): Content Sources row in Content & Sources opens the subscreen; the 5 seam sources render + edit/save/clear; both themes.

Refs #1624

🤖 Generated with [Claude Code](https://claude.com/claude-code)