### PR TITLE
feat(settings): complete deadline-reminder regression bar (#1631 follow-up)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/StoryvoxApp.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/StoryvoxApp.kt
@@ -19,6 +19,7 @@ import `in`.jphe.storyvox.data.repository.ShelfRepository
 import `in`.jphe.storyvox.data.work.MetadataBackfillScheduler
 import `in`.jphe.storyvox.data.work.NewChapterNotifier
 import `in`.jphe.storyvox.data.work.WorkScheduler
+import `in`.jphe.storyvox.deadline.DeadlineReminderReconciler
 import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
 import `in`.jphe.storyvox.playback.VoiceEngineQualityBridge
 import `in`.jphe.storyvox.sync.coordinator.SyncCoordinator
@@ -141,6 +142,14 @@ class StoryvoxApp : Application(), Configuration.Provider {
      * rest of init (Issue #409 cold-launch posture).
      */
     @Inject lateinit var metadataBackfillScheduler: Lazy<MetadataBackfillScheduler>
+
+    /**
+     * Issue #1631 — keeps the on-device deadline alarms in sync with the
+     * master `deadlineRemindersEnabled` pref. Reacts to in-session toggle
+     * flips (OFF cancels armed alarms; ON re-arms from the store). Lazy + IO
+     * like the rest of init (Issue #409 cold-launch posture).
+     */
+    @Inject lateinit var deadlineReminderReconciler: Lazy<DeadlineReminderReconciler>
 
     override val workManagerConfiguration: Configuration
         get() = Configuration.Builder()
@@ -303,6 +312,12 @@ class StoryvoxApp : Application(), Configuration.Provider {
         // P22T-class hardware. Idempotent — re-starting is a no-op.
         initScope.launch {
             widgetStateObserver.get().start()
+        }
+        // Issue #1631 — reconcile deadline alarms with the master enable
+        // pref on every in-session flip. Idempotent start; off the cold-
+        // launch critical path like the rest of deferred init.
+        initScope.launch {
+            deadlineReminderReconciler.get().start()
         }
         // Issue #178 — Royal Road tag-sync. Two coroutines:
         //   1. Schedule the 24h periodic worker (idempotent, KEEP).

--- a/app/src/main/kotlin/in/jphe/storyvox/deadline/DeadlineBootReceiver.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/deadline/DeadlineBootReceiver.kt
@@ -12,6 +12,13 @@ import android.content.Intent
  * BOOT_COMPLETED we read the persisted reminders straight off disk (no
  * Hilt needed) and re-schedule each one via [DeadlineAlarms]. All local,
  * no network.
+ *
+ * Issue #1631 — gated on the master `deadlineRemindersEnabled` pref, read
+ * **race-safe** ([deadlineRemindersEnabledOrTrue] defaults TRUE on any
+ * failure). This is the regression hotspot: a boot read that fell through
+ * to "disabled" would silently drop every existing user's reminders. The
+ * store is only ever read here — reminders are never deleted, so a disabled
+ * user who re-enables gets them all back on the next boot / flip.
  */
 class DeadlineBootReceiver : BroadcastReceiver() {
 
@@ -21,8 +28,12 @@ class DeadlineBootReceiver : BroadcastReceiver() {
         val pending = goAsync()
         Thread {
             try {
-                DeadlineReminderJson.readAll(appContext).forEach {
-                    DeadlineAlarms.schedule(appContext, it)
+                // Off the main thread already (goAsync worker), so the
+                // awaited pref read is safe. Default-TRUE on any failure.
+                if (deadlineRemindersEnabledOrTrue(appContext)) {
+                    DeadlineReminderJson.readAll(appContext).forEach {
+                        DeadlineAlarms.schedule(appContext, it)
+                    }
                 }
             } finally {
                 pending.finish()

--- a/app/src/main/kotlin/in/jphe/storyvox/deadline/DeadlineReminderGate.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/deadline/DeadlineReminderGate.kt
@@ -1,0 +1,42 @@
+package `in`.jphe.storyvox.deadline
+
+import android.content.Context
+import dagger.hilt.EntryPoint
+import dagger.hilt.EntryPoints
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import `in`.jphe.storyvox.feature.techempower.deadline.DeadlineRemindersEnabledSource
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Issue #1631 — the Hilt-less read of the master `deadlineRemindersEnabled`
+ * pref for the two deadline [android.content.BroadcastReceiver]s
+ * ([DeadlineBootReceiver], [DeadlineReminderReceiver]), which run without a
+ * Hilt-injected constructor. Mirrors the `WidgetEntryPoint` accessor in
+ * `NowPlayingWidgetProvider`.
+ */
+@EntryPoint
+@InstallIn(SingletonComponent::class)
+internal interface DeadlineReminderGateEntryPoint {
+    fun remindersEnabled(): DeadlineRemindersEnabledSource
+}
+
+/**
+ * Reads the master enable pref, **defaulting to `true` on ANY failure** —
+ * Hilt graph not ready, DataStore mid-load, or a bind error. This is the
+ * load-bearing safety property nebula flagged: a boot-time read that fell
+ * through to "disabled" would silently drop EVERY existing user's reminders
+ * on the first boot after upgrade. [DeadlineRemindersEnabledSource.enabled]
+ * *awaits* the DataStore's first real emission, so a slow load blocks here
+ * (fine — callers are already off the main thread) rather than reading a
+ * wrong default.
+ *
+ * **Threading:** blocks via [runBlocking] — call ONLY from a background
+ * worker (both receivers wrap this in `goAsync()` + a worker thread), never
+ * from `onReceive`'s main thread.
+ */
+internal fun deadlineRemindersEnabledOrTrue(context: Context): Boolean = runCatching {
+    EntryPoints.get(context.applicationContext, DeadlineReminderGateEntryPoint::class.java)
+        .remindersEnabled()
+        .let { source -> runBlocking { source.enabled() } }
+}.getOrDefault(true)

--- a/app/src/main/kotlin/in/jphe/storyvox/deadline/DeadlineReminderReceiver.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/deadline/DeadlineReminderReceiver.kt
@@ -20,9 +20,16 @@ import `in`.jphe.storyvox.playback.R as PlaybackR
  * PendingIntent (explicit component) triggers it.
  *
  * The notification copy travels in the intent extras (set when the alarm
- * was armed), so this receiver needs neither Hilt nor storage access. The
- * banner shows the user's chosen text — by default a program label +
- * "deadline", never dollar amounts or case numbers (issue's Privacy note).
+ * was armed), so this receiver needs no storage access. The banner shows
+ * the user's chosen text — by default a program label + "deadline", never
+ * dollar amounts or case numbers (issue's Privacy note).
+ *
+ * Issue #1631 — suppressed when the master `deadlineRemindersEnabled` pref
+ * is off (read race-safe via [deadlineRemindersEnabledOrTrue], the only
+ * Hilt touch). Toggling off cancels pending alarms up front, so this is a
+ * belt-and-suspenders guard for an alarm already in flight; either way the
+ * reminder in the store is never deleted. The post is moved onto a
+ * `goAsync()` worker so the awaited pref read never blocks the main thread.
  */
 class DeadlineReminderReceiver : BroadcastReceiver() {
 
@@ -35,33 +42,47 @@ class DeadlineReminderReceiver : BroadcastReceiver() {
         val body = intent.getStringExtra(DeadlineAlarms.EXTRA_BODY).orEmpty()
         val notifId = intent.getIntExtra(DeadlineAlarms.EXTRA_NOTIF_ID, title.hashCode())
 
-        DeadlineAlarms.ensureChannel(context)
+        val appContext = context.applicationContext
+        val pending = goAsync()
+        Thread {
+            try {
+                // Issue #1631 — suppress if deadline reminders are off.
+                // Race-safe (default TRUE) and on a worker thread so the
+                // awaited pref read never blocks the main thread. The
+                // reminder in the store is untouched regardless — an alarm
+                // that slips past a just-flipped toggle drops at most one
+                // banner, never a saved deadline.
+                if (deadlineRemindersEnabledOrTrue(appContext) && notificationsAllowed(appContext)) {
+                    DeadlineAlarms.ensureChannel(appContext)
 
-        val contentIntent = context.packageManager
-            .getLaunchIntentForPackage(context.packageName)
-            ?.let { launch ->
-                PendingIntent.getActivity(
-                    context,
-                    notifId,
-                    launch,
-                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
-                )
+                    val contentIntent = appContext.packageManager
+                        .getLaunchIntentForPackage(appContext.packageName)
+                        ?.let { launch ->
+                            PendingIntent.getActivity(
+                                appContext,
+                                notifId,
+                                launch,
+                                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+                            )
+                        }
+
+                    val notification = NotificationCompat.Builder(appContext, DeadlineAlarms.CHANNEL_ID)
+                        .setSmallIcon(PlaybackR.drawable.ic_storyvox_notif)
+                        .setContentTitle(title)
+                        .setContentText(body)
+                        .setStyle(NotificationCompat.BigTextStyle().bigText(body))
+                        .setPriority(NotificationCompat.PRIORITY_HIGH)
+                        .setCategory(NotificationCompat.CATEGORY_REMINDER)
+                        .setAutoCancel(true)
+                        .apply { contentIntent?.let { setContentIntent(it) } }
+                        .build()
+
+                    NotificationManagerCompat.from(appContext).notify(notifId, notification)
+                }
+            } finally {
+                pending.finish()
             }
-
-        val notification = NotificationCompat.Builder(context, DeadlineAlarms.CHANNEL_ID)
-            .setSmallIcon(PlaybackR.drawable.ic_storyvox_notif)
-            .setContentTitle(title)
-            .setContentText(body)
-            .setStyle(NotificationCompat.BigTextStyle().bigText(body))
-            .setPriority(NotificationCompat.PRIORITY_HIGH)
-            .setCategory(NotificationCompat.CATEGORY_REMINDER)
-            .setAutoCancel(true)
-            .apply { contentIntent?.let { setContentIntent(it) } }
-            .build()
-
-        if (notificationsAllowed(context)) {
-            NotificationManagerCompat.from(context).notify(notifId, notification)
-        }
+        }.start()
     }
 
     private fun notificationsAllowed(context: Context): Boolean =

--- a/app/src/main/kotlin/in/jphe/storyvox/deadline/DeadlineReminderReconciler.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/deadline/DeadlineReminderReconciler.kt
@@ -1,0 +1,76 @@
+package `in`.jphe.storyvox.deadline
+
+import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
+import `in`.jphe.storyvox.feature.techempower.deadline.DeadlineReminderScheduler
+import `in`.jphe.storyvox.feature.techempower.deadline.DeadlineReminderStore
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+
+/**
+ * Issue #1631 — keeps the on-device deadline alarms in sync with the master
+ * `deadlineRemindersEnabled` pref while the app process is alive. Owned by
+ * [`in`.jphe.storyvox.StoryvoxApp], started from the deferred-init block
+ * (same posture as `WidgetStateObserver`).
+ *
+ * Reacts ONLY to *flips* of the pref (`drop(1)` skips the replay-on-subscribe
+ * value) because the other alarm owners already cover the rest:
+ *  - new reminders are armed at creation (`DeadlineKeeperViewModel`, gated),
+ *  - reboots are re-armed by [DeadlineBootReceiver],
+ *  - AlarmManager alarms survive process death, so a normal relaunch needs
+ *    no re-arm — only an in-session toggle does.
+ *
+ * On a flip ([reconcile]):
+ *  - **ON**  → re-arm every reminder in the store (`rescheduleAll`).
+ *  - **OFF** → cancel every armed alarm.
+ *
+ * The store is NEVER mutated, so turning off *silences* reminders without
+ * deleting the user's deadlines; turning back on restores exactly the same
+ * set (and boot re-arms them too, while enabled).
+ */
+@Singleton
+class DeadlineReminderReconciler @Inject constructor(
+    private val settings: SettingsRepositoryUi,
+    private val scheduler: DeadlineReminderScheduler,
+    private val store: DeadlineReminderStore,
+) {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private var job: Job? = null
+
+    /** Idempotent — calling [start] twice is a no-op. */
+    fun start() {
+        if (job?.isActive == true) return
+        job = scope.launch {
+            settings.settings
+                .map { it.deadlineRemindersEnabled }
+                .distinctUntilChanged()
+                .drop(1) // skip the current value; react only to in-session flips
+                .collect { enabled -> reconcile(enabled) }
+        }
+    }
+
+    /**
+     * Cancel-all (OFF) or re-arm-all-from-store (ON). Extracted for unit
+     * tests; never deletes from the store.
+     */
+    internal suspend fun reconcile(enabled: Boolean) {
+        val reminders = store.all()
+        if (enabled) {
+            scheduler.rescheduleAll(reminders)
+        } else {
+            reminders.forEach { scheduler.cancel(it) }
+        }
+    }
+
+    internal fun stop() {
+        job?.cancel()
+        job = null
+    }
+}

--- a/app/src/test/kotlin/in/jphe/storyvox/deadline/DeadlineReminderReconcilerTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/deadline/DeadlineReminderReconcilerTest.kt
@@ -1,0 +1,89 @@
+package `in`.jphe.storyvox.deadline
+
+import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
+import `in`.jphe.storyvox.feature.api.UiSettings
+import `in`.jphe.storyvox.feature.techempower.deadline.DeadlineReminder
+import `in`.jphe.storyvox.feature.techempower.deadline.DeadlineReminderScheduler
+import `in`.jphe.storyvox.feature.techempower.deadline.DeadlineReminderStore
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1631 — the toggle-flip half of the deadline-reminder regression
+ * bar: OFF cancels every armed alarm, ON re-arms from the store, and the
+ * store is never mutated (a saved benefits deadline is never deleted by
+ * flipping the master toggle).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class DeadlineReminderReconcilerTest {
+
+    private val r1 = reminder("a")
+    private val r2 = reminder("b")
+
+    @Test
+    fun `enabling re-arms every stored reminder`() = runTest {
+        val store = FakeStore(mutableListOf(r1, r2))
+        val scheduler = FakeScheduler()
+        val reconciler = DeadlineReminderReconciler(FakeSettings(), scheduler, store)
+
+        reconciler.reconcile(enabled = true)
+
+        assertEquals(listOf("a", "b"), scheduler.scheduled.map { it.id })
+        assertTrue("nothing cancelled on ON", scheduler.cancelled.isEmpty())
+        assertEquals("store untouched", 2, store.all().size)
+    }
+
+    @Test
+    fun `disabling cancels every stored reminder but never deletes the store`() = runTest {
+        val store = FakeStore(mutableListOf(r1, r2))
+        val scheduler = FakeScheduler()
+        val reconciler = DeadlineReminderReconciler(FakeSettings(), scheduler, store)
+
+        reconciler.reconcile(enabled = false)
+
+        assertEquals(listOf("a", "b"), scheduler.cancelled.map { it.id })
+        assertTrue("nothing armed on OFF", scheduler.scheduled.isEmpty())
+        // The saved deadlines survive — turning off is reversible.
+        assertEquals("store untouched", 2, store.all().size)
+    }
+
+    // ── Fakes ──────────────────────────────────────────────────────────
+
+    private fun reminder(id: String) = DeadlineReminder(
+        id = id,
+        programId = null,
+        label = id,
+        deadlineEpochDay = 20_000L,
+        notificationTitle = id,
+        notificationBody = id,
+        createdEpochDay = 19_000L,
+    )
+
+    /** reconcile() never reads [settings], so an empty flow suffices (avoids
+     *  constructing the 90+-field UiSettings). */
+    private class FakeSettings : SettingsRepositoryUi {
+        override val settings: Flow<UiSettings> = emptyFlow()
+    }
+
+    private class FakeStore(private val items: MutableList<DeadlineReminder>) : DeadlineReminderStore {
+        override fun reminders(): Flow<List<DeadlineReminder>> = flowOf(items)
+        override suspend fun all(): List<DeadlineReminder> = items.toList()
+        override suspend fun upsert(reminder: DeadlineReminder) { items += reminder }
+        override suspend fun delete(id: String) { items.removeAll { it.id == id } }
+    }
+
+    private class FakeScheduler : DeadlineReminderScheduler {
+        val scheduled = mutableListOf<DeadlineReminder>()
+        val cancelled = mutableListOf<DeadlineReminder>()
+        override fun schedule(reminder: DeadlineReminder) { scheduled += reminder }
+        override fun cancel(reminder: DeadlineReminder) { cancelled += reminder }
+        override fun rescheduleAll(reminders: List<DeadlineReminder>) { scheduled += reminders }
+        override fun canScheduleExact(): Boolean = true
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -1369,12 +1369,13 @@ data class UiSettings(
      * reminders (the Deadline keeper's local AlarmManager notifications).
      *
      * Default ON, so a user who scanned deadlines before this pref existed
-     * keeps being reminded (behavior-neutral upgrade). Turning it OFF gates
-     * only *new* scheduling — confirming a new deadline no longer arms an
-     * alarm — while reminders already armed, and the boot re-arm that
-     * survives a reboot, are intentionally left alone so a benefits deadline
-     * the user already set is never silently lost. Device-local (the
-     * reminders themselves never sync / back up), so this flag isn't synced.
+     * keeps being reminded (behavior-neutral upgrade). Turning it OFF cancels
+     * every scheduled deadline alarm and stops the boot re-arm and new-reminder
+     * arming; turning it back ON re-arms every reminder from the store. The
+     * saved deadlines are the durable source of truth — the toggle only adds or
+     * removes the *derived* alarms, so a benefits deadline the user set is never
+     * silently deleted. Device-local (the reminders themselves never sync / back
+     * up), so this flag isn't synced either.
      */
     val deadlineRemindersEnabled: Boolean = true,
     /**
@@ -2605,8 +2606,9 @@ interface SettingsRepositoryUi {
     suspend fun setInboxNotifyWikipedia(enabled: Boolean) {}
     /**
      * Issue #1631 — master enable for benefits deadline reminders (#1515).
-     * Gates only *new* alarm scheduling; already-armed reminders and the
-     * boot re-arm are untouched. Device-local (not synced). Default impl is
+     * OFF cancels all scheduled alarms + stops re-arming; ON re-arms from the
+     * store (reconciled by `DeadlineReminderReconciler` / `DeadlineBootReceiver`).
+     * Never deletes saved deadlines. Device-local (not synced). Default impl is
      * a no-op so existing test fakes compile without overrides.
      */
     suspend fun setDeadlineRemindersEnabled(enabled: Boolean) = Unit

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/NotificationsSettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/NotificationsSettingsScreen.kt
@@ -34,15 +34,16 @@ import `in`.jphe.storyvox.ui.theme.LocalSpacing
  *    write the same prefs (single source of truth); each toggle suppresses both
  *    the Android notification and the in-app Inbox event for that source.
  *  - **Deadline reminders** — a master `deadlineRemindersEnabled` pref (#1515).
- *    Default ON; toggling it OFF gates only *new* deadline scheduling in the
- *    Deadline keeper. Reminders already armed — and the boot re-arm — are left
- *    alone, so a benefits deadline the user already set is never silently dropped.
+ *    Default ON; toggling OFF cancels every scheduled deadline alarm (and stops
+ *    the boot re-arm + new-reminder arming), ON re-arms them from the store. The
+ *    saved deadlines are never deleted, so it silences reminders reversibly.
  *
  * Scope note: slice 1 (#1647) landed the `inboxNotify*` un-bury + the permission
  * affordance; slice 2 (this change) adds the `deadlineRemindersEnabled` gate — a
- * new pref across UiContracts / repo / VM plus a VM-side scheduling gate in
- * [DeadlineKeeperViewModel][in.jphe.storyvox.feature.techempower.deadline.DeadlineKeeperViewModel],
- * per the spec in `scratch/candela-1631-notifications/`.
+ * new pref (UiContracts / repo / VM) plus alarm reconciliation across the
+ * new-schedule path ([DeadlineKeeperViewModel][in.jphe.storyvox.feature.techempower.deadline.DeadlineKeeperViewModel]),
+ * an app-side reconciler for toggle flips, and the boot / fire receivers — per
+ * the spec in `scratch/candela-1631-notifications/`.
  */
 @Composable
 fun NotificationsSettingsScreen(

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/deadline/DeadlineKeeperViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/techempower/deadline/DeadlineKeeperViewModel.kt
@@ -153,11 +153,11 @@ class DeadlineKeeperViewModel @Inject constructor(
         )
         viewModelScope.launch {
             store.upsert(reminder)
-            // Issue #1631 — the master enable gates ONLY new scheduling.
-            // When off we still persist (the reminder shows in the list),
-            // just don't arm its alarm. Already-armed reminders and the
-            // boot re-arm are intentionally untouched, so a deadline the
-            // user set before turning this off is never silently dropped.
+            // Issue #1631 — gate arming of this NEW reminder on the master
+            // enable. When off we still persist it (saved in the store, shown
+            // in the list) but don't arm the alarm; re-enabling re-arms it from
+            // the store via DeadlineReminderReconciler. The store is the durable
+            // source of truth — the toggle never deletes a saved deadline.
             if (remindersEnabled.enabled()) {
                 scheduler.schedule(reminder)
             }

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -758,7 +758,7 @@
     <!-- #1631 slice 2 — deadline-reminder master enable (gates #1515). EN-only per #1583. -->
     <string name="settings_notifications_deadline_heading">Deadline reminders</string>
     <string name="settings_deadline_reminders_title">Remind me before deadlines</string>
-    <string name="settings_deadline_reminders_subtitle">A local reminder before benefits deadlines you scan with the Deadline keeper. Turning this off stops new reminders; ones you\'ve already set keep working.</string>
+    <string name="settings_deadline_reminders_subtitle">On-device reminders before benefits deadlines you scan. Turn this off to silence them all — your saved deadlines aren\'t deleted and return when you turn it back on.</string>
     <string name="settings_content_sources_empty">No configurable sources yet — enable a source under Plugins to set it up here.</string>
 
     <!-- Settings · Reading subscreen -->


### PR DESCRIPTION
## Follow-up to #1649 — completes nebula's deadline-reminder regression bar

#1649 (shipped in **v1.12.6**) landed the master `deadlineRemindersEnabled` pref with only the **new-schedule gate** (`confirmDraft`). That means turning the toggle OFF stopped *new* reminders but left *existing* armed alarms firing — a half-toggle. This PR completes the full regression bar nebula mapped so the toggle actually silences existing reminders **reversibly, without ever deleting a saved deadline**.

### The four alarm owners (store = durable source of truth; alarms = derived)
| Trigger | Behavior | Where |
|---|---|---|
| New reminder | arm iff enabled | `DeadlineKeeperViewModel.confirmDraft` (from #1649) |
| **Toggle flip** | OFF → cancel all armed; ON → `rescheduleAll` from store | **`DeadlineReminderReconciler`** (new; owned by `StoryvoxApp`, mirrors `WidgetStateObserver`; `drop(1)` → reacts to in-session flips only) |
| **Boot** | re-arm iff enabled, **race-safe** | **`DeadlineBootReceiver`** gated via `deadlineRemindersEnabledOrTrue` |
| **Fire** | suppress banner if disabled | **`DeadlineReminderReceiver`** (moved off-main via `goAsync`) |

### The regression hotspot — boot read is default-TRUE
`deadlineRemindersEnabledOrTrue()` (new `DeadlineReminderGate.kt`) reads the pref through a Hilt `@EntryPoint` (mirrors `NowPlayingWidgetProvider`) and **`.getOrDefault(true)` on ANY failure** — Hilt-not-ready, DataStore mid-load, bind error. `enabled()` *awaits* the DataStore's first real value, so a slow boot load blocks (on the `goAsync` worker) rather than reading a wrong default. A boot read that fell through to "disabled" would silently drop **every existing user's** reminders — this is structurally impossible here.

### Never deletes a saved deadline
The reconciler and receivers only ever add/remove **alarms**; the `JsonFileDeadlineReminderStore` is never mutated by the toggle. OFF → cancel + keep store; ON (or next boot while enabled) → re-arm the exact same set. Default ON ⇒ behavior-neutral for existing users.

### Notes
- Branched off current `main` (`0dc10f9d`, v1.12.6) — `git merge-tree` clean, 0 conflicts. The #1649 minimal commit is already in main (squash), so this is only the +delta.
- `DeadlineReminderReconcilerTest` covers ON re-arms-all / OFF cancels-all + store-never-deleted.
- Copy/KDoc updated to the new semantics (OFF is reversible, not "leaves existing alone").
- EN-only strings (#1583); device-local pref unchanged.

Refs #1631 #1624

🤖 Generated with [Claude Code](https://claude.com/claude-code)