### PR TITLE
feat(settings): Downloads & Storage subscreen + global default download mode (#1632)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
@@ -56,6 +56,7 @@ import `in`.jphe.storyvox.feature.api.PalaceProbeResult
 import `in`.jphe.storyvox.feature.api.ReadingDirection
 import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
 import `in`.jphe.storyvox.feature.api.SpeakChapterMode
+import `in`.jphe.storyvox.feature.api.DownloadMode
 import `in`.jphe.storyvox.feature.api.ThemeOverride
 import `in`.jphe.storyvox.feature.api.UiAiSettings
 import `in`.jphe.storyvox.feature.api.UiAzureConfig
@@ -428,6 +429,8 @@ private object Keys {
     val THEME_OVERRIDE = stringPreferencesKey("pref_theme_override")
     val DOWNLOAD_WIFI_ONLY = booleanPreferencesKey("pref_download_wifi_only")
     val POLL_INTERVAL_HOURS = intPreferencesKey("pref_poll_interval_hours")
+    // #1632 — global default download mode, persisted as the DownloadMode name.
+    val DEFAULT_DOWNLOAD_MODE = stringPreferencesKey("pref_default_download_mode")
     val SIGNED_IN = booleanPreferencesKey("pref_signed_in")
     /** Issue #109 — continuous inter-sentence pause multiplier (Float).
      *  Replaces the pre-#109 enum-string key `pref_punctuation_pause`; the
@@ -1376,6 +1379,11 @@ class SettingsRepositoryUiImpl(
                 ?: ThemeOverride.System,
             downloadOnWifiOnly = prefs[Keys.DOWNLOAD_WIFI_ONLY] ?: true,
             pollIntervalHours = prefs[Keys.POLL_INTERVAL_HOURS] ?: 6,
+            // #1632 — global default download mode; falls back to Lazy (today's
+            // implicit default) when unset or on an unknown persisted value.
+            defaultDownloadMode = prefs[Keys.DEFAULT_DOWNLOAD_MODE]
+                ?.let { runCatching { DownloadMode.valueOf(it) }.getOrNull() }
+                ?: DownloadMode.Lazy,
             isSignedIn = prefs[Keys.SIGNED_IN] ?: false,
             pitchInterpolationHighQuality = prefs[Keys.PITCH_INTERP_HIGH_QUALITY] ?: true,
             punctuationPauseMultiplier = (prefs[Keys.PUNCTUATION_PAUSE_MULTIPLIER]
@@ -1818,6 +1826,11 @@ class SettingsRepositoryUiImpl(
 
     override suspend fun setPollIntervalHours(hours: Int) {
         store.edit { it[Keys.POLL_INTERVAL_HOURS] = hours.coerceIn(1, 24) }
+    }
+
+    // #1632 — persist the global default download mode (enum name).
+    override suspend fun setDefaultDownloadMode(mode: DownloadMode) {
+        store.edit { it[Keys.DEFAULT_DOWNLOAD_MODE] = mode.name }
     }
 
     override suspend fun setPunctuationPauseMultiplier(multiplier: Float) {

--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -95,7 +95,11 @@ object AppBindings {
     fun provideFictionRepositoryUi(
         repo: FictionRepository,
         chapters: ChapterRepository,
-    ): FictionRepositoryUi = RealFictionRepositoryUi(repo, chapters)
+        // #1632 — dagger.Lazy to stay clear of any settings↔repo init cycle
+        // (the documented consumer↔settings Dagger-cycle trap); resolved lazily
+        // inside follow() to read the global default download mode.
+        settings: dagger.Lazy<SettingsRepositoryUi>,
+    ): FictionRepositoryUi = RealFictionRepositoryUi(repo, chapters, settings)
 
     // Issue #1531 — generic config-field seam contributors. Each is added to
     // the `Set<SourceConfigContributor>` that SettingsRepositoryUiImpl
@@ -716,6 +720,7 @@ object AppBindings {
 private class RealFictionRepositoryUi(
     private val repo: FictionRepository,
     private val chapters: ChapterRepository,
+    private val settings: dagger.Lazy<SettingsRepositoryUi>,
 ) : FictionRepositoryUi {
 
     override val library: Flow<List<UiFiction>> =
@@ -848,7 +853,20 @@ private class RealFictionRepositoryUi(
     }
 
     override suspend fun follow(fictionId: String, follow: Boolean) {
-        if (follow) repo.addToLibrary(fictionId, mode = null) else repo.removeFromLibrary(fictionId)
+        if (follow) {
+            // #1632 — a newly-added fiction inherits the global default download
+            // mode. Lazy is today's implicit default (the Fiction.downloadMode
+            // column defaults to null, treated as Lazy), so we pass null for Lazy
+            // to keep the stored state byte-identical to pre-#1632; only an
+            // explicit Eager/Subscribe default writes a non-null mode.
+            val default = settings.get().settings.first().defaultDownloadMode
+            repo.addToLibrary(
+                fictionId,
+                mode = default.takeIf { it != DownloadMode.Lazy }?.toData(),
+            )
+        } else {
+            repo.removeFromLibrary(fictionId)
+        }
     }
 
     override suspend fun setFollowedRemote(

--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -60,6 +60,7 @@ import `in`.jphe.storyvox.feature.settings.AiSettingsScreen
 import `in`.jphe.storyvox.feature.settings.BookshareSettingsScreen
 import `in`.jphe.storyvox.feature.settings.CloudVoicesSettingsScreen
 import `in`.jphe.storyvox.feature.settings.ContentSourcesSettingsScreen
+import `in`.jphe.storyvox.feature.settings.DownloadsStorageSettingsScreen
 import `in`.jphe.storyvox.feature.settings.MemoryPalaceSettingsScreen
 import `in`.jphe.storyvox.feature.settings.PerformanceSettingsScreen
 import `in`.jphe.storyvox.feature.settings.ReadingSettingsScreen
@@ -208,6 +209,9 @@ object StoryvoxRoutes {
      *  generic SourceConfigContributor seam, un-buried from the legacy
      *  [SETTINGS] monolith into a dedicated route under Content & Sources. */
     const val SETTINGS_CONTENT_SOURCES = "settings/content-sources"
+
+    /** Issue #1632 — Downloads & Storage subscreen (hub group 4). */
+    const val SETTINGS_DOWNLOADS = "settings/downloads"
     /** Settings → Account. Royal Road sign-in, GitHub OAuth + scope. */
     const val SETTINGS_ACCOUNT = "settings/account"
     /** Settings → Memory Palace. Daemon host, API key, test probe. */
@@ -1253,6 +1257,7 @@ private fun StoryvoxNavHostContent(
                     onOpenCloudVoices = { navController.navigate(StoryvoxRoutes.SETTINGS_CLOUD_VOICES) },
                     // #1630 — Content Sources subscreen.
                     onOpenContentSources = { navController.navigate(StoryvoxRoutes.SETTINGS_CONTENT_SOURCES) },
+                    onOpenDownloads = { navController.navigate(StoryvoxRoutes.SETTINGS_DOWNLOADS) },
                 )
             }
 
@@ -1532,6 +1537,19 @@ private fun StoryvoxNavHostContent(
                 popExitTransition = popExit,
             ) {
                 ContentSourcesSettingsScreen(
+                    onBack = { navController.popBackStack() },
+                )
+            }
+            // #1632 — Downloads & Storage subscreen (default download mode +
+            // Wi-Fi/interval + cache), un-buried into hub group 4.
+            composable(
+                StoryvoxRoutes.SETTINGS_DOWNLOADS,
+                enterTransition = pushEnter,
+                exitTransition = pushExit,
+                popEnterTransition = popEnter,
+                popExitTransition = popExit,
+            ) {
+                DownloadsStorageSettingsScreen(
                     onBack = { navController.popBackStack() },
                 )
             }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -1607,6 +1607,15 @@ data class UiSettings(
      * band (`TELEPROMPTER_MIN_WPM`/`MAX_WPM`). Per-device pref (NOT synced).
      */
     val teleprompterWpm: Int = 130,
+    /**
+     * Issue #1632 — app-wide default [DownloadMode] applied to newly-added
+     * fictions that don't specify one. The effective per-book mode is the
+     * `Fiction.downloadMode` column; this is the default the "add to library"
+     * flow passes when the user hasn't chosen. Surfaced in the Downloads &
+     * Storage subscreen. Defaults to [DownloadMode.Lazy] (fetch a chapter's
+     * body on first play).
+     */
+    val defaultDownloadMode: DownloadMode = DownloadMode.Lazy,
 ) {
     /**
      * Resolved reading-surface colours for the reader (#993). Inactive when
@@ -2119,6 +2128,13 @@ interface SettingsRepositoryUi {
     suspend fun setDefaultVoice(voiceId: String?)
     suspend fun setDownloadOnWifiOnly(enabled: Boolean)
     suspend fun setPollIntervalHours(hours: Int)
+    /**
+     * Issue #1632 — persist the app-wide default download mode applied to
+     * newly-added fictions. Defaulted no-op so the many hand-rolled
+     * [SettingsRepositoryUi] test fakes don't have to implement it (same
+     * pattern as the other defaulted setters here); the real impl overrides it.
+     */
+    suspend fun setDefaultDownloadMode(mode: DownloadMode) = Unit
     /**
      * Issue #109 — set the inter-sentence pause multiplier (continuous,
      * coerced to [PUNCTUATION_PAUSE_MIN_MULTIPLIER]..[PUNCTUATION_PAUSE_MAX_MULTIPLIER]).

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/DownloadsStorageSettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/DownloadsStorageSettingsScreen.kt
@@ -1,0 +1,183 @@
+package `in`.jphe.storyvox.feature.settings
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import `in`.jphe.storyvox.feature.R
+import `in`.jphe.storyvox.feature.api.DownloadMode
+import `in`.jphe.storyvox.feature.settings.components.SectionHeading
+import `in`.jphe.storyvox.ui.theme.LocalSpacing
+
+/**
+ * Issue #1632 — Settings → Downloads & Storage subscreen (hub group 4, per the
+ * #1624 IA — between Content & Sources and AI).
+ *
+ * Consolidates download/storage prefs that were scattered — Wi-Fi-only +
+ * update-check interval lived only in the legacy [SettingsScreen] monolith,
+ * and cache quota + clear-cache lived under Performance — and adds the new
+ * global **default download mode** applied to newly-added fictions (the
+ * per-`Fiction` mode is untouched; see `RealFictionRepositoryUi.follow`).
+ *
+ * Curated view over shared prefs: it reuses [CacheSizeSelector] / [CacheUsageRow]
+ * and the shared switch/slider rows rather than reimplementing them, and the
+ * legacy "All settings" page keeps the same controls as the power-user escape
+ * hatch. Strings are EN-only (#1583). Accessibility contract preserved: labelled
+ * [SectionHeading]s, a `Role.RadioButton` selectable group for the mode picker,
+ * and a `stateDescription` on the interval slider.
+ */
+@Composable
+fun DownloadsStorageSettingsScreen(
+    onBack: () -> Unit,
+    viewModel: SettingsViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val spacing = LocalSpacing.current
+
+    SettingsSubscreenScaffold(
+        title = stringResource(R.string.settings_downloads_title),
+        onBack = onBack,
+    ) { padding ->
+        val s = state.settings ?: run {
+            SettingsSkeleton(
+                modifier = Modifier.fillMaxSize().padding(padding).padding(spacing.md),
+            )
+            return@SettingsSubscreenScaffold
+        }
+        SettingsSubscreenBody(padding) {
+            // ── Default download mode (new global pref) ─────────────────
+            SectionHeading(label = stringResource(R.string.settings_downloads_mode_heading))
+            SettingsGroupCard {
+                DownloadModeSelector(
+                    selected = s.defaultDownloadMode,
+                    onSelect = viewModel::setDefaultDownloadMode,
+                )
+            }
+
+            // ── Network ─────────────────────────────────────────────────
+            SectionHeading(label = stringResource(R.string.settings_downloads_network_heading))
+            SettingsGroupCard {
+                SettingsSwitchRow(
+                    title = stringResource(R.string.settings_downloads_wifi_title),
+                    subtitle = stringResource(R.string.settings_downloads_wifi_subtitle),
+                    checked = s.downloadOnWifiOnly,
+                    onCheckedChange = viewModel::setWifiOnly,
+                )
+                // Hoisted out of the semantics lambda (stringResource is
+                // @Composable and can't be called inside it).
+                val pollTitle = stringResource(R.string.settings_downloads_poll_title)
+                val pollValue = stringResource(R.string.settings_downloads_poll_value, s.pollIntervalHours)
+                SettingsSliderBlock(
+                    title = pollTitle,
+                    valueLabel = pollValue,
+                    subtitle = stringResource(R.string.settings_downloads_poll_subtitle),
+                    slider = {
+                        Slider(
+                            value = s.pollIntervalHours.toFloat(),
+                            onValueChange = { viewModel.setPollHours(it.toInt().coerceIn(1, 24)) },
+                            valueRange = 1f..24f,
+                            modifier = Modifier.semantics {
+                                contentDescription = pollTitle
+                                stateDescription = pollValue
+                            },
+                        )
+                    },
+                )
+            }
+
+            // ── Storage (reused from Performance) ───────────────────────
+            SectionHeading(label = stringResource(R.string.settings_downloads_storage_heading))
+            SettingsGroupCard {
+                CacheSizeSelector(
+                    quotaBytes = s.cacheQuotaBytes,
+                    onQuotaChange = viewModel::setCacheQuotaBytes,
+                )
+                CacheUsageRow(
+                    usedBytes = s.cacheUsedBytes,
+                    quotaBytes = s.cacheQuotaBytes,
+                    onClearCache = viewModel::clearCache,
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Radio-group picker for the global default [DownloadMode]. Standard Material3
+ * a11y shape: a [selectableGroup] of rows, each [selectable] with
+ * [Role.RadioButton], the [RadioButton] itself `onClick = null` so the whole
+ * row is the single TalkBack node announcing its selected state.
+ */
+@Composable
+private fun DownloadModeSelector(
+    selected: DownloadMode,
+    onSelect: (DownloadMode) -> Unit,
+) {
+    val spacing = LocalSpacing.current
+    val options = listOf(
+        Triple(
+            DownloadMode.Lazy,
+            R.string.settings_downloads_mode_lazy,
+            R.string.settings_downloads_mode_lazy_desc,
+        ),
+        Triple(
+            DownloadMode.Eager,
+            R.string.settings_downloads_mode_eager,
+            R.string.settings_downloads_mode_eager_desc,
+        ),
+        Triple(
+            DownloadMode.Subscribe,
+            R.string.settings_downloads_mode_subscribe,
+            R.string.settings_downloads_mode_subscribe_desc,
+        ),
+    )
+    Column(modifier = Modifier.selectableGroup()) {
+        options.forEach { (mode, labelRes, descRes) ->
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .selectable(
+                        selected = mode == selected,
+                        onClick = { onSelect(mode) },
+                        role = Role.RadioButton,
+                    )
+                    .padding(vertical = spacing.sm, horizontal = spacing.xs),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                RadioButton(selected = mode == selected, onClick = null)
+                Spacer(Modifier.width(spacing.sm))
+                Column(modifier = Modifier.fillMaxWidth()) {
+                    Text(
+                        text = stringResource(labelRes),
+                        style = MaterialTheme.typography.bodyLarge,
+                    )
+                    Text(
+                        text = stringResource(descRes),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/PerformanceSettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/PerformanceSettingsScreen.kt
@@ -218,7 +218,9 @@ fun PerformanceSettingsScreen(
  * row in the legacy SettingsScreen).
  */
 @Composable
-private fun CacheSizeSelector(
+// #1632 — internal so the Downloads & Storage subscreen reuses the same
+// cache-quota control instead of reimplementing it.
+internal fun CacheSizeSelector(
     quotaBytes: Long,
     onQuotaChange: (Long) -> Unit,
 ) {
@@ -267,7 +269,9 @@ private fun CacheSizeSelector(
  * mess.
  */
 @Composable
-private fun CacheUsageRow(
+// #1632 — internal so the Downloads & Storage subscreen reuses the same
+// cache-usage + clear-cache control.
+internal fun CacheUsageRow(
     usedBytes: Long,
     quotaBytes: Long,
     onClearCache: () -> Unit,

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsHubScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsHubScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.icons.outlined.Cloud
 import androidx.compose.material.icons.outlined.CloudSync
 import androidx.compose.material.icons.outlined.Tune
 import androidx.compose.material.icons.outlined.ChevronRight
+import androidx.compose.material.icons.outlined.Download
 import androidx.compose.material.icons.outlined.Extension
 import androidx.compose.material.icons.outlined.GraphicEq
 import androidx.compose.material.icons.outlined.Info
@@ -203,6 +204,10 @@ fun SettingsHubScreen(
      * [`in.jphe.storyvox.navigation.StoryvoxNavHost`].
      */
     onOpenContentSources: () -> Unit = {},
+    /** Issue #1632 — Downloads & Storage subscreen. Default no-op so callers
+     *  / smoke tests compile without wiring it; production wiring in
+     *  [`in`.jphe.storyvox.navigation.StoryvoxNavHost]. */
+    onOpenDownloads: () -> Unit = {},
 ) {
     val spacing = LocalSpacing.current
     var query by remember { mutableStateOf("") }
@@ -377,6 +382,23 @@ fun SettingsHubScreen(
                         subtitle = stringResource(R.string.settings_hub_bookshare_subtitle),
                         onClick = onOpenBookshare,
                         keywords = HubKeywords.bookshare,
+                    )
+                }
+                // #1632 — Downloads & Storage (group 4, between Content &
+                // Sources and AI per the #1624 IA; Notifications slots in
+                // after this when #1631 lands).
+                HubGroup(
+                    query = query,
+                    heading = stringResource(R.string.settings_hub_group_downloads),
+                    icon = Icons.Outlined.Download,
+                    sections = downloadsStorageSections,
+                ) {
+                    SettingsHubRow(
+                        icon = Icons.Outlined.Download,
+                        title = stringResource(R.string.settings_hub_downloads_title),
+                        subtitle = stringResource(R.string.settings_hub_downloads_subtitle),
+                        onClick = onOpenDownloads,
+                        keywords = HubKeywords.downloadsStorage,
                     )
                 }
                 HubGroup(
@@ -666,6 +688,10 @@ internal object HubKeywords {
     val account = listOf("royal road", "github", "sign in", "login", "cloud sync", "oauth")
     val memoryPalace = listOf("mempalace", "memory palace", "daemon", "host", "lan", "probe")
     val bookshare = listOf("bookshare", "daisy", "accessible", "partner", "api key")
+    val downloadsStorage = listOf(
+        "download", "downloads", "storage", "cache", "offline", "wifi", "wi-fi",
+        "data saver", "unmetered", "clear cache", "quota", "update interval", "poll",
+    )
     val advanced = listOf("android auto", "car", "items per category", "integration")
     val developer = listOf("debug", "overlay", "log", "diagnostics", "reset onboarding", "verbose")
     val about = listOf(
@@ -703,6 +729,15 @@ internal val contentSourcesSections = listOf(
     SettingsHubSection("Memory Palace", "Daemon host, probe, integration.", HubKeywords.memoryPalace),
     SettingsHubSection("Bookshare", "Accessible DAISY library · partner API key.", HubKeywords.bookshare),
 )
+// #1632 — Downloads & Storage (group 4). Subtitle matches the rendered
+// R.string.settings_hub_downloads_subtitle.
+internal val downloadsStorageSections = listOf(
+    SettingsHubSection(
+        "Downloads & Storage",
+        "Default download mode, Wi-Fi, update interval, cache.",
+        HubKeywords.downloadsStorage,
+    ),
+)
 internal val aiSections = listOf(
     SettingsHubSection("AI", "Chat model, grounding, recap.", HubKeywords.ai),
     SettingsHubSection("AI sessions", "Review past chats and delete history.", HubKeywords.aiSessions),
@@ -728,6 +763,7 @@ val SettingsHubSections: List<SettingsHubSection> =
     voiceAudioSections +
         readingDisplaySections +
         contentSourcesSections +
+        downloadsStorageSections +
         aiSections +
         toolsSections +
         systemSections +

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
@@ -16,6 +16,7 @@ import `in`.jphe.storyvox.feature.api.HighlightMode
 import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
 import `in`.jphe.storyvox.feature.api.SpeakChapterMode
 import `in`.jphe.storyvox.ui.theme.ReaderTheme
+import `in`.jphe.storyvox.feature.api.DownloadMode
 import `in`.jphe.storyvox.feature.api.ThemeOverride
 import `in`.jphe.storyvox.ui.theme.ReaderFontFamily
 import `in`.jphe.storyvox.feature.api.UiLlmProvider
@@ -142,6 +143,9 @@ class SettingsViewModel @Inject constructor(
     fun setDefaultVoice(id: String?) = viewModelScope.launch { repo.setDefaultVoice(id) }
     fun setWifiOnly(enabled: Boolean) = viewModelScope.launch { repo.setDownloadOnWifiOnly(enabled) }
     fun setPollHours(h: Int) = viewModelScope.launch { repo.setPollIntervalHours(h) }
+    // #1632 — Downloads & Storage: global default download mode for new fictions.
+    fun setDefaultDownloadMode(mode: DownloadMode) =
+        viewModelScope.launch { repo.setDefaultDownloadMode(mode) }
     // #1295 — Google News full-article-text opt-in.
     fun setGoogleNewsFullArticleText(enabled: Boolean) =
         viewModelScope.launch { repo.setGoogleNewsFullArticleText(enabled) }

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -723,6 +723,10 @@
          track. Subtitle must match the catalog literal in SettingsHubScreen. -->
     <string name="settings_hub_content_sources_title">Content Sources</string>
     <string name="settings_hub_content_sources_subtitle">Per-source keys, tokens, and options.</string>
+    <!-- #1632 — Downloads & Storage hub group + row -->
+    <string name="settings_hub_group_downloads">Downloads &amp; Storage</string>
+    <string name="settings_hub_downloads_title">Downloads &amp; Storage</string>
+    <string name="settings_hub_downloads_subtitle">Default download mode, Wi-Fi, update interval, cache.</string>
     <string name="settings_content_sources_empty">No configurable sources yet — enable a source under Plugins to set it up here.</string>
 
     <!-- Settings · Reading subscreen -->
@@ -906,6 +910,23 @@
 
     <!-- Settings · Performance subscreen -->
     <string name="settings_performance_title">Performance</string>
+
+    <!-- #1632 — Downloads &amp; Storage subscreen (EN-only, #1583) -->
+    <string name="settings_downloads_title">Downloads &amp; Storage</string>
+    <string name="settings_downloads_mode_heading">Default download mode</string>
+    <string name="settings_downloads_mode_lazy">On demand</string>
+    <string name="settings_downloads_mode_lazy_desc">Download each chapter when you start playing it. Uses the least storage.</string>
+    <string name="settings_downloads_mode_eager">Whole book</string>
+    <string name="settings_downloads_mode_eager_desc">Download every chapter as soon as you add a book, so it\'s ready offline.</string>
+    <string name="settings_downloads_mode_subscribe">New chapters</string>
+    <string name="settings_downloads_mode_subscribe_desc">Download the current chapters, then auto-fetch new ones as they\'re published.</string>
+    <string name="settings_downloads_network_heading">Network</string>
+    <string name="settings_downloads_wifi_title">Download over Wi-Fi only</string>
+    <string name="settings_downloads_wifi_subtitle">Defer downloads until you\'re on an unmetered network.</string>
+    <string name="settings_downloads_poll_title">Update check interval</string>
+    <string name="settings_downloads_poll_subtitle">How often to check followed books for new chapters.</string>
+    <string name="settings_downloads_poll_value">Every %1$d h</string>
+    <string name="settings_downloads_storage_heading">Storage</string>
     <string name="settings_performance_catchup_title">Catch-up Pause</string>
     <string name="settings_performance_catchup_on">Pause briefly when the voice falls behind, then resume cleanly.</string>
     <string name="settings_performance_catchup_off">Drain through underruns; no buffering spinner.</string>

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsHubSectionsTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsHubSectionsTest.kt
@@ -44,9 +44,10 @@ class SettingsHubSectionsTest {
         // had no way in — you had to dig through Plugins → Azure).
         // 21 → 22 in #1630, which added the Content Sources row (the
         // per-source config seam, un-buried from the legacy monolith).
+        // 22 → 23 in #1632, which added the Downloads & Storage group + row.
         // Adding a new section requires updating both this assertion AND
         // the composable's row list — that drift is the point of pinning.
-        assertEquals(22, SettingsHubSections.size)
+        assertEquals(23, SettingsHubSections.size)
     }
 
     @Test
@@ -81,6 +82,9 @@ class SettingsHubSectionsTest {
             // #1630 — Content Sources subscreen (per-source config seam),
             // un-buried from the legacy monolith into the Content & Sources group.
             "Content Sources",
+            // #1632 — Downloads & Storage subscreen (default download mode +
+            // Wi-Fi/interval + cache), un-buried into hub group 4.
+            "Downloads & Storage",
         )
         val actual = SettingsHubSections.map { it.title.lowercase() }.toSet()
         for (expected in expectedSectionTitles) {


### PR DESCRIPTION
## What & why

Issue #1632 — download/storage prefs were scattered (`downloadOnWifiOnly` + `pollIntervalHours` only in the legacy monolith; `cacheQuotaBytes` + clear-cache under Performance) and `DownloadMode {Lazy,Eager,Subscribe}` was a per-`Fiction` column with **no global default**. This adds the **Downloads & Storage** hub subscreen — the 8th JP-approved group (group 4, between Content & Sources and AI) — consolidating them, plus a persisted **global default download mode** applied to newly-added fictions.

## Backend (data path — committed first, 4 slices)
- `UiSettings.defaultDownloadMode` + `SettingsRepositoryUi.setDefaultDownloadMode()` (defaulted no-op → hand-rolled fakes don't break).
- DataStore persistence (`pref_default_download_mode`, stored as the `DownloadMode` name; falls back to Lazy on unset/unknown).
- `SettingsViewModel.setDefaultDownloadMode`.
- **Consumption at `addToLibrary`** (`RealFictionRepositoryUi.follow`), injected via `dagger.Lazy<SettingsRepositoryUi>` to avoid the documented consumer↔settings Dagger-cycle trap. **No-surprise:** default = Lazy, and Lazy maps to `null` at the call site — a newly-added fiction's stored `downloadMode` stays byte-identical to pre-#1632 (unset ≈ Lazy, zero eager downloads) until a user opts into Eager/Subscribe.

## UI
- `DownloadsStorageSettingsScreen`: default-mode **radio group** (`Role.RadioButton` + `selectableGroup` a11y), Wi-Fi-only switch, update-interval slider (`stateDescription`), and the **reused** `CacheSizeSelector`/`CacheUsageRow` (widened `private→internal`, not reimplemented). The legacy "All settings" page stays intact as the power-user escape hatch.
- Hub group 4 + row + `onOpenDownloads`; `StoryvoxNavHost` `SETTINGS_DOWNLOADS` route + wiring.
- EN-only strings (#1583); accessibility contract preserved (labelled `SectionHeading`s, radio-group role, slider state description).

## Coordination
Rebased on the v1.12.4 main (post-Luna's #1630/#1641). Per the agreed sequencing I'm the **first hub-editor to merge**; `SettingsHubSectionsTest` 22→23; lucid's #1631 (Notifications) rebases after this. `merge-base == origin/main` (`d320e3bb`) → clean linear descendant, fast-forward, no conflict.

## Tests
`SettingsHubSectionsTest` 22→23 + pins the "Downloads & Storage" title (the catalog↔render drift guard). Backend additions are defaulted-safe (no fake breakage). No local gradle — CI is the compile gate.

Closes #1632
Refs #1624


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new **Downloads & Storage** settings area with its own hub entry and screen.
  * Users can now choose a default download mode for newly added items, along with network and storage preferences.

* **Bug Fixes**
  * Default download mode now saves and restores reliably, with a safe fallback if no value is set.

* **Tests**
  * Updated settings hub coverage to include the new Downloads & Storage section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->