### PR TITLE
feat(settings): parked settings trio — sleep-timer default #1590, Palace config #1591, AO3 row #1592

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/data/PalaceLibraryConfigImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/PalaceLibraryConfigImpl.kt
@@ -1,0 +1,66 @@
+package `in`.jphe.storyvox.data
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import `in`.jphe.storyvox.source.palace.PalaceLibraryConfig
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+
+private val Context.palaceLibraryDataStore: DataStore<Preferences> by
+    preferencesDataStore(name = "storyvox_palace_library")
+
+private object PalaceLibraryKeys {
+    /** Palace Project OPDS library root URL. Plaintext — a network
+     *  address, not a secret. Absent/blank = no library configured. */
+    val ROOT_URL = stringPreferencesKey("pref_palace_library_root_url")
+}
+
+/**
+ * Issue #1591 / #501 — production [PalaceLibraryConfig] backed by a tiny
+ * dedicated DataStore, replacing source-palace's `InMemoryPalaceLibraryConfig`
+ * fallback (which always emitted `null`).
+ *
+ * Same one-store-per-source posture as [OutlineConfigImpl] / [RadioConfigImpl]:
+ * `:source-palace` stays DataStore-free and only READS through the
+ * [PalaceLibraryConfig] contract, while the write side ([setRootUrl]) lives on
+ * this impl so the source can't mutate the config it consumes. Bound in
+ * `AppBindings` (`:app` is the sole provider, mirroring `RadioConfig`).
+ *
+ * URL-only — Palace v1 reads public OPDS feeds, so no credentials touch this
+ * store (per the [PalaceLibraryConfig] contract's future-state note).
+ */
+@Singleton
+class PalaceLibraryConfigImpl(
+    private val store: DataStore<Preferences>,
+) : PalaceLibraryConfig {
+
+    @Inject constructor(@ApplicationContext context: Context) : this(context.palaceLibraryDataStore)
+
+    // DataStore replays the latest value on subscribe, satisfying the
+    // PalaceLibraryConfig "emit current value on subscribe" contract.
+    override val libraryRootUrl: Flow<String?> = store.data
+        .map { it[PalaceLibraryKeys.ROOT_URL]?.ifBlank { null } }
+        .distinctUntilChanged()
+
+    /** Snapshot for the config contributor's echo path. */
+    suspend fun current(): String? =
+        store.data.first()[PalaceLibraryKeys.ROOT_URL]?.ifBlank { null }
+
+    /** Persist the user's library root URL. Blank clears it. */
+    suspend fun setRootUrl(url: String?) {
+        val trimmed = url?.trim().orEmpty()
+        store.edit { prefs ->
+            if (trimmed.isBlank()) prefs.remove(PalaceLibraryKeys.ROOT_URL)
+            else prefs[PalaceLibraryKeys.ROOT_URL] = trimmed
+        }
+    }
+}

--- a/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SettingsRepositoryUiImpl.kt
@@ -51,6 +51,7 @@ import `in`.jphe.storyvox.data.repository.GoogleNewsConfig
 import `in`.jphe.storyvox.data.repository.playback.AutoBrowserConfig
 import `in`.jphe.storyvox.data.repository.playback.PrerenderChapterCountConfig
 import `in`.jphe.storyvox.data.repository.playback.SleepTimerDndConfig
+import `in`.jphe.storyvox.data.repository.playback.SleepTimerDefaultConfig
 import `in`.jphe.storyvox.data.repository.playback.SleepTimerExtendConfig
 import `in`.jphe.storyvox.feature.api.PalaceProbeResult
 import `in`.jphe.storyvox.feature.api.ReadingDirection
@@ -494,6 +495,11 @@ private object Keys {
      *  `SHAKE_EXTEND_MINUTES` constant in StoryvoxPlaybackService. */
     val SLEEP_SHAKE_EXTEND_MINUTES =
         intPreferencesKey("pref_sleep_shake_extend_min_v1")
+
+    /** Issue #1590 — default sleep-timer duration in minutes (Int).
+     *  Snapped to [SLEEP_TIMER_DEFAULT_TIERS_MIN]. */
+    val SLEEP_TIMER_DEFAULT_MIN =
+        intPreferencesKey("pref_sleep_timer_default_min_v1")
 
     /** Auto-arm sleep timer when phone enters DND / Bedtime mode.
      *  Per-device (NOT synced). Default false. */
@@ -1013,6 +1019,14 @@ internal val SLEEP_SHAKE_EXTEND_TIERS_MIN: List<Int> = listOf(5, 10, 15, 30)
 internal fun snapSleepShakeExtendMinutes(minutes: Int): Int =
     SLEEP_SHAKE_EXTEND_TIERS_MIN.minBy { kotlin.math.abs(it - minutes) }
 
+// Issue #1590 — the default sleep-timer duration snaps to the same presets
+// the player sheet offers (SLEEP_TIMER_PRESETS_MIN), so a synced or legacy
+// value always lands on a pickable option.
+internal val SLEEP_TIMER_DEFAULT_TIERS_MIN: List<Int> = listOf(5, 15, 30, 60)
+
+internal fun snapSleepTimerDefaultMinutes(minutes: Int): Int =
+    SLEEP_TIMER_DEFAULT_TIERS_MIN.minBy { kotlin.math.abs(it - minutes) }
+
 /**
  * Issue #596 — supported pre-render chapter-count tiers. Chip-row
  * spec is "N+1 / N+2 / N+3 / N+5"; we store the raw integer count
@@ -1168,6 +1182,7 @@ class SettingsRepositoryUiImpl(
     `in`.jphe.storyvox.data.repository.playback.PlaybackSkipConfig,
     SleepTimerExtendConfig,
     SleepTimerDndConfig,
+    SleepTimerDefaultConfig,
     `in`.jphe.storyvox.data.repository.playback.BedtimeSleepConfig,
     PrerenderChapterCountConfig,
     AutoBrowserConfig,
@@ -1650,6 +1665,9 @@ class SettingsRepositoryUiImpl(
             sleepShakeExtendMinutes = snapSleepShakeExtendMinutes(
                 prefs[Keys.SLEEP_SHAKE_EXTEND_MINUTES] ?: 15,
             ),
+            sleepTimerDefaultMinutes = snapSleepTimerDefaultMinutes(
+                prefs[Keys.SLEEP_TIMER_DEFAULT_MIN] ?: 15,
+            ),
             sleepBedtimeAutoEnabled = prefs[Keys.SLEEP_BEDTIME_AUTO_ENABLED] ?: true,
             // Issue #1190 — auto Do Not Disturb while a sleep timer runs.
             dndWithSleepTimerEnabled = prefs[Keys.SLEEP_TIMER_DND_ENABLED] ?: false,
@@ -1957,6 +1975,16 @@ class SettingsRepositoryUiImpl(
     override val shakeExtendMinutes: Flow<Int> = store.data.map { prefs ->
         snapSleepShakeExtendMinutes(prefs[Keys.SLEEP_SHAKE_EXTEND_MINUTES] ?: 15)
     }
+
+    // --- SleepTimerDefaultConfig (issue #1590, consumed by core-playback's
+    //     PlaybackController.toggleSleepTimer) ---
+
+    override val sleepTimerDefaultMinutes: Flow<Int> = store.data.map { prefs ->
+        snapSleepTimerDefaultMinutes(prefs[Keys.SLEEP_TIMER_DEFAULT_MIN] ?: 15)
+    }
+
+    override suspend fun currentSleepTimerDefaultMinutes(): Int =
+        sleepTimerDefaultMinutes.first()
 
     override suspend fun currentShakeExtendMinutes(): Int = shakeExtendMinutes.first()
 
@@ -2796,6 +2824,14 @@ class SettingsRepositoryUiImpl(
     override suspend fun setSleepShakeExtendMinutes(minutes: Int) {
         store.edit {
             it[Keys.SLEEP_SHAKE_EXTEND_MINUTES] = snapSleepShakeExtendMinutes(minutes)
+        }
+        stampSyncedWrite()
+    }
+
+    // Issue #1590 — default sleep-timer duration for the quick toggle.
+    override suspend fun setSleepTimerDefaultMinutes(minutes: Int) {
+        store.edit {
+            it[Keys.SLEEP_TIMER_DEFAULT_MIN] = snapSleepTimerDefaultMinutes(minutes)
         }
         stampSyncedWrite()
     }

--- a/app/src/main/kotlin/in/jphe/storyvox/data/SourceConfigContributors.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/data/SourceConfigContributors.kt
@@ -248,6 +248,43 @@ class MatrixConfigContributor @Inject constructor(
 }
 
 /**
+ * Issue #1591 — Palace Project (public-library OPDS) library config. Palace has
+ * no canonical default library — each library is its own OPDS root — so the user
+ * supplies their library's catalog URL. Surfaced through the generic seam
+ * (renders in the Content Sources subscreen) as a single URL field wrapping
+ * [PalaceLibraryConfigImpl], which the source reads via the PalaceLibraryConfig
+ * contract. URL-only: Palace v1 reads public feeds, so no credentials.
+ */
+@Singleton
+class PalaceConfigContributor @Inject constructor(
+    private val config: PalaceLibraryConfigImpl,
+) : SourceConfigContributor {
+    override val sourceId: String = SourceIds.PALACE
+    override val displayName: String = "Palace Project"
+    override val sectionHelp: String =
+        "Read ebooks from a public library's Palace Project (OPDS) catalog. " +
+            "Paste your library's catalog root URL — some are at " +
+            "<library>.palaceproject.io, some at a custom domain."
+
+    override fun fields(): List<SourceConfigField> = listOf(
+        SourceConfigField.UrlText(
+            key = "libraryRootUrl",
+            label = "Library catalog URL",
+            help = "Your library's Palace / OPDS catalog root.",
+            placeholder = "https://catalog.example.org",
+        ),
+    )
+
+    override val values: Flow<Map<String, SourceConfigValue>> = config.libraryRootUrl.map { url ->
+        mapOf("libraryRootUrl" to SourceConfigValue.Text(url ?: ""))
+    }
+
+    override suspend fun set(key: String, raw: String) {
+        if (key == "libraryRootUrl") config.setRootUrl(raw.ifBlank { null })
+    }
+}
+
+/**
  * Issue #1624 — Outline (#245) migrated onto the generic seam. Was a bespoke
  * `OutlineConfigRow` (host + API key) in the legacy Settings monolith; now a
  * host URL + write-only key through the seam, so it renders in the Content

--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -485,6 +485,13 @@ object AppBindings {
     fun provideSleepTimerDndConfig(impl: SettingsRepositoryUiImpl):
         `in`.jphe.storyvox.data.repository.playback.SleepTimerDndConfig = impl
 
+    /** Issue #1590 — user-tunable default sleep-timer duration. Same
+     *  singleton; consumed by `:core-playback`'s
+     *  `DefaultPlaybackController.toggleSleepTimer`. */
+    @Provides @Singleton
+    fun provideSleepTimerDefaultConfig(impl: SettingsRepositoryUiImpl):
+        `in`.jphe.storyvox.data.repository.playback.SleepTimerDefaultConfig = impl
+
     /** Issue #596 — user-tunable PCM-cache pre-render window size.
      *  Same singleton; consumed by `:core-playback`'s
      *  `PrerenderTriggers`. */

--- a/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/di/AppBindings.kt
@@ -145,6 +145,12 @@ object AppBindings {
         impl: `in`.jphe.storyvox.data.WikipediaConfigContributor,
     ): `in`.jphe.storyvox.data.source.plugin.SourceConfigContributor = impl
 
+    // #1591 — Palace Project library config (public-library OPDS root URL).
+    @Provides @Singleton @IntoSet
+    fun providePalaceConfigContributor(
+        impl: `in`.jphe.storyvox.data.PalaceConfigContributor,
+    ): `in`.jphe.storyvox.data.source.plugin.SourceConfigContributor = impl
+
     /** Issue #1228 — bridges the `:feature` [DocumentImporterUi] seam to
      *  the app-side single-file import path (the same one MainActivity's
      *  "Open With" ingest uses), so the Library "Import a file…" picker can
@@ -276,6 +282,14 @@ object AppBindings {
      *  directly. */
     @Provides @Singleton
     fun provideRadioConfig(impl: `in`.jphe.storyvox.data.RadioConfigImpl): `in`.jphe.storyvox.source.radio.config.RadioConfig = impl
+
+    /** Issue #1591 / #501 — DataStore-backed Palace Project library config,
+     *  replacing source-palace's in-memory fallback. `:app` is the sole
+     *  provider (mirrors [provideRadioConfig]). */
+    @Provides @Singleton
+    fun providePalaceLibraryConfig(
+        impl: `in`.jphe.storyvox.data.PalaceLibraryConfigImpl,
+    ): `in`.jphe.storyvox.source.palace.PalaceLibraryConfig = impl
 
     /** Bridges the source-epub [EpubConfig] read interface (#235) to
      *  the concrete app-side SAF-backed impl. */

--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -1603,6 +1603,7 @@ private fun StoryvoxNavHostContent(
                     onBack = { navController.popBackStack() },
                     onOpenSyncSignIn = { navController.navigate(StoryvoxRoutes.SYNC) },
                     onOpenRoyalRoadSignIn = { navController.navigate(StoryvoxRoutes.authWebView(SourceIds.ROYAL_ROAD)) },
+                    onOpenAo3SignIn = { navController.navigate(StoryvoxRoutes.authWebView(SourceIds.AO3)) },
                     onOpenGitHubSignIn = { navController.navigate(StoryvoxRoutes.GITHUB_SIGN_IN) },
                     onOpenGitHubRevoke = {
                         // Mirrors the SETTINGS legacy page's revoke handler:

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/playback/SleepTimerDefaultConfig.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/repository/playback/SleepTimerDefaultConfig.kt
@@ -1,0 +1,35 @@
+package `in`.jphe.storyvox.data.repository.playback
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Issue #1590 — user-tunable default sleep-timer duration.
+ *
+ * When a listener arms the sleep timer without picking a specific length
+ * (the quick toggle — [PlaybackController.toggleSleepTimer]), the timer
+ * runs for this many minutes. Pre-#1590 this was hardcoded at 15 in
+ * `PlaybackController`.
+ *
+ * Surfaced as its own contract (mirroring [PlaybackSkipConfig] /
+ * [SleepTimerDndConfig]) so `:core-playback` can read the user's pref
+ * without taking a feature-layer dep.
+ *
+ * Per-device (same posture as the other sleep-timer contracts) — a
+ * bedroom tablet and a commuting phone want different wind-down lengths.
+ *
+ * Implementations read from the same DataStore that hosts the rest of
+ * the UI settings; `:app`'s `SettingsRepositoryUiImpl` implements this
+ * alongside the existing contracts. One DataStore, many contracts.
+ */
+interface SleepTimerDefaultConfig {
+
+    /** Live flow of the default sleep-timer duration in minutes. */
+    val sleepTimerDefaultMinutes: Flow<Int>
+
+    /**
+     * Snapshot read for callers that need a single value without
+     * subscribing. Implementations return the most-recent value,
+     * falling back to 15 if the underlying store hasn't emitted yet.
+     */
+    suspend fun currentSleepTimerDefaultMinutes(): Int
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackController.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackController.kt
@@ -203,6 +203,11 @@ class DefaultPlaybackController @Inject constructor(
      *  time, and a snapshot read is fine because skip taps are user-
      *  driven and inherently bursty (not a hot loop). */
     private val skipConfig: `in`.jphe.storyvox.data.repository.playback.PlaybackSkipConfig,
+    /** #1590 — user-tunable default sleep-timer duration. Snapshot-read
+     *  (via [cachedDefaultSleepMinutes]) inside [toggleSleepTimer]; the
+     *  quick toggle is user-driven and bursty, not a hot loop — the same
+     *  rationale as [skipConfig]. */
+    private val sleepTimerDefaultConfig: `in`.jphe.storyvox.data.repository.playback.SleepTimerDefaultConfig,
 ) : PlaybackController {
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -306,6 +311,9 @@ class DefaultPlaybackController @Inject constructor(
      */
     @Volatile private var cachedSkipDistanceSec: Int = 30
     @Volatile private var cachedRewindToStartThresholdSec: Int = 3
+    // #1590 — default sleep-timer duration for the quick toggle. Kept fresh
+    // by the collector below so toggleSleepTimer picks up pref changes live.
+    @Volatile private var cachedDefaultSleepMinutes: Int = 15
 
     init {
         scope.launch {
@@ -324,6 +332,13 @@ class DefaultPlaybackController @Inject constructor(
         scope.launch {
             skipConfig.rewindToStartThresholdSec.collect { v ->
                 cachedRewindToStartThresholdSec = v
+            }
+        }
+        // #1590 — keep the default sleep duration fresh so the quick toggle
+        // picks up the user's pref the moment they change it.
+        scope.launch {
+            sleepTimerDefaultConfig.sleepTimerDefaultMinutes.collect { v ->
+                cachedDefaultSleepMinutes = v
             }
         }
     }
@@ -898,7 +913,8 @@ class DefaultPlaybackController @Inject constructor(
 
     override fun toggleSleepTimer() {
         if (state.value.sleepTimerRemainingMs != null) cancelSleepTimer()
-        else startSleepTimer(SleepTimerMode.Duration(15))
+        // #1590 — was hardcoded 15; now the user's default (Voice & Playback).
+        else startSleepTimer(SleepTimerMode.Duration(cachedDefaultSleepMinutes))
     }
 
     override fun setShakeToExtendEnabled(enabled: Boolean) {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/api/UiContracts.kt
@@ -1489,6 +1489,10 @@ data class UiSettings(
      * Per-device pref (NOT synced).
      */
     val sleepShakeExtendMinutes: Int = 15,
+    /** Issue #1590 — default duration (minutes) a sleep timer runs when
+     *  armed via the quick toggle. Consumed by core-playback's
+     *  PlaybackController.toggleSleepTimer via SleepTimerDefaultConfig. */
+    val sleepTimerDefaultMinutes: Int = 15,
     /** Auto-arm the sleep timer when the phone enters Bedtime / Sleep
      *  / DND mode during playback. Uses [sleepShakeExtendMinutes] as
      *  the timer duration. Per-device pref (NOT synced). */
@@ -2071,6 +2075,9 @@ interface SettingsRepositoryUi {
      * a no-op so existing test fakes compile without overrides.
      */
     suspend fun setSleepShakeExtendMinutes(minutes: Int) = Unit
+
+    /** Issue #1590 — set the default sleep-timer duration (minutes). */
+    suspend fun setSleepTimerDefaultMinutes(minutes: Int) = Unit
     /** Auto-arm sleep timer on Bedtime / DND mode. Default no-op. */
     suspend fun setSleepBedtimeAutoEnabled(enabled: Boolean) = Unit
     /** Issue #1190 — auto Do Not Disturb with the sleep timer. Default

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/auth/AuthViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/auth/AuthViewModel.kt
@@ -4,14 +4,19 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import `in`.jphe.storyvox.data.auth.SessionHydrator
+import `in`.jphe.storyvox.data.auth.SessionState
 import `in`.jphe.storyvox.data.repository.AuthRepository
 import `in`.jphe.storyvox.data.repository.FictionRepository
 import `in`.jphe.storyvox.data.source.SourceIds
 import `in`.jphe.storyvox.feature.api.SettingsRepositoryUi
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 /**
@@ -53,6 +58,23 @@ class AuthViewModel @Inject constructor(
 
     private val _captureState = MutableStateFlow<CaptureState>(CaptureState.Idle)
     val captureState: StateFlow<CaptureState> = _captureState.asStateFlow()
+
+    /** #1592 — AO3 signed-in state for the Account screen row, observed off
+     *  [AuthRepository.sessionState] (the same source Browse reads for its
+     *  auth-only AO3 tabs). */
+    val ao3SignedIn: StateFlow<Boolean> = auth.sessionState(SourceIds.AO3)
+        .map { it is SessionState.Authenticated }
+        .distinctUntilChanged()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
+
+    /** #1592 — sign out a web-session source: clear the stored cookie header
+     *  (AuthRepository) AND the live OkHttp jar (per-source hydrator), mirroring
+     *  SettingsRepositoryUiImpl.signOut() for Royal Road. Without the jar clear
+     *  the source keeps sending the stale session cookie until app restart. */
+    fun signOut(sourceId: String) = viewModelScope.launch {
+        auth.clearSession(sourceId)
+        hydrators[sourceId]?.clear()
+    }
 
     /**
      * Persist the captured cookie map for [sourceId].

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/AccountSettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/AccountSettingsScreen.kt
@@ -24,8 +24,10 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import `in`.jphe.storyvox.data.source.SourceIds
 import `in`.jphe.storyvox.feature.R
 import `in`.jphe.storyvox.feature.api.UiGitHubAuthState
+import `in`.jphe.storyvox.feature.auth.AuthViewModel
 import `in`.jphe.storyvox.feature.settings.components.StatusPill
 import `in`.jphe.storyvox.feature.settings.components.StatusTone
 import `in`.jphe.storyvox.feature.sync.DomainStatusRow
@@ -47,13 +49,16 @@ fun AccountSettingsScreen(
     onBack: () -> Unit,
     onOpenSyncSignIn: () -> Unit,
     onOpenRoyalRoadSignIn: () -> Unit,
+    onOpenAo3SignIn: () -> Unit,
     onOpenGitHubSignIn: () -> Unit,
     onOpenGitHubRevoke: () -> Unit,
     viewModel: SettingsViewModel = hiltViewModel(),
     syncViewModel: AccountSyncViewModel = hiltViewModel(),
+    authViewModel: AuthViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val syncState by syncViewModel.state.collectAsStateWithLifecycle()
+    val ao3SignedIn by authViewModel.ao3SignedIn.collectAsStateWithLifecycle()
     val spacing = LocalSpacing.current
 
     SettingsSubscreenScaffold(title = stringResource(R.string.settings_account_title), onBack = onBack) { padding ->
@@ -167,6 +172,37 @@ fun AccountSettingsScreen(
                         },
                     )
                 }
+
+                // #1592 — AO3 (web-session cookie auth). State observed off
+                // AuthRepository (the same source Browse reads); sign-in via
+                // the generic auth WebView; sign-out clears the cookie header
+                // + the live OkHttp jar.
+                StatusPill(
+                    text = if (ao3SignedIn) stringResource(R.string.settings_account_ao3_signed_in) else stringResource(R.string.settings_account_ao3_not_signed_in),
+                    tone = if (ao3SignedIn) StatusTone.Connected else StatusTone.Neutral,
+                )
+                SettingsRow(
+                    title = stringResource(R.string.settings_account_ao3_title),
+                    subtitle = stringResource(
+                        if (ao3SignedIn) R.string.settings_account_ao3_signed_in_subtitle
+                        else R.string.settings_account_ao3_signin_subtitle,
+                    ),
+                    trailing = {
+                        if (ao3SignedIn) {
+                            BrassButton(
+                                label = stringResource(R.string.settings_sign_out),
+                                onClick = { authViewModel.signOut(SourceIds.AO3) },
+                                variant = BrassButtonVariant.Secondary,
+                            )
+                        } else {
+                            BrassButton(
+                                label = stringResource(R.string.settings_sign_in),
+                                onClick = onOpenAo3SignIn,
+                                variant = BrassButtonVariant.Primary,
+                            )
+                        }
+                    },
+                )
 
                 StatusPill(
                     text = when (val g = s.github) {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/SettingsViewModel.kt
@@ -599,6 +599,10 @@ class SettingsViewModel @Inject constructor(
     fun setSleepShakeExtendMinutes(minutes: Int) =
         viewModelScope.launch { repo.setSleepShakeExtendMinutes(minutes) }
 
+    // Issue #1590 — default sleep-timer duration.
+    fun setSleepTimerDefaultMinutes(minutes: Int) =
+        viewModelScope.launch { repo.setSleepTimerDefaultMinutes(minutes) }
+
     fun setSleepBedtimeAutoEnabled(enabled: Boolean) =
         viewModelScope.launch { repo.setSleepBedtimeAutoEnabled(enabled) }
 

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/VoiceAndPlaybackSettingsScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/settings/VoiceAndPlaybackSettingsScreen.kt
@@ -214,6 +214,26 @@ fun VoiceAndPlaybackSettingsScreen(
             // enable → duration → auto-arm → Do Not Disturb.
             SettingsSectionHeader(label = stringResource(R.string.settings_voice_sleep_group_title))
             SettingsGroupCard {
+                // Issue #1590 — default sleep-timer duration. This is what the
+                // quick sleep toggle arms (pre-#1590 hardcoded 15 in
+                // core-playback's PlaybackController); the presets mirror the
+                // player-sheet options (5 / 15 / 30 / 60).
+                val sleepDefaultOptions = listOf(5, 15, 30, 60)
+                val sleepDefaultIndex = sleepDefaultOptions
+                    .indexOfFirst { it == s.sleepTimerDefaultMinutes }
+                    .let { if (it < 0) sleepDefaultOptions.indexOf(15) else it }
+                SettingsSegmentedBlock(
+                    title = stringResource(R.string.settings_voice_sleep_default_title),
+                    subtitle = stringResource(R.string.settings_voice_sleep_default_subtitle),
+                    options = sleepDefaultOptions.map {
+                        stringResource(R.string.settings_voice_sleep_default_option, it)
+                    },
+                    selectedIndex = sleepDefaultIndex,
+                    onSelected = { idx ->
+                        viewModel.setSleepTimerDefaultMinutes(sleepDefaultOptions[idx])
+                    },
+                )
+
                 // #150 — shake-to-extend enable (moved here from Reading in
                 // #1577 so it sits directly above the duration it governs).
                 SettingsSwitchRow(

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -1089,6 +1089,11 @@
     <string name="settings_account_royal_road_title">Royal Road</string>
     <string name="settings_account_royal_road_signed_in_subtitle">Signed in</string>
     <string name="settings_account_royal_road_signin_subtitle">Sign-in unlocks Premium chapters and your Follows list.</string>
+    <string name="settings_account_ao3_title">Archive of Our Own</string>
+    <string name="settings_account_ao3_signed_in">AO3: signed in</string>
+    <string name="settings_account_ao3_not_signed_in">AO3: not signed in</string>
+    <string name="settings_account_ao3_signed_in_subtitle">Your AO3 session unlocks Subscriptions and Marked for Later in Browse.</string>
+    <string name="settings_account_ao3_signin_subtitle">Sign in to AO3 to read your Subscriptions and Marked for Later.</string>
     <string name="settings_account_github_not_signed_in">GitHub · not signed in</string>
     <string name="settings_account_github_signed_in_as">GitHub · signed in as @%1$s</string>
     <string name="settings_account_github_signed_in">GitHub · signed in</string>

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -937,6 +937,9 @@
     <!-- #1577 — Voice &amp; Playback section headers + the shake-to-extend enable row moved here from Reading so the whole sleep-timer feature lives on one screen. -->
     <string name="settings_voice_transport_group_title">Playback controls</string>
     <string name="settings_voice_sleep_group_title">Sleep timer</string>
+    <string name="settings_voice_sleep_default_title">Default duration</string>
+    <string name="settings_voice_sleep_default_subtitle">How long a new sleep timer runs when you start one without picking a time.</string>
+    <string name="settings_voice_sleep_default_option">%1$d min</string>
     <string name="settings_voice_shake_enable_title">Shake to extend</string>
     <string name="settings_voice_shake_enable_subtitle">Shake your device during the timer\'s fade-out to keep listening.</string>
 

--- a/source-palace/src/main/kotlin/in/jphe/storyvox/source/palace/di/PalaceModule.kt
+++ b/source-palace/src/main/kotlin/in/jphe/storyvox/source/palace/di/PalaceModule.kt
@@ -1,15 +1,12 @@
 package `in`.jphe.storyvox.source.palace.di
 
 import android.content.Context
-import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import `in`.jphe.storyvox.data.network.UserAgentHeader
-import `in`.jphe.storyvox.source.palace.InMemoryPalaceLibraryConfig
-import `in`.jphe.storyvox.source.palace.PalaceLibraryConfig
 import `in`.jphe.storyvox.source.palace.PalaceSource
 import `in`.jphe.storyvox.source.palace.net.PalaceApi
 import okhttp3.Interceptor
@@ -82,30 +79,8 @@ internal object PalaceHttpModule {
         File(ctx.cacheDir, "palace").apply { mkdirs() }
 }
 
-/**
- * Binds [PalaceLibraryConfig] to the in-memory default. The
- * DataStore-backed real implementation lives in `:app` / `:feature`
- * and is wired up by issue #501's settings refactor — until then, the
- * in-memory binding returns `null` for the library URL and the source
- * surfaces "configure a library" copy on every browse call.
- *
- * When #501's settings binding lands, it will provide its own
- * `@Module @InstallIn(SingletonComponent::class)` with a `@Provides`
- * for `PalaceLibraryConfig` and a `@TestInstallIn` to replace this
- * binding. We don't put it behind a `@Singleton` rebinder here so that
- * a downstream module-level override works without a `@TestInstallIn`
- * pragma in the production code path. The
- * `(@Suppress("DaggerProductionScope"))` posture mirrors how
- * `:source-radio` provides a default `RadioConfig` overridden by
- * `:app`'s real implementation.
- */
-@Module
-@InstallIn(SingletonComponent::class)
-internal abstract class PalaceConfigBindings {
-
-    /** Default in-memory binding. Replace with a DataStore-backed
-     *  implementation in `:app` / `:feature` (issue #501). */
-    @Binds
-    @Singleton
-    abstract fun bindConfig(impl: InMemoryPalaceLibraryConfig): PalaceLibraryConfig
-}
+// Issue #1591 / #501 — the DataStore-backed PalaceLibraryConfig now lives in
+// `:app` (PalaceLibraryConfigImpl, bound in AppBindings), so the previous
+// in-memory default binding is gone. `:source-palace` stays DataStore-free and
+// reads through the PalaceLibraryConfig contract — same posture as source-radio,
+// where `:app` is the sole RadioConfig provider.


### PR DESCRIPTION
Parked settings trio from the #1577 audit — Settings-hub lane. Serialized on one branch (they touch the same hub/settings surfaces), one commit per issue.

## Scope

- [x] **#1590** — sleep-timer default-duration preference
- [x] **#1591** — Palace Project library config (generic config seam)
- [x] **#1592** — AO3 account row (login/session)

---

### #1590 — sleep-timer default-duration preference
The quick sleep toggle armed a hardcoded `Duration(15)` in `core-playback` (`PlaybackController.toggleSleepTimer`). Now a user pref:
- **core-data** — new `SleepTimerDefaultConfig` contract (mirrors `PlaybackSkipConfig` / `SleepTimerDndConfig`) so `:core-playback` reads the pref without a feature dep.
- **core-playback** — `DefaultPlaybackController` collects the flow into a cached snapshot (same idiom as `skipConfig`) and toggles `Duration(cachedDefaultSleepMinutes)`.
- **app** — `SettingsRepositoryUiImpl` implements it + DataStore key (snapped to the 5/15/30/60 player presets); `AppBindings @Provides` the binding.
- **feature** — `UiSettings.sleepTimerDefaultMinutes` (default 15) + `setSleepTimerDefaultMinutes` (`= Unit`-defaulted per the fake-safe rule) + a segmented "Default duration" row in the Voice & Playback sleep group (mirrors the #595 shake-extend control).

### #1591 — Palace Project library config (via the seam)
Palace Project (public-library OPDS) had no settings surface — the only `PalaceLibraryConfig` impl was the null-returning `InMemoryPalaceLibraryConfig` fallback (the #501 wiring never landed).
- **source-palace** — drop the in-memory `@Binds` default (`PalaceConfigBindings`) so `:app` becomes the sole provider — the handoff the binding's own KDoc anticipated, mirroring how source-radio leaves `RadioConfig` to `:app`.
- **app** — new `PalaceLibraryConfigImpl` (dedicated DataStore, URL-only; mirrors `OutlineConfigImpl`) bound in `AppBindings`; `PalaceConfigContributor` exposes a single `UrlText(libraryRootUrl)` via the #1531 seam, so it renders in the Content Sources subscreen (#1630) with zero bespoke UI.

### #1592 — AO3 account row (login/session)
AO3 supports authed access (Subscriptions / Marked for Later) but the session was only reachable from Browse.
- **feature** — `AuthViewModel` (methods-only; `SettingsViewModel`'s ctor is test-fragile so left untouched): `ao3SignedIn` observed off `AuthRepository.sessionState(AO3)` (same source Browse reads) + a generic `signOut(sourceId)` that clears BOTH the cookie header and the live OkHttp jar (mirrors RR's sign-out). `AccountSettingsScreen` gains an AO3 row (status pill + sign-in / sign-out).
- **app** — `StoryvoxNavHost` wires `onOpenAo3SignIn → authWebView(AO3)`. Sign-in reuses the existing generic auth infra; no new machinery.

---

**Notes:** EN-only (#1583); a11y preserved (section headers carry `heading()`). Branch is 2 non-conflicting commits behind main (CHANGELOG + Room `19.json`) — clean to rebase/merge. Each issue is a separate commit for easy review.

Refs #1590 Refs #1591 Refs #1592

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable default sleep-timer duration, with quick selection options in playback settings.
  * Added AO3 account sign-in/sign-out controls and status in account settings.
  * Added a saved library root URL setting for supported source integrations.

* **Bug Fixes**
  * Sleep-timer toggles now use the user’s saved default duration instead of a fixed value.
  * Account status now updates correctly for AO3 sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->