### PR TITLE
feat(settings): deadline-reminder enable toggle (#1631 slice 2)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
@@ -829,6 +829,13 @@ private object Keys {
     val INBOX_NOTIFY_KVMR = booleanPreferencesKey("pref_inbox_notify_kvmr")
     val INBOX_NOTIFY_WIKIPEDIA = booleanPreferencesKey("pref_inbox_notify_wikipedia")
 
+    // ── Deadline reminders master enable (issue #1631 / #1515) ─────
+    // Device-local (NOT synced): the deadline reminders themselves live in
+    // on-device storage that never syncs or backs up, so their enable flag
+    // stays per-device too (mirrors the #992 reader-typography ruling).
+    // Deliberately ABSENT from the sync allowlist + SyncedType map below.
+    val DEADLINE_REMINDERS_ENABLED = booleanPreferencesKey("pref_deadline_reminders_enabled")
+
     // ── InstantDB magical sign-in onboarding (issue #500) ──────────
     /** Has the user seen and dismissed (or completed) the first-launch
      *  InstantDB sync onboarding card mounted after the
@@ -1591,6 +1598,9 @@ class SettingsRepositoryUiImpl(
             inboxNotifyRoyalRoad = prefs[Keys.INBOX_NOTIFY_ROYALROAD] ?: true,
             inboxNotifyKvmr = prefs[Keys.INBOX_NOTIFY_KVMR] ?: true,
             inboxNotifyWikipedia = prefs[Keys.INBOX_NOTIFY_WIKIPEDIA] ?: true,
+            // Issue #1631 / #1515 — deadline-reminder master enable.
+            // Default ON so existing users keep their reminders on upgrade.
+            deadlineRemindersEnabled = prefs[Keys.DEADLINE_REMINDERS_ENABLED] ?: true,
             // Accessibility scaffold (Phase 1) — all defaults are the
             // no-op state so an upgrading user sees identical behavior
             // until they explicitly opt in. Enum keys fall back to
@@ -3205,6 +3215,12 @@ class SettingsRepositoryUiImpl(
     override suspend fun setInboxNotifyWikipedia(enabled: Boolean) {
         store.edit { it[Keys.INBOX_NOTIFY_WIKIPEDIA] = enabled }
         stampSyncedWrite()
+    }
+
+    // ── Issue #1631 / #1515 — deadline-reminder master enable ──────
+    // Device-local: no stampSyncedWrite() (the reminders never sync).
+    override suspend fun setDeadlineRemindersEnabled(enabled: Boolean) {
+        store.edit { it[Keys.DEADLINE_REMINDERS_ENABLED] = enabled }
     }
 
     // ── Issue #500 — magical InstantDB sign-in onboarding ──────────

--- a/app/src/main/kotlin/in/jphe/storyvox/di/DeadlineBindingsModule.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/DeadlineBindingsModule.kt
@@ -7,11 +7,14 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import `in`.jphe.storyvox.deadline.AlarmDeadlineReminderScheduler
 import `in`.jphe.storyvox.deadline.JsonFileDeadlineReminderStore
+import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
 import `in`.jphe.storyvox.feature.techempower.deadline.DeadlineClock
 import `in`.jphe.storyvox.feature.techempower.deadline.DeadlineReminderScheduler
+import `in`.jphe.storyvox.feature.techempower.deadline.DeadlineRemindersEnabledSource
 import `in`.jphe.storyvox.feature.techempower.deadline.DeadlineReminderStore
 import java.time.LocalDate
 import javax.inject.Singleton
+import kotlinx.coroutines.flow.first
 
 /**
  * Issue #1515 — binds the deadline-keeper seams (defined in :feature) to
@@ -36,5 +39,17 @@ abstract class DeadlineBindingsModule {
         @Provides
         @Singleton
         fun provideClock(): DeadlineClock = DeadlineClock { LocalDate.now() }
+
+        /**
+         * Issue #1631 — reads the master deadline-reminders enable pref off
+         * the settings DataStore (same singleton [SettingsRepositoryUi] as
+         * the rest of the app). Device-local pref; default true.
+         */
+        @Provides
+        @Singleton
+        fun provideRemindersEnabledSource(
+            settings: SettingsRepositoryUi,
+        ): DeadlineRemindersEnabledSource =
+            DeadlineRemindersEnabledSource { settings.settings.first().deadlineRemindersEnabled }
     }
 }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -1365,6 +1365,19 @@ data class UiSettings(
     val inboxNotifyKvmr: Boolean = true,
     val inboxNotifyWikipedia: Boolean = true,
     /**
+     * Issue #1631 / #1515 — master enable for on-device benefits deadline
+     * reminders (the Deadline keeper's local AlarmManager notifications).
+     *
+     * Default ON, so a user who scanned deadlines before this pref existed
+     * keeps being reminded (behavior-neutral upgrade). Turning it OFF gates
+     * only *new* scheduling — confirming a new deadline no longer arms an
+     * alarm — while reminders already armed, and the boot re-arm that
+     * survives a reboot, are intentionally left alone so a benefits deadline
+     * the user already set is never silently lost. Device-local (the
+     * reminders themselves never sync / back up), so this flag isn't synced.
+     */
+    val deadlineRemindersEnabled: Boolean = true,
+    /**
      * Accessibility scaffold (Phase 1) — opt-in switches that adapt
      * storyvox for users on TalkBack, Switch Access, or other
      * assistive services. The toggles persist user intent here in
@@ -2590,6 +2603,13 @@ interface SettingsRepositoryUi {
     suspend fun setInboxNotifyRoyalRoad(enabled: Boolean) {}
     suspend fun setInboxNotifyKvmr(enabled: Boolean) {}
     suspend fun setInboxNotifyWikipedia(enabled: Boolean) {}
+    /**
+     * Issue #1631 — master enable for benefits deadline reminders (#1515).
+     * Gates only *new* alarm scheduling; already-armed reminders and the
+     * boot re-arm are untouched. Device-local (not synced). Default impl is
+     * a no-op so existing test fakes compile without overrides.
+     */
+    suspend fun setDeadlineRemindersEnabled(enabled: Boolean) = Unit
 
     // ── Accessibility scaffold (Phase 1) ───────────────────────────
     /**

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/NotificationsSettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/NotificationsSettingsScreen.kt
@@ -33,12 +33,16 @@ import `in`.jphe.storyvox.ui.theme.LocalSpacing
  *    Reuses the existing `setInboxNotify*` setters, so this and the legacy page
  *    write the same prefs (single source of truth); each toggle suppresses both
  *    the Android notification and the in-app Inbox event for that source.
+ *  - **Deadline reminders** — a master `deadlineRemindersEnabled` pref (#1515).
+ *    Default ON; toggling it OFF gates only *new* deadline scheduling in the
+ *    Deadline keeper. Reminders already armed — and the boot re-arm — are left
+ *    alone, so a benefits deadline the user already set is never silently dropped.
  *
- * Scope note (#1631 slice 1): the buried `inboxNotify*` un-bury + the permission
- * affordance. A global **`deadlineRemindersEnabled`** pref that gates the
- * unconditional deadline alarms (#1515) is a follow-up slice — it's data+logic
- * (new pref across UiContracts/repo/VM + `DeadlineAlarms` gating), spec'd in
- * `scratch/candela-1631-notifications/`.
+ * Scope note: slice 1 (#1647) landed the `inboxNotify*` un-bury + the permission
+ * affordance; slice 2 (this change) adds the `deadlineRemindersEnabled` gate — a
+ * new pref across UiContracts / repo / VM plus a VM-side scheduling gate in
+ * [DeadlineKeeperViewModel][in.jphe.storyvox.feature.techempower.deadline.DeadlineKeeperViewModel],
+ * per the spec in `scratch/candela-1631-notifications/`.
  */
 @Composable
 fun NotificationsSettingsScreen(
@@ -106,6 +110,16 @@ fun NotificationsSettingsScreen(
                     subtitle = stringResource(R.string.settings_inbox_wikipedia_subtitle),
                     checked = s.inboxNotifyWikipedia,
                     onCheckedChange = viewModel::setInboxNotifyWikipedia,
+                )
+            }
+
+            SectionHeading(label = stringResource(R.string.settings_notifications_deadline_heading))
+            SettingsGroupCard {
+                SettingsSwitchRow(
+                    title = stringResource(R.string.settings_deadline_reminders_title),
+                    subtitle = stringResource(R.string.settings_deadline_reminders_subtitle),
+                    checked = s.deadlineRemindersEnabled,
+                    onCheckedChange = viewModel::setDeadlineRemindersEnabled,
                 )
             }
         }

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
@@ -545,6 +545,9 @@ class SettingsViewModel @Inject constructor(
     fun setInboxNotifyWikipedia(enabled: Boolean) =
         viewModelScope.launch { repo.setInboxNotifyWikipedia(enabled) }
 
+    fun setDeadlineRemindersEnabled(enabled: Boolean) =
+        viewModelScope.launch { repo.setDeadlineRemindersEnabled(enabled) }
+
     // ── Accessibility scaffold (Phase 1) ───────────────────────────
     // Phase 1 forwards the user's intent to the repo; no behavior is
     // wired yet. Phase 2 agents read [UiSettings.a11y*] + the

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/deadline/DeadlineKeeperViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/deadline/DeadlineKeeperViewModel.kt
@@ -38,6 +38,7 @@ class DeadlineKeeperViewModel @Inject constructor(
     private val store: DeadlineReminderStore,
     private val scheduler: DeadlineReminderScheduler,
     private val clock: DeadlineClock,
+    private val remindersEnabled: DeadlineRemindersEnabledSource,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(
@@ -152,7 +153,14 @@ class DeadlineKeeperViewModel @Inject constructor(
         )
         viewModelScope.launch {
             store.upsert(reminder)
-            scheduler.schedule(reminder)
+            // Issue #1631 — the master enable gates ONLY new scheduling.
+            // When off we still persist (the reminder shows in the list),
+            // just don't arm its alarm. Already-armed reminders and the
+            // boot re-arm are intentionally untouched, so a deadline the
+            // user set before turning this off is never silently dropped.
+            if (remindersEnabled.enabled()) {
+                scheduler.schedule(reminder)
+            }
             _state.update {
                 it.copy(
                     draft = null,

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/deadline/DeadlineReminderSeams.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/deadline/DeadlineReminderSeams.kt
@@ -68,3 +68,21 @@ interface DeadlineReminderStore {
 fun interface DeadlineClock {
     fun today(): LocalDate
 }
+
+/**
+ * Issue #1631 — reads the user's master "deadline reminders" enable pref
+ * (from settings) without dragging the whole `SettingsRepositoryUi` /
+ * `UiSettings` surface into this plain-JVM lane. The production binding
+ * (`:app`) reads it off the settings DataStore; tests pass a fixed lambda.
+ *
+ * Same tiny-seam posture as [DeadlineClock] — keeps the VM unit-testable
+ * with a one-line fake and immune to unrelated `UiSettings` churn.
+ *
+ * Only the *new-scheduling* path consults this ([DeadlineKeeperViewModel.
+ * confirmDraft]); the boot re-arm and already-armed alarms are deliberately
+ * left alone so a deadline the user already set is never silently dropped.
+ */
+fun interface DeadlineRemindersEnabledSource {
+    /** Current value of the master enable pref (default true). */
+    suspend fun enabled(): Boolean
+}

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -755,6 +755,10 @@
     <string name="settings_notifications_permission_title">System notifications</string>
     <string name="settings_notifications_permission_on">Allowed. Tap to manage in Android settings.</string>
     <string name="settings_notifications_permission_off">Blocked — tap to allow in Android settings.</string>
+    <!-- #1631 slice 2 — deadline-reminder master enable (gates #1515). EN-only per #1583. -->
+    <string name="settings_notifications_deadline_heading">Deadline reminders</string>
+    <string name="settings_deadline_reminders_title">Remind me before deadlines</string>
+    <string name="settings_deadline_reminders_subtitle">A local reminder before benefits deadlines you scan with the Deadline keeper. Turning this off stops new reminders; ones you\'ve already set keep working.</string>
     <string name="settings_content_sources_empty">No configurable sources yet — enable a source under Plugins to set it up here.</string>
 
     <!-- Settings · Reading subscreen -->

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/techempower/deadline/DeadlineKeeperViewModelTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/techempower/deadline/DeadlineKeeperViewModelTest.kt
@@ -34,6 +34,7 @@ class DeadlineKeeperViewModelTest {
     private lateinit var recognizer: FakeRecognizer
     private lateinit var store: FakeStore
     private lateinit var scheduler: FakeScheduler
+    private lateinit var remindersEnabled: FakeRemindersEnabled
     private lateinit var vm: DeadlineKeeperViewModel
 
     @Before
@@ -44,7 +45,8 @@ class DeadlineKeeperViewModelTest {
         )
         store = FakeStore()
         scheduler = FakeScheduler()
-        vm = DeadlineKeeperViewModel(recognizer, store, scheduler, DeadlineClock { today })
+        remindersEnabled = FakeRemindersEnabled()
+        vm = DeadlineKeeperViewModel(recognizer, store, scheduler, DeadlineClock { today }, remindersEnabled)
     }
 
     @After
@@ -75,6 +77,21 @@ class DeadlineKeeperViewModelTest {
         // Scheduler got exactly the persisted reminder.
         assertEquals(1, scheduler.scheduled.size)
         assertEquals(reminder.id, scheduler.scheduled.first().id)
+    }
+
+    @Test
+    fun `disabled master toggle persists the reminder but arms no alarm`() = runTest {
+        // Issue #1631 — the enable gate wraps only NEW scheduling.
+        remindersEnabled.isEnabled = false
+        vm.onImageCaptured(ByteArray(0))
+        vm.selectCandidate(vm.state.value.candidates.first(), label = "L", defaultBody = "b")
+
+        vm.confirmDraft()
+
+        // Still persisted + shown in the list (never silently dropped)…
+        assertEquals(1, vm.state.value.reminders.size)
+        // …but no alarm armed while deadline reminders are turned off.
+        assertEquals(0, scheduler.scheduled.size)
     }
 
     @Test
@@ -142,5 +159,9 @@ class DeadlineKeeperViewModelTest {
         override fun cancel(reminder: DeadlineReminder) { cancelled += reminder }
         override fun rescheduleAll(reminders: List<DeadlineReminder>) { scheduled += reminders }
         override fun canScheduleExact(): Boolean = exact
+    }
+
+    private class FakeRemindersEnabled(var isEnabled: Boolean = true) : DeadlineRemindersEnabledSource {
+        override suspend fun enabled(): Boolean = isEnabled
     }
 }


### PR DESCRIPTION
## #1631 slice 2 — deadline-reminder enable toggle

Completes **#1631**. Slice 1 (#1647, shipped v1.12.5) un-buried the `inboxNotify*` toggles + the system-permission row into the new Notifications subscreen. This slice adds the master **`deadlineRemindersEnabled`** pref that gates the on-device benefits-deadline reminders (#1515), which previously fired **unconditionally** (no enable pref existed).

### What
- **New DEVICE-LOCAL pref `deadlineRemindersEnabled` (default ON).**
  - `UiSettings` field + `SettingsRepositoryUi` setter (`= Unit` default → existing hand-rolled fakes compile untouched).
  - DataStore key + read + setter in `SettingsRepositoryUiImpl`. **No `stampSyncedWrite()`**, and absent from the sync allowlist / `SYNC_KEY_TYPES` — the deadline reminders themselves never sync/back up, so the flag stays per-device (mirrors the #992 reader-typography ruling; matches the `SweeperPrefsTest` "per-device intent" precedent).
- **Enable-gate at the single new-scheduling choke point** — `DeadlineKeeperViewModel.confirmDraft()`, via a tiny `DeadlineRemindersEnabledSource` seam (same posture as the existing `DeadlineClock` seam; keeps the plain-JVM VM unit-testable and off the 96-field `UiSettings` surface).
- **Toggle** wired into `NotificationsSettingsScreen` (reuses `SectionHeading` `heading()` + `SettingsSwitchRow` for a11y parity). EN-only strings (#1583).

### Regression care (nebula's flag) — already-scheduled reminders are never dropped
The gate wraps **only new scheduling**. These paths are **byte-untouched** (not in the diff):
- `DeadlineBootReceiver` → `DeadlineAlarms.schedule()` (boot re-arm)
- `AlarmDeadlineReminderScheduler.rescheduleAll()` (restore)
- `DeadlineReminderReceiver` (fire path)
- `DeadlineAlarms` (all AlarmManager plumbing)

Default-ON ⇒ **fully behavior-neutral for existing users**. Turning it OFF only stops arming *new* deadlines; reminders already armed keep firing, and the boot re-arm is intentionally left alone so a benefits deadline the user already set is never silently lost (documented in KDoc + the toggle subtitle).

### Test
- `DeadlineKeeperViewModelTest`: new case — disabled toggle → confirm still persists the reminder (shown in the list) but arms **no** alarm.

Closes #1631
Refs #1624

🤖 Generated with [Claude Code](https://claude.com/claude-code)