### PR TITLE
feat(teleprompter): persist recording knobs + countdown + Scripts presets (#1633)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
@@ -905,6 +905,12 @@ private object Keys {
 
     /** Issue #1287 — persisted teleprompter (#1239) auto-scroll pace (WPM). */
     val TELEPROMPTER_WPM = intPreferencesKey("pref_teleprompter_wpm_v1")
+    // #1633 — teleprompter recording-overlay knobs (persisted; session-only before).
+    val TELEPROMPTER_COUNTDOWN_SEC = intPreferencesKey("pref_teleprompter_countdown_sec")
+    val TELEPROMPTER_OVERLAY_OPACITY = floatPreferencesKey("pref_teleprompter_overlay_opacity")
+    val TELEPROMPTER_FONT_SIZE_SP = intPreferencesKey("pref_teleprompter_font_size_sp")
+    val TELEPROMPTER_MIRROR = booleanPreferencesKey("pref_teleprompter_mirror")
+    val TELEPROMPTER_FRONT_CAMERA = booleanPreferencesKey("pref_teleprompter_front_camera")
 
     // ── Reader-surface typography (issue #992) ──────────────────────
     /** Reader font family — stored as the [ReaderFontFamily] enum's name.
@@ -1685,6 +1691,13 @@ class SettingsRepositoryUiImpl(
             // #1287 — clamp on read so a legacy / corrupt value can't drive the
             // teleprompter out of its supported band (defensive; writes clamp too).
             teleprompterWpm = (prefs[Keys.TELEPROMPTER_WPM] ?: 130).coerceIn(30, 500),
+            // #1633 — teleprompter recording knobs; coerce to the RecordingViewModel bands.
+            teleprompterCountdownSec = prefs[Keys.TELEPROMPTER_COUNTDOWN_SEC] ?: 3,
+            teleprompterOverlayOpacity =
+                (prefs[Keys.TELEPROMPTER_OVERLAY_OPACITY] ?: 0.7f).coerceIn(0.3f, 1.0f),
+            teleprompterFontSizeSp = (prefs[Keys.TELEPROMPTER_FONT_SIZE_SP] ?: 26).coerceIn(16, 64),
+            teleprompterMirror = prefs[Keys.TELEPROMPTER_MIRROR] ?: false,
+            teleprompterFrontCamera = prefs[Keys.TELEPROMPTER_FRONT_CAMERA] ?: true,
             // Issue #992 — reader-surface typography. Unknown enum strings
             // fall back to Default; numeric fields are clamped by
             // ReaderTypography.clamped() via UiSettings.readerTypography so we
@@ -2872,6 +2885,29 @@ class SettingsRepositoryUiImpl(
         // /MAX_WPM in ReaderView, #1239) so a bad caller can't persist an
         // out-of-range pace the reader would have to re-clamp on read.
         store.edit { it[Keys.TELEPROMPTER_WPM] = wpm.coerceIn(30, 500) }
+    }
+
+    // #1633 — persist the teleprompter recording-overlay knobs (bands mirror
+    // RecordingViewModel's MIN/MAX constants so a bad caller can't store an
+    // out-of-range value the overlay would re-clamp on read).
+    override suspend fun setTeleprompterCountdownSec(seconds: Int) {
+        store.edit { it[Keys.TELEPROMPTER_COUNTDOWN_SEC] = seconds.coerceIn(0, 10) }
+    }
+
+    override suspend fun setTeleprompterOverlayOpacity(opacity: Float) {
+        store.edit { it[Keys.TELEPROMPTER_OVERLAY_OPACITY] = opacity.coerceIn(0.3f, 1.0f) }
+    }
+
+    override suspend fun setTeleprompterFontSizeSp(sp: Int) {
+        store.edit { it[Keys.TELEPROMPTER_FONT_SIZE_SP] = sp.coerceIn(16, 64) }
+    }
+
+    override suspend fun setTeleprompterMirror(enabled: Boolean) {
+        store.edit { it[Keys.TELEPROMPTER_MIRROR] = enabled }
+    }
+
+    override suspend fun setTeleprompterFrontCamera(front: Boolean) {
+        store.edit { it[Keys.TELEPROMPTER_FRONT_CAMERA] = front }
     }
 
     // ── Azure Speech Services BYOK (#182, PR-3) ────────────────────

--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -61,6 +61,7 @@ import `in`.jphe.storyvox.feature.settings.BookshareSettingsScreen
 import `in`.jphe.storyvox.feature.settings.CloudVoicesSettingsScreen
 import `in`.jphe.storyvox.feature.settings.ContentSourcesSettingsScreen
 import `in`.jphe.storyvox.feature.settings.DownloadsStorageSettingsScreen
+import `in`.jphe.storyvox.feature.settings.TeleprompterSettingsScreen
 import `in`.jphe.storyvox.feature.settings.MemoryPalaceSettingsScreen
 import `in`.jphe.storyvox.feature.settings.PerformanceSettingsScreen
 import `in`.jphe.storyvox.feature.settings.ReadingSettingsScreen
@@ -212,6 +213,9 @@ object StoryvoxRoutes {
 
     /** Issue #1632 — Downloads & Storage subscreen (hub group 4). */
     const val SETTINGS_DOWNLOADS = "settings/downloads"
+
+    /** Issue #1633 — teleprompter recording presets, reached from the Scripts gear. */
+    const val SETTINGS_TELEPROMPTER = "settings/teleprompter"
     /** Settings → Account. Royal Road sign-in, GitHub OAuth + scope. */
     const val SETTINGS_ACCOUNT = "settings/account"
     /** Settings → Memory Palace. Daemon host, API key, test probe. */
@@ -1305,6 +1309,22 @@ private fun StoryvoxNavHostContent(
                     onOpenTeleprompter = {
                         navController.navigate(StoryvoxRoutes.PLAYING) { launchSingleTop = true }
                     },
+                    onOpenTeleprompterSettings = {
+                        navController.navigate(StoryvoxRoutes.SETTINGS_TELEPROMPTER)
+                    },
+                )
+            }
+            // #1633 — teleprompter recording presets (reached from the Scripts gear;
+            // off the settings-hub chain, settings-family scaffold).
+            composable(
+                StoryvoxRoutes.SETTINGS_TELEPROMPTER,
+                enterTransition = pushEnter,
+                exitTransition = pushExit,
+                popEnterTransition = popEnter,
+                popExitTransition = popExit,
+            ) {
+                TeleprompterSettingsScreen(
+                    onBack = { navController.popBackStack() },
                 )
             }
             composable(

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -1608,6 +1608,20 @@ data class UiSettings(
      */
     val teleprompterWpm: Int = 130,
     /**
+     * Issue #1633 — persisted teleprompter recording-overlay knobs. These reset
+     * every session today (session `StateFlow`s in `RecordingViewModel`); persist
+     * them (device-local, not synced — like [teleprompterWpm]) and make the
+     * hardcoded countdown user-settable. Defaults mirror the current
+     * `RecordingViewModel` constants, so seeding from these preserves today's
+     * behaviour until the user changes one. `RecordingViewModel` seeds its flows
+     * from these on init and writes back on change (dual-write, like speed/pitch).
+     */
+    val teleprompterCountdownSec: Int = 3,
+    val teleprompterOverlayOpacity: Float = 0.7f,
+    val teleprompterFontSizeSp: Int = 26,
+    val teleprompterMirror: Boolean = false,
+    val teleprompterFrontCamera: Boolean = true,
+    /**
      * Issue #1632 — app-wide default [DownloadMode] applied to newly-added
      * fictions that don't specify one. The effective per-book mode is the
      * `Fiction.downloadMode` column; this is the default the "add to library"
@@ -2113,6 +2127,13 @@ interface SettingsRepositoryUi {
      * without overriding it.
      */
     suspend fun setTeleprompterWpm(wpm: Int) = Unit
+    /** Issue #1633 — persist the teleprompter recording-overlay knobs. Defaulted
+     *  no-op so hand-rolled [SettingsRepositoryUi] fakes don't break. */
+    suspend fun setTeleprompterCountdownSec(seconds: Int) = Unit
+    suspend fun setTeleprompterOverlayOpacity(opacity: Float) = Unit
+    suspend fun setTeleprompterFontSizeSp(sp: Int) = Unit
+    suspend fun setTeleprompterMirror(enabled: Boolean) = Unit
+    suspend fun setTeleprompterFrontCamera(front: Boolean) = Unit
     /**
      * Issue #992 — reader-surface typography setters. Each clamps into the safe
      * range from [ReaderTypography] on write. Default impls are no-ops so tests

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/recording/RecordingViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/recording/RecordingViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import `in`.jphe.storyvox.feature.api.PlaybackControllerUi
+import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
 import `in`.jphe.storyvox.playback.RecordingController
 import `in`.jphe.storyvox.playback.RecordingRequest
 import `in`.jphe.storyvox.playback.TeleprompterController
@@ -21,6 +22,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
@@ -54,6 +56,10 @@ class RecordingViewModel @Inject constructor(
      *  owner: it acts on inbound [RecordingController.requests] and writes back
      *  `armed` / `recording` / `elapsedMs`. */
     private val recordingController: RecordingController,
+    /** Issue #1633 — persist the recording-overlay knobs across sessions: seed
+     *  the flows below from the stored defaults on init and write back on change
+     *  (dual-write, mirroring how per-fiction speed/pitch persist). */
+    private val settings: SettingsRepositoryUi,
 ) : ViewModel() {
 
     /** The chapter text to read — the same script the reader's teleprompter
@@ -104,11 +110,27 @@ class RecordingViewModel @Inject constructor(
     private var countdownJob: Job? = null
     private var elapsedJob: Job? = null
 
+    /** Issue #1633 — countdown length in seconds, seeded from the persisted pref
+     *  on init (replaces the hardcoded [COUNTDOWN_SECONDS]). 0 = skip the
+     *  countdown and begin recording immediately. */
+    private var countdownSec: Int = COUNTDOWN_SECONDS
+
     init {
         // This VM's lifetime ≈ the RecordingScreen being on-screen with the
         // camera bound, so `armed` tells the Wear remote when its record button
         // is live ("open Recording on your phone first" otherwise).
         recordingController.setArmed(true)
+
+        // #1633 — seed the overlay knobs from their persisted defaults so they
+        // survive across sessions; each setter below writes the change back.
+        viewModelScope.launch {
+            val s = settings.settings.first()
+            countdownSec = s.teleprompterCountdownSec
+            _opacity.value = s.teleprompterOverlayOpacity
+            _fontSize.value = s.teleprompterFontSizeSp
+            _mirror.value = s.teleprompterMirror
+            _frontCamera.value = s.teleprompterFrontCamera
+        }
 
         // Inbound remote intents (watch): Start only begins a fresh take from
         // Preview; Stop defers to stopRecording()'s own Recording-only guard.
@@ -170,7 +192,7 @@ class RecordingViewModel @Inject constructor(
     private fun startCountdown() {
         countdownJob?.cancel()
         countdownJob = viewModelScope.launch {
-            for (s in COUNTDOWN_SECONDS downTo 1) {
+            for (s in countdownSec downTo 1) {
                 _uiState.value = RecordingState.Countdown(s)
                 delay(1_000)
             }
@@ -224,21 +246,33 @@ class RecordingViewModel @Inject constructor(
     fun flipCamera() {
         when (_uiState.value) {
             is RecordingState.Recording, is RecordingState.Saving -> return
-            else -> _frontCamera.value = !_frontCamera.value
+            else -> {
+                _frontCamera.value = !_frontCamera.value
+                persist { setTeleprompterFrontCamera(_frontCamera.value) }
+            }
         }
     }
 
     fun setOpacity(value: Float) {
         _opacity.value = value.coerceIn(MIN_OPACITY, MAX_OPACITY)
+        persist { setTeleprompterOverlayOpacity(_opacity.value) }
     }
 
     /** Step the script font size (A− / A+) within the supported band. */
     fun adjustFontSize(deltaSp: Int) {
         _fontSize.value = (_fontSize.value + deltaSp).coerceIn(MIN_FONT_SP, MAX_FONT_SP)
+        persist { setTeleprompterFontSizeSp(_fontSize.value) }
     }
 
     fun toggleMirror() {
         _mirror.value = !_mirror.value
+        persist { setTeleprompterMirror(_mirror.value) }
+    }
+
+    /** #1633 — write an overlay-knob change back to the persisted defaults so it
+     *  seeds the next recording session (dual-write, like speed/pitch). */
+    private fun persist(write: suspend SettingsRepositoryUi.() -> Unit) {
+        viewModelScope.launch { settings.write() }
     }
 
     /** Back to a clean live preview (after a save, an error, or "record

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/script/ScriptListScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/reader/script/ScriptListScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material.icons.outlined.Close
 import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.Delete
@@ -74,6 +75,9 @@ fun ScriptListScreen(
     onBack: () -> Unit,
     onOpenScript: (String) -> Unit,
     onOpenTeleprompter: () -> Unit,
+    // #1633 — gear → dedicated TeleprompterSettingsScreen (recording presets).
+    //  Default no-op so existing callers / the smoke test still compile.
+    onOpenTeleprompterSettings: () -> Unit = {},
     modifier: Modifier = Modifier,
     viewModel: ScriptManagerViewModel = hiltViewModel(),
 ) {
@@ -108,6 +112,16 @@ fun ScriptListScreen(
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    // #1633 — teleprompter recording presets (countdown, overlay
+                    // opacity/font, mirror, camera, scroll speed).
+                    IconButton(onClick = onOpenTeleprompterSettings) {
+                        Icon(
+                            Icons.Outlined.Settings,
+                            contentDescription = "Teleprompter settings",
+                        )
                     }
                 },
             )

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
@@ -143,6 +143,13 @@ class SettingsViewModel @Inject constructor(
     fun setDefaultVoice(id: String?) = viewModelScope.launch { repo.setDefaultVoice(id) }
     fun setWifiOnly(enabled: Boolean) = viewModelScope.launch { repo.setDownloadOnWifiOnly(enabled) }
     fun setPollHours(h: Int) = viewModelScope.launch { repo.setPollIntervalHours(h) }
+    // #1633 — teleprompter recording presets (Scripts subscreen "Teleprompter" section).
+    fun setTeleprompterWpm(wpm: Int) = viewModelScope.launch { repo.setTeleprompterWpm(wpm) }
+    fun setTeleprompterCountdownSec(s: Int) = viewModelScope.launch { repo.setTeleprompterCountdownSec(s) }
+    fun setTeleprompterOverlayOpacity(o: Float) = viewModelScope.launch { repo.setTeleprompterOverlayOpacity(o) }
+    fun setTeleprompterFontSizeSp(sp: Int) = viewModelScope.launch { repo.setTeleprompterFontSizeSp(sp) }
+    fun setTeleprompterMirror(on: Boolean) = viewModelScope.launch { repo.setTeleprompterMirror(on) }
+    fun setTeleprompterFrontCamera(front: Boolean) = viewModelScope.launch { repo.setTeleprompterFrontCamera(front) }
     // #1632 — Downloads & Storage: global default download mode for new fictions.
     fun setDefaultDownloadMode(mode: DownloadMode) =
         viewModelScope.launch { repo.setDefaultDownloadMode(mode) }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/TeleprompterSettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/TeleprompterSettingsScreen.kt
@@ -1,0 +1,144 @@
+package `in`.jphe.storyvox.feature.settings
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Slider
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import `in`.jphe.storyvox.feature.R
+import `in`.jphe.storyvox.ui.theme.LocalSpacing
+
+/**
+ * Issue #1633 — dedicated teleprompter recording-preset subscreen, reached via
+ * the gear in the Scripts top-bar (co-located with the teleprompter flow; NOT a
+ * settings-hub row → off the hub-order chain). Built on [SettingsSubscreenScaffold]
+ * so it shares the settings-family look + a11y vocabulary (Luna's IA note).
+ *
+ * These presets seed `RecordingViewModel`'s overlay flows on the next recording
+ * session; the in-overlay controls write back to the same prefs (dual-write), so
+ * this screen and the live overlay stay in sync. Sliders carry a
+ * `stateDescription` so TalkBack reads the value, not a raw float (#160).
+ */
+@Composable
+fun TeleprompterSettingsScreen(
+    onBack: () -> Unit,
+    viewModel: SettingsViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val spacing = LocalSpacing.current
+
+    SettingsSubscreenScaffold(
+        title = stringResource(R.string.teleprompter_settings_title),
+        onBack = onBack,
+    ) { padding ->
+        val s = state.settings ?: run {
+            SettingsSkeleton(
+                modifier = Modifier.fillMaxSize().padding(padding).padding(spacing.md),
+            )
+            return@SettingsSubscreenScaffold
+        }
+        SettingsSubscreenBody(padding) {
+            SettingsGroupCard {
+                val wpmTitle = stringResource(R.string.scripts_recording_wpm_title)
+                val wpmValue = stringResource(R.string.scripts_recording_wpm_value, s.teleprompterWpm)
+                SettingsSliderBlock(
+                    title = wpmTitle,
+                    valueLabel = wpmValue,
+                    slider = {
+                        Slider(
+                            value = s.teleprompterWpm.toFloat(),
+                            onValueChange = { viewModel.setTeleprompterWpm(it.toInt()) },
+                            valueRange = 30f..500f,
+                            modifier = Modifier.semantics {
+                                contentDescription = wpmTitle
+                                stateDescription = wpmValue
+                            },
+                        )
+                    },
+                )
+
+                val cdTitle = stringResource(R.string.scripts_recording_countdown_title)
+                val cdValue = if (s.teleprompterCountdownSec == 0) {
+                    stringResource(R.string.scripts_recording_countdown_off)
+                } else {
+                    stringResource(R.string.scripts_recording_countdown_value, s.teleprompterCountdownSec)
+                }
+                SettingsSliderBlock(
+                    title = cdTitle,
+                    valueLabel = cdValue,
+                    slider = {
+                        Slider(
+                            value = s.teleprompterCountdownSec.toFloat(),
+                            onValueChange = { viewModel.setTeleprompterCountdownSec(it.toInt()) },
+                            valueRange = 0f..10f,
+                            modifier = Modifier.semantics {
+                                contentDescription = cdTitle
+                                stateDescription = cdValue
+                            },
+                        )
+                    },
+                )
+
+                val opTitle = stringResource(R.string.scripts_recording_opacity_title)
+                val opValue = stringResource(
+                    R.string.scripts_recording_opacity_value,
+                    (s.teleprompterOverlayOpacity * 100).toInt(),
+                )
+                SettingsSliderBlock(
+                    title = opTitle,
+                    valueLabel = opValue,
+                    slider = {
+                        Slider(
+                            value = s.teleprompterOverlayOpacity,
+                            onValueChange = { viewModel.setTeleprompterOverlayOpacity(it) },
+                            valueRange = 0.3f..1.0f,
+                            modifier = Modifier.semantics {
+                                contentDescription = opTitle
+                                stateDescription = opValue
+                            },
+                        )
+                    },
+                )
+
+                val fsTitle = stringResource(R.string.scripts_recording_fontsize_title)
+                val fsValue = stringResource(R.string.scripts_recording_fontsize_value, s.teleprompterFontSizeSp)
+                SettingsSliderBlock(
+                    title = fsTitle,
+                    valueLabel = fsValue,
+                    slider = {
+                        Slider(
+                            value = s.teleprompterFontSizeSp.toFloat(),
+                            onValueChange = { viewModel.setTeleprompterFontSizeSp(it.toInt()) },
+                            valueRange = 16f..64f,
+                            modifier = Modifier.semantics {
+                                contentDescription = fsTitle
+                                stateDescription = fsValue
+                            },
+                        )
+                    },
+                )
+
+                SettingsSwitchRow(
+                    title = stringResource(R.string.scripts_recording_mirror_title),
+                    subtitle = stringResource(R.string.scripts_recording_mirror_subtitle),
+                    checked = s.teleprompterMirror,
+                    onCheckedChange = viewModel::setTeleprompterMirror,
+                )
+
+                SettingsSwitchRow(
+                    title = stringResource(R.string.scripts_recording_camera_title),
+                    subtitle = stringResource(R.string.scripts_recording_camera_subtitle),
+                    checked = s.teleprompterFrontCamera,
+                    onCheckedChange = viewModel::setTeleprompterFrontCamera,
+                )
+            }
+        }
+    }
+}

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -701,6 +701,21 @@
     <!-- #1634 — Benefits hub entry (re-discover Screener/Decoder) -->
     <string name="settings_hub_benefits_title">Benefits</string>
     <string name="settings_hub_benefits_subtitle">Do-I-qualify screener &amp; letter decoder.</string>
+    <!-- #1633 — Teleprompter recording presets subscreen (gear in Scripts; EN-only #1583) -->
+    <string name="teleprompter_settings_title">Teleprompter</string>
+    <string name="scripts_recording_wpm_title">Scroll speed</string>
+    <string name="scripts_recording_wpm_value">%1$d wpm</string>
+    <string name="scripts_recording_countdown_title">Countdown before recording</string>
+    <string name="scripts_recording_countdown_off">Off</string>
+    <string name="scripts_recording_countdown_value">%1$d s</string>
+    <string name="scripts_recording_opacity_title">Script overlay opacity</string>
+    <string name="scripts_recording_opacity_value">%1$d%%</string>
+    <string name="scripts_recording_fontsize_title">Script text size</string>
+    <string name="scripts_recording_fontsize_value">%1$d sp</string>
+    <string name="scripts_recording_mirror_title">Mirror script</string>
+    <string name="scripts_recording_mirror_subtitle">Flip horizontally for beam-splitter teleprompter glass.</string>
+    <string name="scripts_recording_camera_title">Front camera</string>
+    <string name="scripts_recording_camera_subtitle">Record with the selfie camera (off = rear camera).</string>
     <string name="settings_hub_all_settings_title">All settings</string>
     <string name="settings_hub_all_settings_subtitle">Every setting on one long page (legacy).</string>
     <!-- #1624 — grouped-hub category headings. Settings-ES is a dedicated


### PR DESCRIPTION
## What & why

Issue #1633 — the teleprompter recording-overlay knobs (opacity, font size, mirror, front/back camera) **reset every session**, the countdown was a hardcoded const with **no control**, and WPM had no Settings preset. This persists all of them and surfaces presets in a distinct **"Recording"** section of the **Scripts subscreen** (Luna's IA — off the hub-order chain, no `SettingsHubScreen` edit).

## Backend / persistence (the core)
- 5 new `UiSettings` fields (`teleprompterCountdownSec`/`OverlayOpacity`/`FontSizeSp`/`Mirror`/`FrontCamera`) + 5 `= Unit`-defaulted `SettingsRepositoryUi` setters (fakes-safe), **defaults mirroring `RecordingViewModel`'s constants** (no behaviour change until a user adjusts).
- `SettingsRepositoryUiImpl`: DataStore keys + reads (coerced to the overlay bands) + setter impls.
- `RecordingViewModel`: injects `SettingsRepositoryUi`, **seeds the overlay flows from persisted defaults on init**, writes each change back (dual-write, like speed/pitch), and reads the countdown from the pref (`0` = skip). Knobs now survive sessions.

## UI (Scripts subscreen)
A distinct **"Recording" `SectionHeading`** section **below the script list** (Luna's IA — not interleaved with script CRUD), rendered in **both** the populated and empty-script states so presets are always reachable. Reuses the shared `SettingsSliderBlock`/`SettingsSwitchRow` controls via `SettingsViewModel`: scroll speed (wpm), countdown (Off / N s), overlay opacity (%), script text size (sp), mirror + front-camera toggles. Sliders carry a11y `stateDescription`s (#160). EN-only strings (#1583).

## Coordination
Off the hub-order chain (no `SettingsHubScreen` edit) per Luna's (b) pick. Shared files `UiContracts` + `SettingsRepositoryUiImpl` append the `teleprompter*` fields/setters in a distinct region from #1631's `notification*` prefs. **Rebased clean onto current main `572c0e64`** (incl. Luna's #1645 §B — zero overlap). 2nd-pusher-rebases vs #1631 stands. Folds into batched v1.12.5.

## Tests
New prefs don't break fakes (`= Unit` defaults + defaulted `UiSettings` fields). `RecordingViewModel`/`ScriptListScreen` have no constructor-based tests to update. CI is the compile gate.

Closes #1633
Refs #1624
