### PR TITLE
docs(changelog): screener shipped a preview seed, not 33 programs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,7 +110,7 @@ Entries before v0.5.12 are reconstructed from the git log — see
 - **"My Documents" encrypted wallet** — keep benefits proofs in a device-credential-gated, encrypted-at-rest store, program-aware and excluded from every backup/sync. (#1514)
 - **Notice deadline keeper** — photograph a letter and Candela reads the date and sets a local reminder before the deadline. On-device. (#1515)
 - **Benefits letter decoder** — a NOA form-number becomes a plain-language + Spanish explainer from a verified corpus; an unknown form says so honestly rather than guessing. (#1516)
-- **Offline benefits screener** — the client-side /qualify (33 programs) bundled on-device, so "what do I qualify for?" works with zero connectivity. (#1517)
+- **Offline benefits screener** — the client-side /qualify screener bundled on-device (a preview set of programs; the full verified corpus is coming), so "what do I qualify for?" works with zero connectivity. (#1517)
 - **"Make the call" guided scripts** — verified call-card scripts with tap-to-dial and optional answer capture. (#1518)
 - **Saved household profile** — a local, encrypted profile that autofills scanned-form fields; a regression fence locks it out of cloud sync. (#1519)
 - **Google Drive Connect** — a Browse Connect entry point + empty state for the Drive source (folder-Picker + refresh follow-ups tracked). (#1534)


### PR DESCRIPTION
## What
The v1.12.0 changelog claimed the offline screener bundled **"the client-side /qualify (33 programs) on-device."** The app ships a **4-program SEED sample** (`screener_corpus.json`, `provenance: "seed-sample"`); **33** is the full techempower.org/qualify verified set that the production corpus (**#1586**) will deliver — not what shipped. Over-claiming coverage for a benefits app aimed at vulnerable users is exactly the failure to avoid.

## Fix (`CHANGELOG.md:113`)
Reworded to a **preview framing** that matches the **already-shipped UI copy** — the screener's "Sample data" banner: *"These programs and questions are a preview."* No hard count, so it's accurate **now** (not a 4-undersell) and **when #1586 lands** (not a 33-overclaim); that release's changelog announces the full verified set.

> before: …the client-side /qualify **(33 programs)** bundled on-device…
> after:  …the client-side /qualify screener bundled on-device **(a preview set of programs; the full verified corpus is coming)**…

## Scope (verified — this is the ONLY over-claim)
Checked every location #1608 flagged against `origin/main`:
- **Play listing / release-notes** `"33"` = **"33 content sources"** (the 33 FictionSources — *accurate*, unrelated to the screener). Not touched.
- **Screener UI copy** already honest — `screener_seed_banner` = "Sample data" / "…a preview…", `screener_intro` claims no count. Not touched.
- **docs/JSON/KDoc** `"33"` mentions correctly describe the *future* production corpus + label the current file a seed. Accurate; not touched.

So a single CHANGELOG edit satisfies the lock-step ask.

## Notes
- No code touched → CI is doc-only; wording is a **product call**, @jp adjust freely.
- Corpus re-verified still `seed-sample` / 4 programs today, so the fix is live (not stale).

Closes #1608

🤖 Generated with [Claude Code](https://claude.com/claude-code)
