### PR TITLE
fix(test): restore Test Compile broken by #1650 (main hotfix)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/deadline/DeadlineReminderReconciler.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/deadline/DeadlineReminderReconciler.kt
@@ -52,25 +52,31 @@ class DeadlineReminderReconciler @Inject constructor(
                 .map { it.deadlineRemindersEnabled }
                 .distinctUntilChanged()
                 .drop(1) // skip the current value; react only to in-session flips
-                .collect { enabled -> reconcile(enabled) }
-        }
-    }
-
-    /**
-     * Cancel-all (OFF) or re-arm-all-from-store (ON). Extracted for unit
-     * tests; never deletes from the store.
-     */
-    internal suspend fun reconcile(enabled: Boolean) {
-        val reminders = store.all()
-        if (enabled) {
-            scheduler.rescheduleAll(reminders)
-        } else {
-            reminders.forEach { scheduler.cancel(it) }
+                .collect { enabled -> reconcileDeadlineAlarms(scheduler, store, enabled) }
         }
     }
 
     internal fun stop() {
         job?.cancel()
         job = null
+    }
+}
+
+/**
+ * Cancel-all (OFF) or re-arm-all-from-store (ON) for the master deadline-
+ * reminders toggle. Top-level with explicit [scheduler] / [store] params so
+ * it's unit-testable without faking the fat [SettingsRepositoryUi]. Never
+ * deletes from the store — the toggle only adds/removes *derived* alarms.
+ */
+internal suspend fun reconcileDeadlineAlarms(
+    scheduler: DeadlineReminderScheduler,
+    store: DeadlineReminderStore,
+    enabled: Boolean,
+) {
+    val reminders = store.all()
+    if (enabled) {
+        scheduler.rescheduleAll(reminders)
+    } else {
+        reminders.forEach { scheduler.cancel(it) }
     }
 }

--- a/app/src/test/kotlin/in/jphe/storyvox/deadline/DeadlineReminderReconcilerTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/deadline/DeadlineReminderReconcilerTest.kt
@@ -1,13 +1,10 @@
 package `in`.jphe.storyvox.deadline
 
-import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
-import `in`.jphe.storyvox.feature.api.UiSettings
 import `in`.jphe.storyvox.feature.techempower.deadline.DeadlineReminder
 import `in`.jphe.storyvox.feature.techempower.deadline.DeadlineReminderScheduler
 import `in`.jphe.storyvox.feature.techempower.deadline.DeadlineReminderStore
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -19,6 +16,9 @@ import org.junit.Test
  * bar: OFF cancels every armed alarm, ON re-arms from the store, and the
  * store is never mutated (a saved benefits deadline is never deleted by
  * flipping the master toggle).
+ *
+ * Exercises [reconcileDeadlineAlarms] directly — it takes the scheduler +
+ * store explicitly, so no fake of the fat `SettingsRepositoryUi` is needed.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class DeadlineReminderReconcilerTest {
@@ -30,9 +30,8 @@ class DeadlineReminderReconcilerTest {
     fun `enabling re-arms every stored reminder`() = runTest {
         val store = FakeStore(mutableListOf(r1, r2))
         val scheduler = FakeScheduler()
-        val reconciler = DeadlineReminderReconciler(FakeSettings(), scheduler, store)
 
-        reconciler.reconcile(enabled = true)
+        reconcileDeadlineAlarms(scheduler, store, enabled = true)
 
         assertEquals(listOf("a", "b"), scheduler.scheduled.map { it.id })
         assertTrue("nothing cancelled on ON", scheduler.cancelled.isEmpty())
@@ -43,9 +42,8 @@ class DeadlineReminderReconcilerTest {
     fun `disabling cancels every stored reminder but never deletes the store`() = runTest {
         val store = FakeStore(mutableListOf(r1, r2))
         val scheduler = FakeScheduler()
-        val reconciler = DeadlineReminderReconciler(FakeSettings(), scheduler, store)
 
-        reconciler.reconcile(enabled = false)
+        reconcileDeadlineAlarms(scheduler, store, enabled = false)
 
         assertEquals(listOf("a", "b"), scheduler.cancelled.map { it.id })
         assertTrue("nothing armed on OFF", scheduler.scheduled.isEmpty())
@@ -64,12 +62,6 @@ class DeadlineReminderReconcilerTest {
         notificationBody = id,
         createdEpochDay = 19_000L,
     )
-
-    /** reconcile() never reads [settings], so an empty flow suffices (avoids
-     *  constructing the 90+-field UiSettings). */
-    private class FakeSettings : SettingsRepositoryUi {
-        override val settings: Flow<UiSettings> = emptyFlow()
-    }
 
     private class FakeStore(private val items: MutableList<DeadlineReminder>) : DeadlineReminderStore {
         override fun reminders(): Flow<List<DeadlineReminder>> = flowOf(items)


### PR DESCRIPTION
## Main hotfix — `:app:compileDebugUnitTestKotlin` is red on main

#1650 merged with a **failing Test Compile** (Build APK — the required gate — was green, so the merge went through). `DeadlineReminderReconcilerTest` faked `SettingsRepositoryUi` by overriding only `settings`, but that interface has **~60 abstract members**, so the test module doesn't compile on main. Production is fine (Build APK green); local `testDebugUnitTest` and every subsequent PR's Test Compile break until this lands.

### Fix (test-only behavior; production unchanged)
- Extract the cancel-all / reschedule-all logic to a top-level `reconcileDeadlineAlarms(scheduler, store, enabled)`. The reconciler's flow-collector calls it; the class still `@Inject`s `settings`/`scheduler`/`store`, so DI + runtime behavior are identical and **Build APK stays green**. nebula's boot/fire fail-safe proof is untouched.
- The test now exercises `reconcileDeadlineAlarms` directly with a fake scheduler + store — no `SettingsRepositoryUi` fake needed (sidesteps the fat interface entirely).

### Scope
2 files, delta only. `git merge-tree` clean on current main (`a7827ed5`). Restores green Test Compile.

Refs #1631 #1624

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved how reminder alarm reconciliation is organized internally, with no change to the visible app behavior.
  * Turning reminders off still cancels derived alarms without deleting stored reminders.

* **Tests**
  * Updated automated coverage for reminder alarm enabling and disabling.
  * Added checks to confirm reminder data remains unchanged while alarms are rescheduled or cancelled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->