### PR TITLE
feat(notes): Voice Notes storage foundation — NotesDatabase + backup rules (Phase 1)

### DIFF
--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -30,4 +30,14 @@
     <!-- Issue #1515 — deadline reminders are on-device only; never back
          them up to the cloud (privacy.md §2.11). -->
     <exclude domain="file" path="deadline_reminders.json" />
+    <!-- Issue #1657 (Voice Notes) — the notes DB + all recordings are
+         on-device only; never back them up (spec §3.7). notes.db is a
+         SEPARATE Room DB precisely so it's file-excludable here; the
+         recordings/ path must match NotesRepository.RECORDINGS_SUBDIR and
+         Phase 2a's write path (a mismatch silently un-protects the audio). -->
+    <exclude domain="database" path="notes.db" />
+    <exclude domain="database" path="notes.db-wal" />
+    <exclude domain="database" path="notes.db-shm" />
+    <exclude domain="database" path="notes.db-journal" />
+    <exclude domain="file" path="recordings/" />
 </full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -24,6 +24,15 @@
         <exclude domain="file" path="wallet/" />
         <!-- Issue #1515 — deadline reminders are on-device only (privacy.md §2.11). -->
         <exclude domain="file" path="deadline_reminders.json" />
+        <!-- Issue #1657 (Voice Notes) — notes DB + recordings are on-device
+             only (spec §3.7). notes.db is a SEPARATE Room DB so it's file-
+             excludable; recordings/ matches NotesRepository.RECORDINGS_SUBDIR
+             + Phase 2a's write path. -->
+        <exclude domain="database" path="notes.db" />
+        <exclude domain="database" path="notes.db-wal" />
+        <exclude domain="database" path="notes.db-shm" />
+        <exclude domain="database" path="notes.db-journal" />
+        <exclude domain="file" path="recordings/" />
     </cloud-backup>
     <device-transfer>
         <exclude domain="sharedpref" path="storyvox.secrets.xml" />
@@ -32,5 +41,14 @@
         <exclude domain="file" path="wallet/" />
         <!-- Issue #1515 — deadline reminders are on-device only (privacy.md §2.11). -->
         <exclude domain="file" path="deadline_reminders.json" />
+        <!-- Issue #1657 (Voice Notes) — notes DB + recordings are on-device
+             only (spec §3.7). notes.db is a SEPARATE Room DB so it's file-
+             excludable; recordings/ matches NotesRepository.RECORDINGS_SUBDIR
+             + Phase 2a's write path. -->
+        <exclude domain="database" path="notes.db" />
+        <exclude domain="database" path="notes.db-wal" />
+        <exclude domain="database" path="notes.db-shm" />
+        <exclude domain="database" path="notes.db-journal" />
+        <exclude domain="file" path="recordings/" />
     </device-transfer>
 </data-extraction-rules>

--- a/app/src/test/kotlin/in/jphe/storyvox/notes/BackupRulesExclusionTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/notes/BackupRulesExclusionTest.kt
@@ -1,0 +1,55 @@
+package `in`.jphe.storyvox.notes
+
+import java.io.File
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Voice Notes (#1657, Phase 1) — **the privacy gate.** Asserts the backup
+ * rules exclude the notes DB file AND the `recordings/` audio dir from BOTH
+ * `cloud-backup` and `device-transfer` (spec §3.7). A mismatched or missing
+ * exclude silently uploads plaintext notes + audio to Google's cloud — so
+ * this test must pass before any note data ships.
+ *
+ * Pure-JVM: reads the res XML by path and checks the exclude lines land in the
+ * right `<domain>` sections (no Android XML parser dependency).
+ */
+class BackupRulesExclusionTest {
+
+    private fun rulesFile(name: String): File =
+        listOf(File("src/main/res/xml/$name"), File("app/src/main/res/xml/$name"))
+            .firstOrNull { it.exists() }
+            ?: error("backup rules file '$name' not found (cwd=${File(".").absoluteFile})")
+
+    /** The substring of [xml] inside `<tag> … </tag>`. */
+    private fun section(xml: String, tag: String): String {
+        val start = xml.indexOf("<$tag>")
+        val end = xml.indexOf("</$tag>")
+        assertTrue("<$tag> section present", start >= 0 && end > start)
+        return xml.substring(start, end)
+    }
+
+    private fun assertNoteExcludes(section: String, where: String) {
+        assertTrue(
+            "$where must exclude the notes.db database file",
+            section.contains("domain=\"database\" path=\"notes.db"),
+        )
+        assertTrue(
+            "$where must exclude the recordings/ audio dir",
+            section.contains("domain=\"file\" path=\"recordings/"),
+        )
+    }
+
+    @Test
+    fun dataExtractionRules_excludeNotesAndRecordings_inBothDomains() {
+        val xml = rulesFile("data_extraction_rules.xml").readText()
+        assertNoteExcludes(section(xml, "cloud-backup"), "cloud-backup")
+        assertNoteExcludes(section(xml, "device-transfer"), "device-transfer")
+    }
+
+    @Test
+    fun legacyBackupRules_excludeNotesAndRecordings() {
+        val xml = rulesFile("backup_rules.xml").readText()
+        assertNoteExcludes(section(xml, "full-backup-content"), "full-backup-content")
+    }
+}

--- a/core-data/schemas/in.jphe.storyvox.data.notes.NotesDatabase/1.json
+++ b/core-data/schemas/in.jphe.storyvox.data.notes.NotesDatabase/1.json
@@ -1,0 +1,91 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 1,
+    "identityHash": "636820d65fa854578fe2cb09d9d8204f",
+    "entities": [
+      {
+        "tableName": "note",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `tags` TEXT NOT NULL, `audioPath` TEXT, `durationMs` INTEGER, `transcript` TEXT, `transcriptLang` TEXT, `summary` TEXT, `body` TEXT, `transcriptionStatus` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioPath",
+            "columnName": "audioPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "durationMs",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "transcript",
+            "columnName": "transcript",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "transcriptLang",
+            "columnName": "transcriptLang",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "summary",
+            "columnName": "summary",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "body",
+            "columnName": "body",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "transcriptionStatus",
+            "columnName": "transcriptionStatus",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '636820d65fa854578fe2cb09d9d8204f')"
+    ]
+  }
+}

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/di/DataModule.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/di/DataModule.kt
@@ -14,6 +14,11 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import `in`.jphe.storyvox.data.coroutines.ApplicationScope
 import `in`.jphe.storyvox.data.db.StoryvoxDatabase
+import `in`.jphe.storyvox.data.notes.NoteDao
+import `in`.jphe.storyvox.data.notes.NotesDatabase
+import `in`.jphe.storyvox.data.notes.NotesRepository
+import java.io.File
+import javax.inject.Named
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -138,6 +143,28 @@ object DataModule {
     @Provides fun teleprompterScriptDao(db: StoryvoxDatabase): TeleprompterScriptDao = db.teleprompterScriptDao()
     // Issue #1235 — read-only aggregate DAO for the listening-stats dashboard.
     @Provides fun listeningStatsDao(db: StoryvoxDatabase): ListeningStatsDao = db.listeningStatsDao()
+
+    // ── Voice Notes (#1657, Phase 1) — SEPARATE notes.db (backup-excludable) ──
+    @Provides
+    @Singleton
+    fun provideNotesDatabase(@ApplicationContext ctx: Context): NotesDatabase =
+        Room.databaseBuilder(ctx, NotesDatabase::class.java, NotesDatabase.NAME)
+            // #570 — same F2FS / One-UI journal-mode workaround as the main DB.
+            .setJournalMode(androidx.room.RoomDatabase.JournalMode.TRUNCATE)
+            // NB: deliberately NO fallbackToDestructiveMigrationOnDowngrade() —
+            // notes are irreplaceable (they don't rehydrate from a backend like
+            // the library does), so wiping on downgrade is unacceptable. At v1
+            // there are no migrations; decide the policy when the first lands.
+            .build()
+
+    @Provides fun noteDao(db: NotesDatabase): NoteDao = db.noteDao()
+
+    /** `filesDir/recordings` — Phase 2a's write path AND the backup-excluded dir. */
+    @Provides
+    @Singleton
+    @Named(NotesRepository.RECORDINGS_DIR_QUALIFIER)
+    fun provideNotesRecordingsDir(@ApplicationContext ctx: Context): File =
+        File(ctx.filesDir, NotesRepository.RECORDINGS_SUBDIR).apply { mkdirs() }
 
     /**
      * Long-lived [CoroutineScope] for singleton repositories that need to fire

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/notes/NoteDao.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/notes/NoteDao.kt
@@ -1,0 +1,51 @@
+package `in`.jphe.storyvox.data.notes
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Voice Notes (#1657, Phase 1) — CRUD + search for [NoteEntity]. Mirrors
+ * [TeleprompterScriptDao][`in`.jphe.storyvox.data.db.dao.TeleprompterScriptDao]:
+ * `@Insert(onConflict = REPLACE)` upsert (screens save a fully-formed row),
+ * `Flow` reads, and a `LIKE` substring search.
+ */
+@Dao
+interface NoteDao {
+
+    /** Insert a new note or replace an existing one with the same [NoteEntity.id]. */
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(note: NoteEntity)
+
+    /** All notes, most-recently-edited first — the list screen's default feed. */
+    @Query("SELECT * FROM note ORDER BY updatedAt DESC")
+    fun observeAll(): Flow<List<NoteEntity>>
+
+    @Query("SELECT * FROM note WHERE id = :id")
+    suspend fun get(id: String): NoteEntity?
+
+    /** One-shot snapshot of every row — used by the orphan-audio sweep. */
+    @Query("SELECT * FROM note")
+    suspend fun all(): List<NoteEntity>
+
+    @Query("DELETE FROM note WHERE id = :id")
+    suspend fun delete(id: String)
+
+    /**
+     * Substring search over title / body / transcript, newest-edited first.
+     * An empty [query] degenerates to `LIKE '%%'`, which matches every row via
+     * the non-null [NoteEntity.title] column — so the screen binds one flow for
+     * both filtered and unfiltered states. (`NULL LIKE …` is `NULL`, so a null
+     * body/transcript simply doesn't contribute a match — correct.)
+     */
+    @Query(
+        "SELECT * FROM note " +
+            "WHERE title LIKE '%' || :query || '%' " +
+            "OR body LIKE '%' || :query || '%' " +
+            "OR transcript LIKE '%' || :query || '%' " +
+            "ORDER BY updatedAt DESC",
+    )
+    fun search(query: String): Flow<List<NoteEntity>>
+}

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/notes/NoteEntity.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/notes/NoteEntity.kt
@@ -1,0 +1,60 @@
+package `in`.jphe.storyvox.data.notes
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * Voice Notes (epic #1657, Phase 1) — one note row. A single table serves
+ * BOTH a typed manual note and a recording-backed note via nullable fields.
+ *
+ * Mirrors the proven [TeleprompterScript][`in`.jphe.storyvox.data.db.entity.TeleprompterScript]
+ * (v18) idioms: client-generated UUID [id] PK, **no foreign keys**, and
+ * comma-separated [tags] with `LIKE` search (a junction table would be
+ * over-engineering for a lightweight, single-user, local-first feature).
+ *
+ * Lives in the **separate [NotesDatabase]** (`notes.db`) — never a
+ * `StoryvoxDatabase` table — so the whole file is cleanly backup-excludable
+ * (spec §3.4/§3.7: Android backup excludes per DB file, not per table).
+ */
+@Entity(tableName = "note")
+data class NoteEntity(
+    /** Client-generated UUID — stable identity for edit/delete + a future syncer. */
+    @PrimaryKey val id: String,
+    /** User-visible title (single line). May be blank for an untitled note. */
+    val title: String = "",
+    /** Wall-clock millis the note was created. */
+    val createdAt: Long,
+    /** Wall-clock millis of the last edit; drives `ORDER BY updatedAt DESC`. */
+    val updatedAt: Long,
+    /** Comma-separated freeform tags (empty = none). Same idiom as TeleprompterScript. */
+    val tags: String = "",
+    /**
+     * Absolute path to the recording (`filesDir/recordings/<id>.m4a`, written
+     * by Phase 2a), or null for a typed-only note. The backup rules exclude
+     * that directory (spec §3.7); [NotesRepository] deletes the file with the row.
+     */
+    val audioPath: String? = null,
+    /** Recording length in millis, or null for a typed-only note. */
+    val durationMs: Long? = null,
+    /**
+     * **Immutable** source-of-truth ASR output — re-transcribing replaces it
+     * wholesale. Distinct from [body] (the user's editable content).
+     */
+    val transcript: String? = null,
+    /** BCP-47-ish language of [transcript] (drives summary language), or null. */
+    val transcriptLang: String? = null,
+    /** Optional AI summary — only ever populated on explicit consent (Phase 3). */
+    val summary: String? = null,
+    /** **Editable** user body — typed/edited content, independent of [transcript]. */
+    val body: String? = null,
+    /** Transcription lifecycle. Persisted by name via [NotesConverters]. */
+    val transcriptionStatus: TranscriptionStatus = TranscriptionStatus.NONE,
+)
+
+/**
+ * Transcription lifecycle for a [NoteEntity]. `NONE` = a typed note with no
+ * audio; `PENDING` = recorded, awaiting the worker; `RUNNING`/`DONE`/`FAILED`
+ * track the WorkManager job (Phase 2b). Persisted by [TranscriptionStatus.name]
+ * (a stored TEXT column), so appending a future state needs no schema migration.
+ */
+enum class TranscriptionStatus { NONE, PENDING, RUNNING, FAILED, DONE }

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/notes/NotesDatabase.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/notes/NotesDatabase.kt
@@ -1,0 +1,49 @@
+package `in`.jphe.storyvox.data.notes
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import androidx.room.TypeConverter
+import androidx.room.TypeConverters
+
+/**
+ * Voice Notes (#1657, Phase 1) — a **separate** Room database (`notes.db`),
+ * deliberately NOT tables in `StoryvoxDatabase`. Rationale (spec §3.4/§3.7):
+ * Android backup excludes per **DB file**, not per table, so a dedicated file
+ * is the only way to keep note data off cloud-backup + device-transfer without
+ * also killing library/settings backup. It also keeps notes off
+ * `StoryvoxDatabase`'s migration ladder (no v20 bump).
+ *
+ * Ships at its own **v1** (fresh DB, no data migration). `exportSchema = true`
+ * → the `1.json` fixture is generated via the ubox0 KSP workflow (#1640) and
+ * committed, so the first migration (v1→v2) has a MigrationTest baseline.
+ *
+ * **Downgrade policy (deliberately deferred):** unlike `StoryvoxDatabase`,
+ * this does NOT `fallbackToDestructiveMigrationOnDowngrade()` — notes are
+ * irreplaceable user data (they don't rehydrate from a backend like the
+ * library does), so silently wiping them on an APK downgrade is unacceptable.
+ * At v1 there are no migrations, so the question is moot; when the first
+ * migration lands, choose an explicit downgrade policy then (see [DataModule]).
+ */
+@Database(entities = [NoteEntity::class], version = 1, exportSchema = true)
+@TypeConverters(NotesConverters::class)
+abstract class NotesDatabase : RoomDatabase() {
+    abstract fun noteDao(): NoteDao
+
+    companion object {
+        const val NAME: String = "notes.db"
+    }
+}
+
+/**
+ * Room type converters for [NotesDatabase]. [TranscriptionStatus] is stored by
+ * name (a TEXT column); an unknown stored value (e.g. a downgrade that predates
+ * a future state) decodes to [TranscriptionStatus.NONE] rather than crashing.
+ */
+internal class NotesConverters {
+    @TypeConverter
+    fun statusToName(status: TranscriptionStatus): String = status.name
+
+    @TypeConverter
+    fun nameToStatus(name: String): TranscriptionStatus =
+        runCatching { TranscriptionStatus.valueOf(name) }.getOrDefault(TranscriptionStatus.NONE)
+}

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/notes/NotesRepository.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/notes/NotesRepository.kt
@@ -1,0 +1,86 @@
+package `in`.jphe.storyvox.data.notes
+
+import java.io.File
+import javax.inject.Inject
+import javax.inject.Named
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Voice Notes (#1657, Phase 1) — the single seam feature code uses for note
+ * persistence. Wraps [NoteDao] with the two file-lifecycle guarantees the
+ * privacy/robustness contract (spec §3.4/§3.7, §4) requires:
+ *
+ *  - **Deleting a note deletes its audio file** — no dangling recordings left
+ *    on disk after a note is removed.
+ *  - **Orphan-audio sweep** — reclaims recordings with no referencing row
+ *    (e.g. a crash between writing the `.m4a` and inserting the row), so a
+ *    failed capture never silently leaks storage.
+ *
+ * [recordingsDir] is injected (not derived from a `Context`) so this class
+ * stays plain-JVM unit-testable with a temp dir + a fake DAO. Production binds
+ * it to `filesDir/`[RECORDINGS_SUBDIR] — the exact path Phase 2a writes to and
+ * the backup rules exclude.
+ */
+@Singleton
+class NotesRepository @Inject constructor(
+    private val dao: NoteDao,
+    @Named(RECORDINGS_DIR_QUALIFIER) private val recordingsDir: File,
+) {
+
+    fun observeAll(): Flow<List<NoteEntity>> = dao.observeAll()
+
+    fun search(query: String): Flow<List<NoteEntity>> = dao.search(query)
+
+    suspend fun get(id: String): NoteEntity? = dao.get(id)
+
+    suspend fun upsert(note: NoteEntity) = dao.upsert(note)
+
+    /**
+     * Delete a note AND its recording. No-op if the id is absent. The row is
+     * removed first, then the audio file — so a delete failure on the file
+     * never leaves a row pointing at a deleted-then-half-gone file; a stray
+     * file with no row is caught by [sweepOrphanAudio] on next launch.
+     */
+    suspend fun delete(id: String) {
+        val note = dao.get(id) ?: return
+        dao.delete(id)
+        note.audioPath?.let { path ->
+            runCatching { File(path).takeIf(File::exists)?.delete() }
+        }
+    }
+
+    /**
+     * Delete every file in [recordingsDir] that no note row references (matched
+     * by file name, since audio is always `recordingsDir/<id>.m4a`). Returns the
+     * number of files reclaimed. Safe to call on startup; a no-audio install is
+     * a no-op (empty/absent dir → 0).
+     */
+    suspend fun sweepOrphanAudio(): Int {
+        val referenced = dao.all()
+            .mapNotNull { it.audioPath }
+            .map { File(it).name }
+            .toSet()
+        val files = recordingsDir.listFiles()?.filter { it.isFile } ?: return 0
+        var reclaimed = 0
+        for (file in files) {
+            if (file.name !in referenced && runCatching { file.delete() }.getOrDefault(false)) {
+                reclaimed++
+            }
+        }
+        return reclaimed
+    }
+
+    companion object {
+        /**
+         * Subdirectory under `filesDir` holding recordings. **Load-bearing:**
+         * this exact name must match Phase 2a's write path AND the
+         * `<exclude domain="file" path="recordings/">` backup rule — a mismatch
+         * silently un-protects the audio (spec §3.7).
+         */
+        const val RECORDINGS_SUBDIR: String = "recordings"
+
+        /** Hilt qualifier for the injected [recordingsDir] `File`. */
+        const val RECORDINGS_DIR_QUALIFIER: String = "notesRecordingsDir"
+    }
+}

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/notes/NoteDaoTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/notes/NoteDaoTest.kt
@@ -1,0 +1,122 @@
+package `in`.jphe.storyvox.data.notes
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Voice Notes (#1657, Phase 1) — in-memory Room exercise of [NoteDao] against
+ * the separate [NotesDatabase]. Mirrors `AnnotationDaoTest`'s posture.
+ * Covers: upsert/get roundtrip incl. the [TranscriptionStatus] enum converter,
+ * REPLACE-on-id, `observeAll` ordering, delete, `LIKE` search across
+ * title/body/transcript (+ empty-query-matches-all), and nullable-field roundtrip.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class NoteDaoTest {
+
+    private lateinit var db: NotesDatabase
+    private lateinit var dao: NoteDao
+
+    private fun note(
+        id: String,
+        title: String = "",
+        body: String? = null,
+        transcript: String? = null,
+        tags: String = "",
+        status: TranscriptionStatus = TranscriptionStatus.NONE,
+        audioPath: String? = null,
+        at: Long = 1000L,
+    ) = NoteEntity(
+        id = id, title = title, createdAt = at, updatedAt = at, tags = tags,
+        audioPath = audioPath, transcript = transcript, body = body, transcriptionStatus = status,
+    )
+
+    @Before
+    fun setUp() {
+        val ctx = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(ctx, NotesDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        dao = db.noteDao()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun upsert_thenGet_roundTripsIncludingEnum() = runTest {
+        dao.upsert(note("n1", title = "Groceries", body = "milk", status = TranscriptionStatus.DONE))
+
+        val got = dao.get("n1")!!
+        assertEquals("Groceries", got.title)
+        assertEquals("milk", got.body)
+        assertEquals(TranscriptionStatus.DONE, got.transcriptionStatus)
+    }
+
+    @Test
+    fun upsertSameId_replacesInPlace() = runTest {
+        dao.upsert(note("n1", title = "draft", at = 1000L))
+        dao.upsert(note("n1", title = "final", at = 2000L))
+
+        assertEquals("exactly one row", 1, dao.all().size)
+        assertEquals("final", dao.get("n1")!!.title)
+    }
+
+    @Test
+    fun observeAll_ordersByUpdatedAtDesc() = runTest {
+        dao.upsert(note("old", at = 1000L))
+        dao.upsert(note("new", at = 3000L))
+        dao.upsert(note("mid", at = 2000L))
+
+        assertEquals(listOf("new", "mid", "old"), dao.observeAll().first().map { it.id })
+    }
+
+    @Test
+    fun delete_removesOnlyThatRow() = runTest {
+        dao.upsert(note("a"))
+        dao.upsert(note("b"))
+
+        dao.delete("a")
+
+        assertEquals(listOf("b"), dao.all().map { it.id })
+    }
+
+    @Test
+    fun search_matchesTitleBodyTranscript_andEmptyMatchesAll() = runTest {
+        dao.upsert(note("t", title = "Standup meeting", at = 3000L))
+        dao.upsert(note("b", body = "buy oat milk", at = 2000L))
+        dao.upsert(note("x", transcript = "the quarterly numbers", at = 1000L))
+
+        assertEquals(listOf("t"), dao.search("meeting").first().map { it.id })
+        assertEquals(listOf("b"), dao.search("milk").first().map { it.id })
+        assertEquals(listOf("x"), dao.search("quarterly").first().map { it.id })
+        // Empty query degenerates to match-all, newest-first.
+        assertEquals(listOf("t", "b", "x"), dao.search("").first().map { it.id })
+    }
+
+    @Test
+    fun nullableFields_roundTrip() = runTest {
+        dao.upsert(note("n1")) // audio/body/transcript/summary/duration all null
+
+        val got = dao.get("n1")!!
+        assertNull(got.audioPath)
+        assertNull(got.durationMs)
+        assertNull(got.transcript)
+        assertNull(got.summary)
+        assertNull(got.body)
+        assertEquals(TranscriptionStatus.NONE, got.transcriptionStatus)
+    }
+}

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/notes/NotesRepositoryTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/notes/NotesRepositoryTest.kt
@@ -1,0 +1,114 @@
+package `in`.jphe.storyvox.data.notes
+
+import java.io.File
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Voice Notes (#1657, Phase 1) — the two file-lifecycle guarantees, tested
+ * plain-JVM with a fake [NoteDao] + a real temp `recordings/` dir (no Room,
+ * no Robolectric): **delete-note-deletes-audio** and the **orphan-audio sweep**.
+ */
+class NotesRepositoryTest {
+
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private fun repo(dao: NoteDao, dir: File) = NotesRepository(dao, dir)
+
+    private fun note(id: String, audioPath: String? = null, title: String = "") =
+        NoteEntity(id = id, title = title, createdAt = 0L, updatedAt = 0L, audioPath = audioPath)
+
+    @Test
+    fun delete_removesRowAndAudioFile() = runTest {
+        val dir = tmp.newFolder("recordings")
+        val audio = File(dir, "n1.m4a").apply { writeBytes(byteArrayOf(1, 2, 3)) }
+        val dao = FakeNoteDao()
+        dao.upsert(note("n1", audioPath = audio.absolutePath))
+
+        repo(dao, dir).delete("n1")
+
+        assertNull("row gone", dao.get("n1"))
+        assertFalse("audio file deleted with the row", audio.exists())
+    }
+
+    @Test
+    fun delete_absentId_isNoOp() = runTest {
+        val dir = tmp.newFolder("recordings")
+        repo(FakeNoteDao(), dir).delete("nope") // must not throw
+    }
+
+    @Test
+    fun delete_typedNoteWithNoAudio_isFine() = runTest {
+        val dir = tmp.newFolder("recordings")
+        val dao = FakeNoteDao()
+        dao.upsert(note("n1", audioPath = null))
+
+        repo(dao, dir).delete("n1")
+
+        assertNull(dao.get("n1"))
+    }
+
+    @Test
+    fun sweepOrphanAudio_deletesUnreferenced_keepsReferenced() = runTest {
+        val dir = tmp.newFolder("recordings")
+        val referenced = File(dir, "keep.m4a").apply { writeBytes(byteArrayOf(1)) }
+        val orphan = File(dir, "orphan.m4a").apply { writeBytes(byteArrayOf(2)) }
+        val dao = FakeNoteDao()
+        dao.upsert(note("keep", audioPath = referenced.absolutePath))
+
+        val reclaimed = repo(dao, dir).sweepOrphanAudio()
+
+        assertEquals(1, reclaimed)
+        assertTrue("referenced file kept", referenced.exists())
+        assertFalse("orphan file swept", orphan.exists())
+    }
+
+    @Test
+    fun sweepOrphanAudio_emptyDir_isZero() = runTest {
+        val dir = tmp.newFolder("recordings")
+        assertEquals(0, repo(FakeNoteDao(), dir).sweepOrphanAudio())
+    }
+
+    @Test
+    fun search_delegatesToDao() = runTest {
+        val dir = tmp.newFolder("recordings")
+        val dao = FakeNoteDao()
+        dao.upsert(note("n1", title = "hello world"))
+
+        assertEquals(listOf("n1"), repo(dao, dir).search("hello").first().map { it.id })
+    }
+
+    /**
+     * Plain-JVM fake — in-memory list; `search` does a case-sensitive substring
+     * over title/body/transcript, newest-first (mirrors the DAO's `LIKE` shape).
+     */
+    private class FakeNoteDao : NoteDao {
+        private val rows = MutableStateFlow<List<NoteEntity>>(emptyList())
+        override suspend fun upsert(note: NoteEntity) {
+            rows.value = rows.value.filterNot { it.id == note.id } + note
+        }
+        override fun observeAll(): Flow<List<NoteEntity>> = rows
+        override suspend fun get(id: String): NoteEntity? = rows.value.find { it.id == id }
+        override suspend fun all(): List<NoteEntity> = rows.value
+        override suspend fun delete(id: String) {
+            rows.value = rows.value.filterNot { it.id == id }
+        }
+        override fun search(query: String): Flow<List<NoteEntity>> = MutableStateFlow(
+            rows.value.filter {
+                it.title.contains(query) ||
+                    (it.body?.contains(query) ?: false) ||
+                    (it.transcript?.contains(query) ?: false)
+            }.sortedByDescending { it.updatedAt },
+        )
+    }
+}


### PR DESCRIPTION
## Voice Notes epic #1657 — **Phase 1: storage & privacy foundation** (blocks all)

Builds the Phase 1 contract from `docs/superpowers/plans/2026-07-06-voice-notes.md` (spec §3.4/§3.7). Storage-only foundation; Phases 2a/2b (record ∥ transcribe) fan out once this merges.

### What
- **Separate `NotesDatabase`** (`notes.db`, own **v1**, `exportSchema=true`) — deliberately NOT a `StoryvoxDatabase` bump. Android backup excludes per **DB file**, not per table (§3.7), so a dedicated file is the only way to keep notes off backup without killing library/settings backup; it also stays off the main DB's migration ladder.
- **`NoteEntity`** mirrors `TeleprompterScript` (v18): UUID PK, no FK, comma-sep `tags`. One table serves typed notes + recordings via nullable fields: `audioPath`/`durationMs`, `transcript` (immutable), `transcriptLang`, `summary`, `body` (editable), and a `TranscriptionStatus` enum (stored by name via `NotesConverters`, safe-decode to `NONE`).
- **`NoteDao`** — `upsert(REPLACE)`, `Flow` `observeAll`/`search` (`LIKE` over title/body/transcript, empty = match-all), `get`/`all`/`delete`.
- **`NotesRepository`** — CRUD + search; **deleting a note deletes its audio file**; **startup orphan-audio sweep** (files with no row). `recordingsDir` is injected (not derived from `Context`) so it's plain-JVM testable; `RECORDINGS_SUBDIR` is the single source of the audio path shared with Phase 2a **and** the backup rule.
- **DI** — `@Provides NotesDatabase` / `noteDao` / `@Named` recordings dir in `DataModule`.

### Privacy gate (§3.7) — the core promise
Excludes **`notes.db`** (+ `-wal`/`-shm`/`-journal`) **and** `recordings/` in **both** `cloud-backup` and `device-transfer` (`data_extraction_rules.xml`) **and** `full-backup-content` (`backup_rules.xml`) — the #951/#1514 pattern. Without this, plaintext notes + audio would auto-upload to Google backup by default.

### Tests (TDD)
- `NoteDaoTest` — in-memory Room (Robolectric): CRUD, REPLACE, `observeAll` ordering, search across title/body/transcript + empty-matches-all, enum + nullable roundtrip.
- `NotesRepositoryTest` — plain-JVM (fake DAO + temp dir): delete-deletes-audio, orphan sweep keeps-referenced/deletes-orphan, no-op on absent id.
- `BackupRulesExclusionTest` — **the privacy gate**: asserts `notes.db` + `recordings/` excluded in both domains + full-backup-content.

### Verification
Pre-flighted on the ubox0 build host at this tip: **`:app:assembleDebug` (Build APK gate) + `:core-data`/`:app` `compileDebugUnitTestKotlin` (Test Compile gate) both green**, and that run generated the committed `notes.db` `1.json` (byte-exact, identityHash `636820d6…`, table `note`). `git merge-tree` clean on current main.

Refs #1657

🤖 Generated with [Claude Code](https://claude.com/claude-code)