### PR TITLE
feat(settings): Benefits hub entry — re-discover Screener/Decoder (#1634)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -1252,6 +1252,7 @@ private fun StoryvoxNavHostContent(
                     onOpenStats = { navController.navigate(StoryvoxRoutes.STATS) },
                     onOpenBriefing = { navController.navigate(StoryvoxRoutes.MORNING_BRIEFING) },
                     onOpenScripts = { navController.navigate(StoryvoxRoutes.SCRIPT_LIST) },
+                    onOpenBenefits = { navController.navigate(StoryvoxRoutes.TECHEMPOWER_HOME) },
                     // #1624 — Cloud Voices hub row (screen + route already
                     // existed; the hub just never surfaced it).
                     onOpenCloudVoices = { navController.navigate(StoryvoxRoutes.SETTINGS_CLOUD_VOICES) },

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsHubScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsHubScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.material.icons.outlined.Key
 import androidx.compose.material.icons.outlined.Description
 import androidx.compose.material.icons.outlined.Insights
 import androidx.compose.material.icons.outlined.Podcasts
+import androidx.compose.material.icons.outlined.VolunteerActivism
 import androidx.compose.material.icons.outlined.RecordVoiceOver
 import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material.icons.outlined.Speed
@@ -189,6 +190,9 @@ fun SettingsHubScreen(
      * in [`in.jphe.storyvox.navigation.StoryvoxNavHost`].
      */
     onOpenScripts: () -> Unit = {},
+    /** Issue #1634 — Benefits suite (Screener/Decoder) re-discovery entry.
+     *  Default no-op so callers / the smoke test compile without wiring it. */
+    onOpenBenefits: () -> Unit = {},
     /**
      * Issue #1624 — Cloud Voices (Azure HD / Dragon HD). The subscreen +
      * [`SETTINGS_CLOUD_VOICES`] route already shipped, but there was no hub
@@ -452,6 +456,16 @@ fun SettingsHubScreen(
                         onClick = onOpenScripts,
                         keywords = HubKeywords.scripts,
                     )
+                    // #1634 — Benefits suite (Screener/Decoder) re-discovery: a
+                    // hub row for users who dismissed the Library hero card.
+                    // Links the existing TECHEMPOWER_HOME route (no new screen).
+                    SettingsHubRow(
+                        icon = Icons.Outlined.VolunteerActivism,
+                        title = stringResource(R.string.settings_hub_benefits_title),
+                        subtitle = stringResource(R.string.settings_hub_benefits_subtitle),
+                        onClick = onOpenBenefits,
+                        keywords = HubKeywords.benefits,
+                    )
                 }
                 HubGroup(
                     query = query,
@@ -657,6 +671,10 @@ internal object HubKeywords {
     val stats = listOf("stats", "streak", "history", "finished", "time listened", "progress")
     val briefing = listOf("briefing", "podcast", "digest", "morning", "episode", "queue")
     val scripts = listOf("teleprompter", "script", "prompter", "rehearsal", "wpm", "words per minute")
+    val benefits = listOf(
+        "benefits", "qualify", "screener", "decoder", "calfresh", "medi-cal",
+        "snap", "assistance", "aid", "notice", "letter", "techempower",
+    )
     val appearance = listOf(
         "cover", "monogram", "animation", "motion", "particle", "confetti",
         "skeleton", "shimmer", "brass pulse", "theme",
@@ -746,6 +764,8 @@ internal val toolsSections = listOf(
     SettingsHubSection("Listening stats", "Time listened, streaks, books finished.", HubKeywords.stats),
     SettingsHubSection("Morning Briefing", "One episode from your sources — HN, arXiv, RSS, GitHub.", HubKeywords.briefing),
     SettingsHubSection("Scripts", "Save, edit, and organize teleprompter scripts.", HubKeywords.scripts),
+    // #1634 — Benefits re-discovery. Subtitle matches R.string.settings_hub_benefits_subtitle.
+    SettingsHubSection("Benefits", "Do-I-qualify screener & letter decoder.", HubKeywords.benefits),
 )
 internal val systemSections = listOf(
     SettingsHubSection("Performance", "Buffer, parallel synth, decoder choice.", HubKeywords.performance),

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -698,6 +698,9 @@
     <!-- Issue #1369 — teleprompter script manager hub row -->
     <string name="settings_hub_scripts_title">Scripts</string>
     <string name="settings_hub_scripts_subtitle">Save, edit, and organize teleprompter scripts.</string>
+    <!-- #1634 — Benefits hub entry (re-discover Screener/Decoder) -->
+    <string name="settings_hub_benefits_title">Benefits</string>
+    <string name="settings_hub_benefits_subtitle">Do-I-qualify screener &amp; letter decoder.</string>
     <string name="settings_hub_all_settings_title">All settings</string>
     <string name="settings_hub_all_settings_subtitle">Every setting on one long page (legacy).</string>
     <!-- #1624 — grouped-hub category headings. Settings-ES is a dedicated

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsHubSectionsTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsHubSectionsTest.kt
@@ -45,9 +45,10 @@ class SettingsHubSectionsTest {
         // 21 → 22 in #1630, which added the Content Sources row (the
         // per-source config seam, un-buried from the legacy monolith).
         // 22 → 23 in #1632, which added the Downloads & Storage group + row.
+        // 23 → 24 in #1634, which added the Benefits row to the Tools group.
         // Adding a new section requires updating both this assertion AND
         // the composable's row list — that drift is the point of pinning.
-        assertEquals(23, SettingsHubSections.size)
+        assertEquals(24, SettingsHubSections.size)
     }
 
     @Test
@@ -85,6 +86,8 @@ class SettingsHubSectionsTest {
             // #1632 — Downloads & Storage subscreen (default download mode +
             // Wi-Fi/interval + cache), un-buried into hub group 4.
             "Downloads & Storage",
+            // #1634 — Benefits re-discovery row (Screener/Decoder) in Tools.
+            "Benefits",
         )
         val actual = SettingsHubSections.map { it.title.lowercase() }.toSet()
         for (expected in expectedSectionTitles) {


### PR DESCRIPTION
## What & why

Issue #1634 — a user who dismisses the Library benefits hero card has **no other way** to reach the benefits Screener/Decoder. This adds a **Benefits** row to the **Tools** hub group that links the existing `TECHEMPOWER_HOME` route. Smallest of the remaining #1624 gaps: **no new prefs, no new screen** — the route + composable + nav arm already exist; this is purely a re-discovery affordance.

## Changes (per Nebula's build-sheet)
- **SettingsHubScreen**: `onOpenBenefits` param + a `SettingsHubRow` in the Tools group (`Icons.Outlined.VolunteerActivism`) + `HubKeywords.benefits` + a `toolsSections` catalog entry.
- **StoryvoxNavHost**: wire `onOpenBenefits → TECHEMPOWER_HOME` at the hub call site.
- **Strings**: `settings_hub_benefits_title` / `_subtitle` (EN-only, #1583).
- **Test**: `SettingsHubSectionsTest` 23→24 + pins the "Benefits" title (catalog↔render drift guard).

4 files, +28 lines.

## a11y
No extra work — `SettingsHubRow` already handles the decorative leading icon + row-title label + decorative chevron; TalkBack heading-nav lands on the "Tools" `SectionHeading`. Follows the established pattern.

## Coordination
Cut off the **#1632-merged** main (`09b3e1ac`), so this is the **2nd of the two hub edits serialized in my hands** — zero `SettingsHubScreen.kt`/catalog contention. `merge-base == origin/main` → clean fast-forward, no conflict. Hub-merge order: #1632 → **#1634** → #1631 (lucid's Notifications rebases after). `SettingsSearchIndex` intentionally untouched (that's the legacy long-scroll index; Benefits is a nav destination, not a legacy section).

Closes #1634
Refs #1624
