### PR TITLE
feat(settings): migrate Outline + Wikipedia onto the config seam (#1624 §B)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/data/SourceConfigContributors.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SourceConfigContributors.kt
@@ -246,3 +246,91 @@ class MatrixConfigContributor @Inject constructor(
         }
     }
 }
+
+/**
+ * Issue #1624 — Outline (#245) migrated onto the generic seam. Was a bespoke
+ * `OutlineConfigRow` (host + API key) in the legacy Settings monolith; now a
+ * host URL + write-only key through the seam, so it renders in the Content
+ * Sources subscreen (#1630) with no bespoke row. Wraps the same
+ * [OutlineConfigImpl] that `SettingsRepositoryUi.setOutlineHost/ApiKey` write
+ * to, so storage keeps a single source of truth.
+ */
+@Singleton
+class OutlineConfigContributor @Inject constructor(
+    private val config: OutlineConfigImpl,
+) : SourceConfigContributor {
+    override val sourceId: String = SourceIds.OUTLINE
+    override val displayName: String = "Outline"
+    override val sectionHelp: String =
+        "Read documents from an Outline knowledge base. Enter your instance " +
+            "URL and a personal API token (Outline → Settings → API Tokens)."
+
+    override fun fields(): List<SourceConfigField> = listOf(
+        SourceConfigField.UrlText(
+            key = "host",
+            label = "Outline URL",
+            help = "Your Outline instance, e.g. https://wiki.example.com.",
+            placeholder = "https://outline.example.com",
+        ),
+        SourceConfigField.SecretText(
+            key = "apiKey",
+            label = "API key",
+            help = "A personal API token from your Outline account.",
+        ),
+    )
+
+    override val values: Flow<Map<String, SourceConfigValue>> = config.state.map { s ->
+        mapOf(
+            "host" to SourceConfigValue.Text(s.host),
+            "apiKey" to SourceConfigValue.Secret(s.apiKey.isNotBlank()),
+        )
+    }
+
+    override suspend fun set(key: String, raw: String) {
+        when (key) {
+            "host" -> config.setHost(raw)
+            "apiKey" -> config.setApiKey(raw)
+        }
+    }
+}
+
+/**
+ * Issue #1624 — Wikipedia (#377) migrated onto the generic seam. Was a bespoke
+ * `WikipediaLanguageRow` (free-text language code) in the legacy monolith; now
+ * a single plain field through the seam. Wraps the same [WikipediaConfigImpl]
+ * that `SettingsRepositoryUi.setWikipediaLanguageCode` writes to (single source
+ * of truth). Blank reverts to the default language.
+ *
+ * Free text here matches the pre-migration behaviour; a validated dropdown
+ * wants a `Choice` field type the seam doesn't have yet (deferred — see
+ * content-sources-fields.md §D).
+ */
+@Singleton
+class WikipediaConfigContributor @Inject constructor(
+    private val config: WikipediaConfigImpl,
+) : SourceConfigContributor {
+    override val sourceId: String = SourceIds.WIKIPEDIA
+    override val displayName: String = "Wikipedia"
+    override val sectionHelp: String =
+        "Read Wikipedia articles. Set the language edition to read from " +
+            "(e.g. en, de, ja, simple). Leave blank for the default."
+
+    override fun fields(): List<SourceConfigField> = listOf(
+        SourceConfigField.PlainText(
+            key = "languageCode",
+            label = "Language code",
+            help = "Wikipedia language edition, e.g. en or es. Blank uses the default.",
+            placeholder = "en",
+        ),
+    )
+
+    override val values: Flow<Map<String, SourceConfigValue>> = config.state.map { s ->
+        mapOf("languageCode" to SourceConfigValue.Text(s.languageCode))
+    }
+
+    override suspend fun set(key: String, raw: String) {
+        when (key) {
+            "languageCode" -> config.setLanguageCode(raw)
+        }
+    }
+}

--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -133,6 +133,18 @@ object AppBindings {
         impl: `in`.jphe.storyvox.data.MatrixConfigContributor,
     ): `in`.jphe.storyvox.data.source.plugin.SourceConfigContributor = impl
 
+    // #1624 — Outline (#245) + Wikipedia (#377) migrated from bespoke legacy
+    // Settings rows onto the generic config seam (Content Sources subscreen).
+    @Provides @Singleton @IntoSet
+    fun provideOutlineConfigContributor(
+        impl: `in`.jphe.storyvox.data.OutlineConfigContributor,
+    ): `in`.jphe.storyvox.data.source.plugin.SourceConfigContributor = impl
+
+    @Provides @Singleton @IntoSet
+    fun provideWikipediaConfigContributor(
+        impl: `in`.jphe.storyvox.data.WikipediaConfigContributor,
+    ): `in`.jphe.storyvox.data.source.plugin.SourceConfigContributor = impl
+
     /** Issue #1228 — bridges the `:feature` [DocumentImporterUi] seam to
      *  the app-side single-file import path (the same one MainActivity's
      *  "Open With" ingest uses), so the Library "Import a file…" picker can

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsScreen.kt
@@ -611,11 +611,9 @@ fun SettingsScreen(
             // sheet links here too.
             EpubFolderPickerRow(viewModel = viewModel)
             PdfFolderPickerRow(viewModel = viewModel)
-            OutlineConfigRow(viewModel = viewModel)
-            WikipediaLanguageRow(
-                languageCode = s.wikipediaLanguageCode,
-                onLanguageCodeChange = viewModel::setWikipediaLanguageCode,
-            )
+            // #1624 — Outline (#245) + Wikipedia (#377) migrated to the generic
+            // config seam; they now render in [SourceConfigSection] below (and
+            // in the Content Sources subscreen). Bespoke rows removed.
             val discordGuilds by viewModel.discordGuilds.collectAsStateWithLifecycle()
             DiscordConfigRow(
                 tokenConfigured = s.discordTokenConfigured,
@@ -3327,151 +3325,10 @@ private fun abbreviateSafUri(raw: String): String {
 }
 
 
-/**
- * Issue #245 — host + API-key entry for the Outline self-hosted-wiki
- * backend. Inline section under the toggle in Library & Sync, mirroring
- * the EPUB folder picker / RSS feed manager. Keeps the user inside
- * Library & Sync rather than navigating to a sub-screen.
- */
-@Composable
-private fun OutlineConfigRow(viewModel: SettingsViewModel) {
-    val host by viewModel.outlineHost.collectAsStateWithLifecycle()
-    val spacing = LocalSpacing.current
-    val context = LocalContext.current
-    var hostDraft by remember(host) { mutableStateOf(host) }
-    var apiKeyDraft by remember { mutableStateOf("") }
-
-    Column(modifier = Modifier.padding(horizontal = spacing.md, vertical = spacing.sm)) {
-        Text(
-            "Outline instance",
-            style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(bottom = spacing.xs),
-        )
-        Text(
-            text = if (host.isBlank()) "Set your Outline host + API token below."
-            else "Currently configured: $host",
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(bottom = spacing.sm),
-        )
-        androidx.compose.material3.OutlinedTextField(
-            value = hostDraft,
-            onValueChange = { hostDraft = it },
-            label = { Text("Outline host") },
-            placeholder = { Text("wiki.example.com") },
-            singleLine = true,
-            modifier = Modifier.fillMaxWidth(),
-        )
-        androidx.compose.material3.OutlinedTextField(
-            value = apiKeyDraft,
-            onValueChange = { apiKeyDraft = it },
-            label = { Text("API token") },
-            placeholder = { Text("From Outline → Account → API Tokens") },
-            singleLine = true,
-            visualTransformation = androidx.compose.ui.text.input.PasswordVisualTransformation(),
-            modifier = Modifier.fillMaxWidth().padding(top = spacing.xs),
-        )
-        Row(
-            modifier = Modifier.fillMaxWidth().padding(top = spacing.sm),
-            horizontalArrangement = Arrangement.spacedBy(spacing.sm),
-        ) {
-            BrassButton(
-                label = "Save",
-                onClick = {
-                    val trimmedHost = hostDraft.trim()
-                    // Issue #455 — empty required fields used to silently
-                    // no-op the Save action with no feedback. JP design
-                    // (issue comment): apply defaults silently to the
-                    // model but surface a transient toast naming the
-                    // skipped field(s) so the user sees that something
-                    // was missing. Lighter than Material 3 supported-
-                    // error chips, no save-blocking.
-                    val skipped = buildList {
-                        if (trimmedHost.isEmpty()) add("Outline host")
-                        if (apiKeyDraft.isBlank()) add("API token")
-                    }
-                    if (trimmedHost.isNotEmpty()) viewModel.setOutlineHost(trimmedHost)
-                    if (apiKeyDraft.isNotBlank()) {
-                        viewModel.setOutlineApiKey(apiKeyDraft)
-                        apiKeyDraft = ""
-                    }
-                    if (skipped.isNotEmpty()) {
-                        Toast.makeText(
-                            context,
-                            "Saved. Skipped (defaults applied): ${skipped.joinToString(", ")}",
-                            Toast.LENGTH_SHORT,
-                        ).show()
-                    }
-                },
-                variant = BrassButtonVariant.Primary,
-            )
-            if (host.isNotBlank()) {
-                androidx.compose.material3.TextButton(
-                    onClick = {
-                        viewModel.clearOutlineConfig()
-                        hostDraft = ""
-                        apiKeyDraft = ""
-                    },
-                ) { Text("Clear") }
-            }
-        }
-    }
-}
-
-/**
- * Issue #377 — Wikipedia language-code picker. Inline row under the
- * Wikipedia toggle in Library & Sync. Single short text field — `en`,
- * `de`, `ja`, `simple`, etc. — resolves to the matching Wikipedia
- * host (`<lang>.wikipedia.org`). Mirrors the inline-config shape of
- * [OutlineConfigRow] / [EpubFolderPickerRow]; nothing to save
- * imperatively because the language code is short and the impl
- * accepts any non-blank value.
- *
- * The Save button keeps the row's interaction visible — users can
- * type without persisting on every keystroke, and a deliberate Save
- * action mirrors what they see on Outline / Memory Palace below.
- */
-@Composable
-private fun WikipediaLanguageRow(
-    languageCode: String,
-    onLanguageCodeChange: (String) -> Unit,
-) {
-    val spacing = LocalSpacing.current
-    var draft by remember(languageCode) { mutableStateOf(languageCode) }
-    Column(modifier = Modifier.padding(horizontal = spacing.md, vertical = spacing.sm)) {
-        Text(
-            "Wikipedia language",
-            style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(bottom = spacing.xs),
-        )
-        Text(
-            text = "Pick a Wikipedia. Use the URL prefix: en, de, ja, simple, fr, ...",
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(bottom = spacing.sm),
-        )
-        androidx.compose.material3.OutlinedTextField(
-            value = draft,
-            onValueChange = { draft = it.trim().lowercase().take(16) },
-            label = { Text("Language code") },
-            placeholder = { Text("en") },
-            singleLine = true,
-            modifier = Modifier.fillMaxWidth(),
-        )
-        Row(
-            modifier = Modifier.fillMaxWidth().padding(top = spacing.sm),
-            horizontalArrangement = Arrangement.spacedBy(spacing.sm),
-        ) {
-            BrassButton(
-                label = "Save",
-                onClick = { onLanguageCodeChange(draft) },
-                variant = BrassButtonVariant.Primary,
-            )
-        }
-    }
-}
+// #1624 — OutlineConfigRow (#245) and WikipediaLanguageRow (#377) removed:
+// both migrated onto the generic config seam (OutlineConfigContributor /
+// WikipediaConfigContributor), so they now render via SourceConfigSection +
+// the Content Sources subscreen (#1630) instead of bespoke rows here.
 
 /**
  * Issue #1531 — generic, registry-driven per-source config section.


### PR DESCRIPTION
## Summary
**§B of Content Sources (#1624, follow-up to #1630).** Move the two genuinely-clean bespoke source-config rows off the 4,100-line legacy monolith onto the generic **#1531 config-field seam**, so they render in the dedicated **Content Sources subscreen** (#1630) — and, per the seam's design, a new credentialed source now appears via *one contributor + one binding, zero Settings-monolith edits*.

Built from Nebula's verified field spec (`content-sources-fields.md`).

## What changed
- **`OutlineConfigContributor`** — `UrlText(host)` + `SecretText(apiKey)`, wrapping the existing `OutlineConfigImpl`.
- **`WikipediaConfigContributor`** — `PlainText(languageCode)`, wrapping `WikipediaConfigImpl`.
- **2 `@IntoSet` bindings** in `AppBindings` (next to the existing 5 contributors).
- **Removed** the bespoke `OutlineConfigRow` (#245) + `WikipediaLanguageRow` (#377) — call sites + defs, ~150 lines — from the legacy `SettingsScreen`.

## Correctness: single source of truth (verified)
`repo.setOutlineHost/ApiKey` and `repo.setWikipediaLanguageCode` **already** route to the **same** `OutlineConfigImpl` / `WikipediaConfigImpl` the contributors wrap (`SettingsRepositoryUiImpl:2411-2416`), so the seam and any remaining caller **cannot diverge**. No storage change — pure UI-seam move.

## Scope — the 2 truly-clean migrations only
Reading the code refined the batch (surfaced to + confirmed by team-lead):
- **Telegram stays bespoke** → §C tail with Discord: its row carries a live **bot-username/channels probe** the static seam can't express; flattening to `SecretText(token)` would lose that UX. Migrate probe-preserving later.
- **Google News** is a `SettingsRepositoryUi` pref (no `ConfigImpl`) → needs a settings-repo **bridge**, separate slice.
- **Wikipedia** ships as **free-text** (behavior-preserving); a validated dropdown wants a `Choice` field type the seam lacks (deferred, §D).

## Independence
No `SettingsHubScreen.kt` / `SettingsSearchIndex.kt` / `SettingsRepositoryUiImpl.kt` touch → **fully independent of Morpheus's #1632** (no rebase either way). Hub row count unchanged (contributors aren't hub rows), so `SettingsHubSectionsTest` is untouched.

## Testing
No local gradle — CI **Build APK** is the compile gate (and validates the Hilt `@IntoSet` graph at `:app`). On-device: Settings → Content & Sources → **Content Sources** now shows Outline + Wikipedia sections (edit/save/clear); the legacy "All settings" page no longer shows their bespoke rows.

Refs #1624

🤖 Generated with [Claude Code](https://claude.com/claude-code)