### PR TITLE
feat(settings): Notifications subscreen — un-bury inbox toggles + permission row (#1631)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -60,6 +60,7 @@ import `in`.jphe.storyvox.feature.settings.AiSettingsScreen
 import `in`.jphe.storyvox.feature.settings.BookshareSettingsScreen
 import `in`.jphe.storyvox.feature.settings.CloudVoicesSettingsScreen
 import `in`.jphe.storyvox.feature.settings.ContentSourcesSettingsScreen
+import `in`.jphe.storyvox.feature.settings.NotificationsSettingsScreen
 import `in`.jphe.storyvox.feature.settings.DownloadsStorageSettingsScreen
 import `in`.jphe.storyvox.feature.settings.TeleprompterSettingsScreen
 import `in`.jphe.storyvox.feature.settings.MemoryPalaceSettingsScreen
@@ -213,9 +214,10 @@ object StoryvoxRoutes {
 
     /** Issue #1632 — Downloads & Storage subscreen (hub group 4). */
     const val SETTINGS_DOWNLOADS = "settings/downloads"
-
     /** Issue #1633 — teleprompter recording presets, reached from the Scripts gear. */
     const val SETTINGS_TELEPROMPTER = "settings/teleprompter"
+    /** Issue #1631 — Notifications subscreen (hub group 5). */
+    const val SETTINGS_NOTIFICATIONS = "settings/notifications"
     /** Settings → Account. Royal Road sign-in, GitHub OAuth + scope. */
     const val SETTINGS_ACCOUNT = "settings/account"
     /** Settings → Memory Palace. Daemon host, API key, test probe. */
@@ -1263,6 +1265,8 @@ private fun StoryvoxNavHostContent(
                     // #1630 — Content Sources subscreen.
                     onOpenContentSources = { navController.navigate(StoryvoxRoutes.SETTINGS_CONTENT_SOURCES) },
                     onOpenDownloads = { navController.navigate(StoryvoxRoutes.SETTINGS_DOWNLOADS) },
+                    // #1631 — Notifications subscreen.
+                    onOpenNotifications = { navController.navigate(StoryvoxRoutes.SETTINGS_NOTIFICATIONS) },
                 )
             }
 
@@ -1571,6 +1575,19 @@ private fun StoryvoxNavHostContent(
                 popExitTransition = popExit,
             ) {
                 DownloadsStorageSettingsScreen(
+                    onBack = { navController.popBackStack() },
+                )
+            }
+            // Issue #1631 — Notifications subscreen (new-chapter alerts + system
+            // permission), un-buried into hub group 5.
+            composable(
+                StoryvoxRoutes.SETTINGS_NOTIFICATIONS,
+                enterTransition = pushEnter,
+                exitTransition = pushExit,
+                popEnterTransition = popEnter,
+                popExitTransition = popExit,
+            ) {
+                NotificationsSettingsScreen(
                     onBack = { navController.popBackStack() },
                 )
             }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/NotificationsSettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/NotificationsSettingsScreen.kt
@@ -1,0 +1,113 @@
+package `in`.jphe.storyvox.feature.settings
+
+import android.content.Intent
+import android.provider.Settings
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.core.app.NotificationManagerCompat
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import `in`.jphe.storyvox.feature.R
+import `in`.jphe.storyvox.feature.settings.components.SectionHeading
+import `in`.jphe.storyvox.ui.theme.LocalSpacing
+
+/**
+ * Issue #1631 — Settings → Notifications subscreen (Wave 1 of the #1624
+ * settings overhaul; lives in the "Notifications" hub group).
+ *
+ * Notification prefs used to be reachable ONLY by scrolling the 4,100-line
+ * legacy "All settings" monolith. This un-buries them behind a dedicated,
+ * discoverable route (mirrors [ContentSourcesSettingsScreen]):
+ *
+ *  - **System permission status + deep-link** — every alert below is silenced
+ *    by the OS if the app's notification permission is off
+ *    (`NewChapterNotifier` guards on `areNotificationsEnabled()`), so surface
+ *    it first with a one-tap deep-link to the system settings that fix it.
+ *  - **Per-source new-chapter alerts** — Royal Road / KVMR / Wikipedia (#383).
+ *    Reuses the existing `setInboxNotify*` setters, so this and the legacy page
+ *    write the same prefs (single source of truth); each toggle suppresses both
+ *    the Android notification and the in-app Inbox event for that source.
+ *
+ * Scope note (#1631 slice 1): the buried `inboxNotify*` un-bury + the permission
+ * affordance. A global **`deadlineRemindersEnabled`** pref that gates the
+ * unconditional deadline alarms (#1515) is a follow-up slice — it's data+logic
+ * (new pref across UiContracts/repo/VM + `DeadlineAlarms` gating), spec'd in
+ * `scratch/candela-1631-notifications/`.
+ */
+@Composable
+fun NotificationsSettingsScreen(
+    onBack: () -> Unit,
+    viewModel: SettingsViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val spacing = LocalSpacing.current
+    val context = LocalContext.current
+
+    SettingsSubscreenScaffold(
+        title = stringResource(R.string.settings_hub_notifications_title),
+        onBack = onBack,
+    ) { padding ->
+        val s = state.settings ?: run {
+            SettingsSkeleton(modifier = Modifier.fillMaxSize().padding(padding).padding(spacing.md))
+            return@SettingsSubscreenScaffold
+        }
+        // Read once on entry; a full live-updating status would need an
+        // on-resume refresh, deferred — the deep-link is the actionable part.
+        val notificationsEnabled = remember {
+            NotificationManagerCompat.from(context).areNotificationsEnabled()
+        }
+        SettingsSubscreenBody(padding) {
+            // System permission first — everything else no-ops without it.
+            SettingsGroupCard {
+                SettingsRow(
+                    title = stringResource(R.string.settings_notifications_permission_title),
+                    subtitle = stringResource(
+                        if (notificationsEnabled) {
+                            R.string.settings_notifications_permission_on
+                        } else {
+                            R.string.settings_notifications_permission_off
+                        },
+                    ),
+                    onClick = {
+                        // ACTION_APP_NOTIFICATION_SETTINGS is O+; runCatching
+                        // guards the rare OEM that doesn't resolve it.
+                        runCatching {
+                            context.startActivity(
+                                Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS)
+                                    .putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName),
+                            )
+                        }
+                    },
+                )
+            }
+
+            SectionHeading(label = stringResource(R.string.settings_notifications_new_chapter_heading))
+            SettingsGroupCard {
+                SettingsSwitchRow(
+                    title = stringResource(R.string.settings_inbox_royalroad_title),
+                    subtitle = stringResource(R.string.settings_inbox_royalroad_subtitle),
+                    checked = s.inboxNotifyRoyalRoad,
+                    onCheckedChange = viewModel::setInboxNotifyRoyalRoad,
+                )
+                SettingsSwitchRow(
+                    title = stringResource(R.string.settings_inbox_kvmr_title),
+                    subtitle = stringResource(R.string.settings_inbox_kvmr_subtitle),
+                    checked = s.inboxNotifyKvmr,
+                    onCheckedChange = viewModel::setInboxNotifyKvmr,
+                )
+                SettingsSwitchRow(
+                    title = stringResource(R.string.settings_inbox_wikipedia_title),
+                    subtitle = stringResource(R.string.settings_inbox_wikipedia_subtitle),
+                    checked = s.inboxNotifyWikipedia,
+                    onCheckedChange = viewModel::setInboxNotifyWikipedia,
+                )
+            }
+        }
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsHubScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsHubScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.material.icons.outlined.Extension
 import androidx.compose.material.icons.outlined.GraphicEq
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.Key
+import androidx.compose.material.icons.outlined.Notifications
 import androidx.compose.material.icons.outlined.Description
 import androidx.compose.material.icons.outlined.Insights
 import androidx.compose.material.icons.outlined.Podcasts
@@ -212,6 +213,12 @@ fun SettingsHubScreen(
      *  / smoke tests compile without wiring it; production wiring in
      *  [`in`.jphe.storyvox.navigation.StoryvoxNavHost]. */
     onOpenDownloads: () -> Unit = {},
+    /**
+     * Issue #1631 — Notifications subscreen (new-chapter alerts + system
+     * permission). Default no-op so callers / smoke tests compile; production
+     * wiring lives in [`in.jphe.storyvox.navigation.StoryvoxNavHost`].
+     */
+    onOpenNotifications: () -> Unit = {},
 ) {
     val spacing = LocalSpacing.current
     var query by remember { mutableStateOf("") }
@@ -403,6 +410,23 @@ fun SettingsHubScreen(
                         subtitle = stringResource(R.string.settings_hub_downloads_subtitle),
                         onClick = onOpenDownloads,
                         keywords = HubKeywords.downloadsStorage,
+                    )
+                }
+                // #1631 — Notifications (group 5, after Downloads & Storage per
+                // the approved 8-group mockup: …Content & Sources · Downloads &
+                // Storage · Notifications · AI…).
+                HubGroup(
+                    query = query,
+                    heading = stringResource(R.string.settings_hub_group_notifications),
+                    icon = Icons.Outlined.Notifications,
+                    sections = notificationsSections,
+                ) {
+                    SettingsHubRow(
+                        icon = Icons.Outlined.Notifications,
+                        title = stringResource(R.string.settings_hub_notifications_title),
+                        subtitle = stringResource(R.string.settings_hub_notifications_subtitle),
+                        onClick = onOpenNotifications,
+                        keywords = HubKeywords.notifications,
                     )
                 }
                 HubGroup(
@@ -710,6 +734,11 @@ internal object HubKeywords {
         "download", "downloads", "storage", "cache", "offline", "wifi", "wi-fi",
         "data saver", "unmetered", "clear cache", "quota", "update interval", "poll",
     )
+    // #1631 — Notifications: new-chapter alerts + system permission.
+    val notifications = listOf(
+        "notification", "notifications", "alert", "alerts", "new chapter", "push",
+        "inbox", "royal road", "kvmr", "wikipedia", "permission", "system settings",
+    )
     val advanced = listOf("android auto", "car", "items per category", "integration")
     val developer = listOf("debug", "overlay", "log", "diagnostics", "reset onboarding", "verbose")
     val about = listOf(
@@ -756,6 +785,14 @@ internal val downloadsStorageSections = listOf(
         HubKeywords.downloadsStorage,
     ),
 )
+// #1631 — Notifications (group 5). Subtitle matches R.string.settings_hub_notifications_subtitle.
+internal val notificationsSections = listOf(
+    SettingsHubSection(
+        "Notifications",
+        "New-chapter alerts and system permission.",
+        HubKeywords.notifications,
+    ),
+)
 internal val aiSections = listOf(
     SettingsHubSection("AI", "Chat model, grounding, recap.", HubKeywords.ai),
     SettingsHubSection("AI sessions", "Review past chats and delete history.", HubKeywords.aiSessions),
@@ -784,6 +821,7 @@ val SettingsHubSections: List<SettingsHubSection> =
         readingDisplaySections +
         contentSourcesSections +
         downloadsStorageSections +
+        notificationsSections +
         aiSections +
         toolsSections +
         systemSections +

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -745,6 +745,16 @@
     <string name="settings_hub_group_downloads">Downloads &amp; Storage</string>
     <string name="settings_hub_downloads_title">Downloads &amp; Storage</string>
     <string name="settings_hub_downloads_subtitle">Default download mode, Wi-Fi, update interval, cache.</string>
+    <!-- #1631 — Notifications subscreen (new-chapter alerts + system permission).
+         EN-only per the #1583 settings-ES track. Subtitle matches the catalog
+         literal in SettingsHubScreen (notificationsSections). -->
+    <string name="settings_hub_group_notifications">Notifications</string>
+    <string name="settings_hub_notifications_title">Notifications</string>
+    <string name="settings_hub_notifications_subtitle">New-chapter alerts and system permission.</string>
+    <string name="settings_notifications_new_chapter_heading">New chapter alerts</string>
+    <string name="settings_notifications_permission_title">System notifications</string>
+    <string name="settings_notifications_permission_on">Allowed. Tap to manage in Android settings.</string>
+    <string name="settings_notifications_permission_off">Blocked — tap to allow in Android settings.</string>
     <string name="settings_content_sources_empty">No configurable sources yet — enable a source under Plugins to set it up here.</string>
 
     <!-- Settings · Reading subscreen -->

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsHubSectionsTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/settings/SettingsHubSectionsTest.kt
@@ -46,9 +46,11 @@ class SettingsHubSectionsTest {
         // per-source config seam, un-buried from the legacy monolith).
         // 22 → 23 in #1632, which added the Downloads & Storage group + row.
         // 23 → 24 in #1634, which added the Benefits row to the Tools group.
+        // 24 → 25 in #1631, which added the Notifications group + row (the
+        // buried inboxNotify* toggles + a system-permission affordance).
         // Adding a new section requires updating both this assertion AND
         // the composable's row list — that drift is the point of pinning.
-        assertEquals(24, SettingsHubSections.size)
+        assertEquals(25, SettingsHubSections.size)
     }
 
     @Test
@@ -88,6 +90,9 @@ class SettingsHubSectionsTest {
             "Downloads & Storage",
             // #1634 — Benefits re-discovery row (Screener/Decoder) in Tools.
             "Benefits",
+            // #1631 — Notifications group (buried inboxNotify* toggles + a
+            // system-permission affordance, un-buried into its own hub group).
+            "Notifications",
         )
         val actual = SettingsHubSections.map { it.title.lowercase() }.toSet()
         for (expected in expectedSectionTitles) {


### PR DESCRIPTION
## Summary
**Wave-1 of #1624 (#1631, from Lucid's audit — clean handoff, mirrors my `ContentSourcesScreen`).** Notification prefs were reachable **only** by scrolling the 4,100-line legacy monolith. A new **Notifications** subscreen surfaces them behind a dedicated, discoverable hub route.

## Surface (slice 1)
- **System-permission status + deep-link** — leads the screen, because every alert below is silenced by the OS if the app's notification permission is off (`NewChapterNotifier` guards on `areNotificationsEnabled()`). One tap → `ACTION_APP_NOTIFICATION_SETTINGS`.
- **Per-source new-chapter alerts** — Royal Road / KVMR / Wikipedia (#383). **Reuses the existing `setInboxNotify*` setters**, so this and the legacy page write the same prefs (single source of truth).

## Hub / nav / test
New **"Notifications"** group (group 5, after Downloads & Storage per the approved 8-group mockup) + row + keywords + catalog entry; `SETTINGS_NOTIFICATIONS` route + composable wiring; `SettingsHubSectionsTest` **24 → 25** + "Notifications" pinned. EN-only strings (#1583). a11y: `SettingsSubscreenScaffold` `heading()` + `SettingsRow`/`SettingsSwitchRow` merged row-labels.

## Deferred to a fast-follow (isolating risky data+logic from the safe UI un-bury)
- **NEW `deadlineRemindersEnabled` pref** gating the currently-**unconditional** deadline alarms (#1515). It's data+logic — a new field/setter across `UiContracts`/`SettingsRepositoryUiImpl`/VM **plus** a **regression-sensitive gate** (must not drop already-scheduled alarms; default-true = behavior-neutral). Spec'd in `scratch/candela-1631-notifications/`. Kept out of this PR deliberately so the un-bury lands clean; `Refs` (not `Closes`) #1631 so it stays open for the follow-up.

## Intentional: legacy inbox rows left in place
The 3 legacy inbox `SettingsSwitchRow`s in `SettingsScreen.kt` are **not** removed. Unlike §B's bespoke config *editors* (which the seam re-rendered, making the legacy copy redundant), these simple toggles have no seam render in the legacy page — removing them would break the **"All settings = everything" escape-hatch invariant** (#440). Same setters = single source of truth = no divergence with the new subscreen.

## Testing
No local gradle — CI **Build APK** is the compile gate. On-device: Settings → **Notifications** → permission row (status + opens system settings) + the 3 new-chapter toggles (persist; also reflected in the legacy page).

Refs #1631
Refs #1624

🤖 Generated with [Claude Code](https://claude.com/claude-code)