### PR TITLE
feat(notes): Voice Notes UI — list / record / detail + Notes dock tab (Phase 4)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -156,6 +156,18 @@ object StoryvoxRoutes {
      *  slashes) but we encode it for parity with [reader]/[fictionDetail]. */
     fun scriptEdit(scriptId: String) = "scripts/${Uri.encode(scriptId)}"
 
+    /** Voice Notes (epic #1657) — the notes list is a first-class bottom-nav
+     *  destination; [NOTES_RECORD] captures a new recording and [NOTES_DETAIL]
+     *  is the per-note detail / editor (also the typed "New note" target). */
+    const val NOTES = "notes"
+    const val NOTES_RECORD = "notes/record"
+    const val NOTES_DETAIL = "notes/detail/{noteId}"
+
+    /** Build the detail route for [noteId] (a client UUID; encoded for parity
+     *  with [scriptEdit]/[reader]). The arg name matches
+     *  `NoteDetailViewModel.NOTE_ID_ARG`. */
+    fun noteDetail(noteId: String) = "notes/detail/${Uri.encode(noteId)}"
+
     const val SETTINGS = "settings"
     const val SETTINGS_PRONUNCIATION = "settings/pronunciation"
     const val VOICE_LIBRARY = "settings/voices"
@@ -357,7 +369,7 @@ object StoryvoxRoutes {
      * too. The bar's *selected* mapping (below) collapses any of these
      * to the LIBRARY pill since that's the umbrella destination now.
      */
-    private val HOME_ROUTES = setOf(PLAYING, LIBRARY, FOLLOWS, BROWSE, VOICE_LIBRARY, SETTINGS_HUB, SETTINGS)
+    private val HOME_ROUTES = setOf(PLAYING, LIBRARY, FOLLOWS, BROWSE, VOICE_LIBRARY, NOTES, SETTINGS_HUB, SETTINGS)
     /** Strip any nav query-arg suffix before checking — PR #475 (magic-link)
      *  registered LIBRARY as `library?sharedUrl={sharedUrl}`, so
      *  `currentBackStackEntryAsState()` reports `destination.route` with the
@@ -574,6 +586,7 @@ private fun StoryvoxNavHostContent(
         StoryvoxRoutes.SETTINGS_HUB,
         StoryvoxRoutes.SETTINGS -> HomeTab.Settings
         StoryvoxRoutes.VOICE_LIBRARY -> HomeTab.Voices
+        StoryvoxRoutes.NOTES -> HomeTab.Notes
         StoryvoxRoutes.PLAYING -> HomeTab.Playing
         StoryvoxRoutes.BROWSE -> HomeTab.Browse
         // Library + Follows + Inbox + History sub-tabs and
@@ -598,6 +611,7 @@ private fun StoryvoxNavHostContent(
             HomeTab.Playing -> StoryvoxRoutes.PLAYING
             HomeTab.Browse -> StoryvoxRoutes.BROWSE
             HomeTab.Voices -> StoryvoxRoutes.VOICE_LIBRARY
+            HomeTab.Notes -> StoryvoxRoutes.NOTES
             HomeTab.Settings -> StoryvoxRoutes.SETTINGS_HUB
         }
         // Issue #918 — strip query-parameter suffixes before comparing.
@@ -1344,6 +1358,58 @@ private fun StoryvoxNavHostContent(
                     onOpenTeleprompter = {
                         navController.navigate(StoryvoxRoutes.PLAYING) { launchSingleTop = true }
                     },
+                )
+            }
+
+            // Voice Notes (epic #1657, Phase 4) — the list is a home-tab surface
+            // (cross-fade + shares the dock); record + detail are drill-downs
+            // (push motion, full-screen). Detail doubles as the typed "New note"
+            // editor (a fresh UUID) and the recording flow's landing screen.
+            composable(
+                StoryvoxRoutes.NOTES,
+                enterTransition = homeEnter,
+                exitTransition = homeExit,
+                popEnterTransition = homeEnter,
+                popExitTransition = homeExit,
+            ) {
+                `in`.jphe.storyvox.feature.notes.ui.NotesListScreen(
+                    onOpenNote = { id -> navController.navigate(StoryvoxRoutes.noteDetail(id)) },
+                    onNewNote = {
+                        navController.navigate(
+                            StoryvoxRoutes.noteDetail(java.util.UUID.randomUUID().toString()),
+                        )
+                    },
+                    onRecord = { navController.navigate(StoryvoxRoutes.NOTES_RECORD) },
+                )
+            }
+            composable(
+                StoryvoxRoutes.NOTES_RECORD,
+                enterTransition = pushEnter,
+                exitTransition = pushExit,
+                popEnterTransition = popEnter,
+                popExitTransition = popExit,
+            ) {
+                `in`.jphe.storyvox.feature.notes.ui.RecordScreen(
+                    // Land on the new note's detail, dropping the record screen
+                    // from the back stack so Back returns to the list, not here.
+                    onRecordingSaved = { id ->
+                        navController.navigate(StoryvoxRoutes.noteDetail(id)) {
+                            popUpTo(StoryvoxRoutes.NOTES_RECORD) { inclusive = true }
+                        }
+                    },
+                    onExit = { navController.popBackStack() },
+                )
+            }
+            composable(
+                route = StoryvoxRoutes.NOTES_DETAIL,
+                arguments = listOf(navArgument("noteId") { type = NavType.StringType }),
+                enterTransition = pushEnter,
+                exitTransition = pushExit,
+                popEnterTransition = popEnter,
+                popExitTransition = popExit,
+            ) {
+                `in`.jphe.storyvox.feature.notes.ui.NoteDetailScreen(
+                    onExit = { navController.popBackStack() },
                 )
             }
 

--- a/app/src/test/kotlin/in/jphe/storyvox/navigation/NavStructureTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/navigation/NavStructureTest.kt
@@ -34,30 +34,28 @@ import org.junit.Test
 class NavStructureTest {
 
     @Test
-    fun `bottom nav exposes exactly five primary destinations`() {
-        // v0.5.72 — Playing + Library + Browse + Voices + Settings.
-        // Browse was promoted from Library sub-tab to a first-class
-        // dock pill. Going past five needs a UX review — the sliding
-        // indicator pill in BottomTabBar is centered per-cell and six
-        // cells starts crowding label rendering on the Flip3's
-        // compact cover width.
-        assertEquals(5, HomeTab.entries.size)
+    fun `bottom nav exposes exactly six primary destinations`() {
+        // v0.5.72 — Playing + Library + Browse + Voices + Settings (5).
+        // Voice Notes (epic #1657) adds Notes as a sixth first-class dock
+        // pill. This deliberately crosses the "past five needs a UX
+        // review" threshold the prior revision flagged: six cells narrow
+        // each cell (notably on the Flip3's ~260 dp cover), so label
+        // rendering must be eyeballed there. Notes was a locked product
+        // decision (a first-class "Notes" destination), so the sixth pill
+        // is intentional — this assertion is the conscious record of it.
+        assertEquals(6, HomeTab.entries.size)
     }
 
     @Test
-    fun `bottom nav primary destinations are Playing Library Browse Voices Settings`() {
+    fun `bottom nav primary destinations are Playing Library Browse Voices Notes Settings`() {
         // Order matters — BottomTabBar uses ordinal to position the
-        // indicator pill. v0.5.72 final order: Playing leads
-        // (most-touched during a listening session); Library second
-        // (cold-launch landing — NavHost startDestination is
-        // independent of dock ordinal but adjacency matters for the
-        // "I just opened the app" glance); Browse third (discovery
-        // sits between "your shelves" and "playback ops"); Voices
-        // fourth; Settings always last. Library + Browse adjacency is
-        // intentional — finishing a book and discovering the next is
-        // one swipe.
+        // indicator pill. Playing leads (most-touched during a listening
+        // session); Library second (cold-launch landing); Browse third
+        // (discovery between "your shelves" and "playback ops"); Voices
+        // fourth; Notes fifth (Voice Notes, epic #1657 — grouped next to
+        // the voice-forward Voices pill); Settings always last.
         val labels = HomeTab.entries.map { it.label }
-        assertEquals(listOf("Playing", "Library", "Browse", "Voices", "Settings"), labels)
+        assertEquals(listOf("Playing", "Library", "Browse", "Voices", "Notes", "Settings"), labels)
         assertEquals(HomeTab.Playing, HomeTab.entries.first())
         assertEquals(HomeTab.Settings, HomeTab.entries.last())
     }

--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/BottomTabBar.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/BottomTabBar.kt
@@ -22,11 +22,13 @@ import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AutoStories
 import androidx.compose.material.icons.filled.Explore
+import androidx.compose.material.icons.filled.GraphicEq
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.RecordVoiceOver
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.outlined.AutoStories
 import androidx.compose.material.icons.outlined.Explore
+import androidx.compose.material.icons.outlined.GraphicEq
 import androidx.compose.material.icons.outlined.PlayArrow
 import androidx.compose.material.icons.outlined.RecordVoiceOver
 import androidx.compose.material.icons.outlined.Settings
@@ -86,7 +88,8 @@ import androidx.compose.ui.unit.dp
  * other dock metaphors (Playing = transport, Library = your shelves,
  * Voices = TTS, Settings = gear).
  *
- * Five tabs now in the dock: `{Playing, Library, Browse, Voices, Settings}`.
+ * Six tabs now in the dock: `{Playing, Library, Browse, Voices, Notes, Settings}`
+ * — Notes added for Voice Notes (epic #1657); Settings stays last.
  */
 // Order matters — entries' ordinal positions the sliding indicator
 // pill left-to-right in the bar. v0.5.72 final order: Playing leads
@@ -103,6 +106,9 @@ enum class HomeTab(val label: String, val filled: ImageVector, val outlined: Ima
     Library("Library", Icons.Filled.AutoStories, Icons.Outlined.AutoStories),
     Browse("Browse", Icons.Filled.Explore, Icons.Outlined.Explore),
     Voices("Voices", Icons.Filled.RecordVoiceOver, Icons.Outlined.RecordVoiceOver),
+    // Voice Notes (epic #1657) — a waveform glyph, distinct from Voices'
+    // RecordVoiceOver head. Positioned before Settings (dock invariant: gear last).
+    Notes("Notes", Icons.Filled.GraphicEq, Icons.Outlined.GraphicEq),
     Settings("Settings", Icons.Filled.Settings, Icons.Outlined.Settings),
 }
 

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/notes/ui/NoteDetailScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/notes/ui/NoteDetailScreen.kt
@@ -1,0 +1,459 @@
+package `in`.jphe.storyvox.feature.notes.ui
+
+import android.content.Intent
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.outlined.AutoAwesome
+import androidx.compose.material.icons.outlined.Close
+import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material.icons.outlined.MoreVert
+import androidx.compose.material.icons.outlined.Share
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalIconButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.InputChip
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import `in`.jphe.storyvox.data.notes.TranscriptionStatus
+import `in`.jphe.storyvox.ui.theme.LibraryNocturneTheme
+import `in`.jphe.storyvox.ui.theme.LocalSpacing
+
+/**
+ * Voice Notes (epic #1657, Phase 4) — the note detail / editor. Serves a typed
+ * note, a recording-backed note, or both:
+ *  - audio player (stubbed — Phase 2a wires real playback + tap-segment→seek),
+ *  - **read-only** transcript (the immutable ASR source of truth),
+ *  - summary + a **Summarize** action (stubbed — Phase 3 wires the consented LLM),
+ *  - **editable** body, tags, and delete / export.
+ *
+ * @param onExit pop back to the list (after Back or a delete).
+ */
+@Composable
+fun NoteDetailScreen(
+    onExit: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: NoteDetailViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(Unit) {
+        viewModel.events.collect { event ->
+            when (event) {
+                NoteDetailEvent.Saved -> snackbarHostState.showSnackbar("Saved")
+                NoteDetailEvent.Deleted -> onExit()
+                NoteDetailEvent.SummarizeUnavailable ->
+                    snackbarHostState.showSnackbar("Summaries arrive in a later update.")
+                is NoteDetailEvent.Share -> {
+                    val send = Intent(Intent.ACTION_SEND).apply {
+                        type = "text/plain"
+                        putExtra(Intent.EXTRA_TEXT, event.text)
+                    }
+                    context.startActivity(Intent.createChooser(send, "Share note"))
+                }
+            }
+        }
+    }
+
+    NoteDetailContent(
+        state = state,
+        snackbarHostState = snackbarHostState,
+        onBack = onExit,
+        onTitleChange = viewModel::onTitleChange,
+        onBodyChange = viewModel::onBodyChange,
+        onTagsChange = viewModel::onTagsChange,
+        onSave = viewModel::save,
+        onDelete = viewModel::delete,
+        onExport = viewModel::export,
+        onSummarize = viewModel::summarize,
+        modifier = modifier,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+internal fun NoteDetailContent(
+    state: NoteDetailUiState,
+    snackbarHostState: SnackbarHostState,
+    onBack: () -> Unit,
+    onTitleChange: (String) -> Unit,
+    onBodyChange: (String) -> Unit,
+    onTagsChange: (String) -> Unit,
+    onSave: () -> Unit,
+    onDelete: () -> Unit,
+    onExport: () -> Unit,
+    onSummarize: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val spacing = LocalSpacing.current
+    var menuOpen by remember { mutableStateOf(false) }
+    var confirmDelete by remember { mutableStateOf(false) }
+    val hasRecording = state.audioPath != null || state.durationMs != null
+
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        topBar = {
+            TopAppBar(
+                title = { Text(if (state.isNewDraft) "New note" else "Note") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    IconButton(onClick = onSave, enabled = state.isDirty) {
+                        Icon(Icons.Filled.Check, contentDescription = "Save")
+                    }
+                    IconButton(onClick = { menuOpen = true }) {
+                        Icon(Icons.Outlined.MoreVert, contentDescription = "More options")
+                    }
+                    DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
+                        DropdownMenuItem(
+                            text = { Text("Share") },
+                            leadingIcon = { Icon(Icons.Outlined.Share, contentDescription = null) },
+                            onClick = {
+                                menuOpen = false
+                                onExport()
+                            },
+                        )
+                        DropdownMenuItem(
+                            text = { Text("Delete") },
+                            leadingIcon = { Icon(Icons.Outlined.Delete, contentDescription = null) },
+                            onClick = {
+                                menuOpen = false
+                                confirmDelete = true
+                            },
+                        )
+                    }
+                },
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = spacing.md, vertical = spacing.xs),
+            verticalArrangement = Arrangement.spacedBy(spacing.sm),
+        ) {
+            OutlinedTextField(
+                value = state.title,
+                onValueChange = onTitleChange,
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+                label = { Text("Title") },
+            )
+
+            if (hasRecording) {
+                AudioPlayerCard(durationMs = state.durationMs, playable = state.audioPath != null)
+            }
+
+            TranscriptSection(
+                transcript = state.transcript,
+                status = state.transcriptionStatus,
+            )
+
+            SummarySection(
+                summary = state.summary,
+                hasTranscript = state.transcript != null,
+                onSummarize = onSummarize,
+            )
+
+            OutlinedTextField(
+                value = state.body,
+                onValueChange = onBodyChange,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(min = 160.dp),
+                label = { Text("Notes") },
+                placeholder = { Text("Write or edit your note…") },
+            )
+
+            OutlinedTextField(
+                value = state.tags,
+                onValueChange = onTagsChange,
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+                label = { Text("Tags (comma-separated)") },
+            )
+
+            val tagList = remember(state.tags) {
+                state.tags.split(',').map { it.trim() }.filter { it.isNotEmpty() }
+            }
+            if (tagList.isNotEmpty()) {
+                FlowRow(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(spacing.xs),
+                ) {
+                    tagList.forEach { tag ->
+                        InputChip(
+                            selected = false,
+                            onClick = {
+                                onTagsChange(
+                                    normalizeNoteTags(tagList.filterNot { it == tag }.joinToString(", ")),
+                                )
+                            },
+                            label = { Text(tag, maxLines = 1, overflow = TextOverflow.Ellipsis) },
+                            trailingIcon = { Icon(Icons.Outlined.Close, contentDescription = "Remove tag") },
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    if (confirmDelete) {
+        androidx.compose.material3.AlertDialog(
+            onDismissRequest = { confirmDelete = false },
+            icon = { Icon(Icons.Outlined.Delete, contentDescription = null) },
+            title = { Text("Delete note?") },
+            text = {
+                Text(
+                    if (hasRecording) {
+                        "This permanently deletes the note and its recording. This can't be undone."
+                    } else {
+                        "This permanently deletes the note. This can't be undone."
+                    },
+                )
+            },
+            confirmButton = {
+                androidx.compose.material3.TextButton(
+                    onClick = {
+                        confirmDelete = false
+                        onDelete()
+                    },
+                ) { Text("Delete") }
+            },
+            dismissButton = {
+                androidx.compose.material3.TextButton(onClick = { confirmDelete = false }) { Text("Cancel") }
+            },
+        )
+    }
+}
+
+/**
+ * Audio player for a recording-backed note. **Phase-4 stub:** the transport is
+ * disabled until [playable] (a real `audioPath`) exists. Phase 2a wires actual
+ * playback (play/scrub) and Phase 2b adds tap-segment→seek from the transcript.
+ */
+@Composable
+private fun AudioPlayerCard(durationMs: Long?, playable: Boolean) {
+    val spacing = LocalSpacing.current
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        shape = MaterialTheme.shapes.large,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Row(
+            modifier = Modifier.padding(spacing.md),
+            horizontalArrangement = Arrangement.spacedBy(spacing.md),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            FilledTonalIconButton(
+                // TODO(#1657 P2a): wire to a MediaPlayer over the note's audioPath.
+                onClick = {},
+                enabled = playable,
+                modifier = Modifier.size(48.dp),
+            ) {
+                Icon(Icons.Filled.PlayArrow, contentDescription = "Play recording")
+            }
+            Column(modifier = Modifier.fillMaxWidth()) {
+                LinearProgressIndicator(
+                    progress = { 0f },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Text(
+                    text = if (playable) {
+                        "0:00 / ${durationMs?.let(::formatNoteDuration) ?: "0:00"}"
+                    } else {
+                        "Recording ${durationMs?.let(::formatNoteDuration) ?: ""} · playback arrives soon"
+                    },
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = spacing.xxs),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun TranscriptSection(transcript: String?, status: TranscriptionStatus) {
+    val spacing = LocalSpacing.current
+    when {
+        transcript != null -> {
+            SectionLabel("Transcript")
+            SelectionContainer {
+                Text(
+                    text = transcript,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.padding(top = spacing.xxs),
+                )
+            }
+        }
+        status == TranscriptionStatus.PENDING || status == TranscriptionStatus.RUNNING -> {
+            SectionLabel("Transcript")
+            Text(
+                text = if (status == TranscriptionStatus.RUNNING) "Transcribing…" else "Transcription pending.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        status == TranscriptionStatus.FAILED -> {
+            SectionLabel("Transcript")
+            Text(
+                text = "Transcription failed.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.error,
+            )
+        }
+        // NONE / DONE-without-text → no transcript section.
+    }
+}
+
+@Composable
+private fun SummarySection(summary: String?, hasTranscript: Boolean, onSummarize: () -> Unit) {
+    val spacing = LocalSpacing.current
+    when {
+        summary != null -> {
+            SectionLabel("Summary")
+            SelectionContainer {
+                Text(
+                    text = summary,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.padding(top = spacing.xxs),
+                )
+            }
+        }
+        hasTranscript -> {
+            // Transcript present, no summary yet → offer Summarize (stubbed → Phase 3).
+            OutlinedButton(onClick = onSummarize) {
+                Icon(
+                    Icons.Outlined.AutoAwesome,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp),
+                )
+                Text(
+                    "Summarize",
+                    modifier = Modifier.padding(start = spacing.xs),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SectionLabel(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelLarge,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = Modifier.semantics { heading() },
+    )
+}
+
+// ── Previews ──────────────────────────────────────────────────────────────
+
+@Preview(name = "Note detail · recording", showBackground = true)
+@Preview(name = "Note detail · recording dark", uiMode = Configuration.UI_MODE_NIGHT_YES, showBackground = true)
+@Composable
+private fun NoteDetailRecordingPreview() {
+    LibraryNocturneTheme {
+        NoteDetailContent(
+            state = NoteDetailUiState(
+                id = "1",
+                title = "Standup ideas",
+                body = "Follow up on the migration plan.",
+                tags = "work, standup",
+                transcript = "Sync on the release, then talk through the migration plan and the on-device tests.",
+                durationMs = 92_000,
+                audioPath = "/x/1.m4a",
+                transcriptionStatus = TranscriptionStatus.DONE,
+                isNewDraft = false,
+                isDirty = true,
+            ),
+            snackbarHostState = remember { SnackbarHostState() },
+            onBack = {},
+            onTitleChange = {},
+            onBodyChange = {},
+            onTagsChange = {},
+            onSave = {},
+            onDelete = {},
+            onExport = {},
+            onSummarize = {},
+        )
+    }
+}
+
+@Preview(name = "Note detail · typed", showBackground = true)
+@Composable
+private fun NoteDetailTypedPreview() {
+    LibraryNocturneTheme {
+        NoteDetailContent(
+            state = NoteDetailUiState(
+                id = "2",
+                title = "Grocery list",
+                body = "Oat milk, coffee, lemons, sourdough.",
+                isNewDraft = false,
+                isDirty = false,
+            ),
+            snackbarHostState = remember { SnackbarHostState() },
+            onBack = {},
+            onTitleChange = {},
+            onBodyChange = {},
+            onTagsChange = {},
+            onSave = {},
+            onDelete = {},
+            onExport = {},
+            onSummarize = {},
+        )
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/notes/ui/NotesListScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/notes/ui/NotesListScreen.kt
@@ -1,0 +1,450 @@
+package `in`.jphe.storyvox.feature.notes.ui
+
+import android.content.res.Configuration
+import android.text.format.DateUtils
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Mic
+import androidx.compose.material.icons.outlined.Close
+import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material.icons.outlined.Description
+import androidx.compose.material.icons.outlined.Edit
+import androidx.compose.material.icons.outlined.Mic
+import androidx.compose.material.icons.outlined.OpenInNew
+import androidx.compose.material.icons.outlined.Search
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExtendedFloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import `in`.jphe.storyvox.data.notes.NoteEntity
+import `in`.jphe.storyvox.data.notes.TranscriptionStatus
+import `in`.jphe.storyvox.ui.theme.LibraryNocturneTheme
+import `in`.jphe.storyvox.ui.theme.LocalSpacing
+
+/**
+ * Voice Notes (epic #1657, Phase 4) — the notes list. A search bar, a feed of
+ * note cards (recording/typed glyph · title · snippet · date · duration ·
+ * transcription-status chip), a long-press menu (Open / Delete), a primary
+ * **Record** FAB, and a top-bar **New note** (typed) action.
+ *
+ * @param onOpenNote open a note's detail by id (also the "New note" target with
+ *   a freshly-minted UUID — the detail seeds a blank draft the first save inserts).
+ * @param onRecord open the [RecordScreen].
+ */
+@Composable
+fun NotesListScreen(
+    onOpenNote: (String) -> Unit,
+    onNewNote: () -> Unit,
+    onRecord: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: NotesListViewModel = hiltViewModel(),
+) {
+    val query by viewModel.query.collectAsStateWithLifecycle()
+    val notes by viewModel.notes.collectAsStateWithLifecycle()
+
+    NotesListContent(
+        query = query,
+        notes = notes,
+        onQueryChange = viewModel::onQueryChange,
+        onOpenNote = onOpenNote,
+        onNewNote = onNewNote,
+        onRecord = onRecord,
+        onDelete = viewModel::delete,
+        modifier = modifier,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun NotesListContent(
+    query: String,
+    notes: List<NoteEntity>,
+    onQueryChange: (String) -> Unit,
+    onOpenNote: (String) -> Unit,
+    onNewNote: () -> Unit,
+    onRecord: () -> Unit,
+    onDelete: (NoteEntity) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val spacing = LocalSpacing.current
+    // The note pending a delete confirmation, or null when the dialog is closed.
+    // A note delete is destructive to the backing recording (no undo), so it is
+    // always gated behind an explicit confirm (see NotesListViewModel KDoc).
+    var pendingDelete by remember { mutableStateOf<NoteEntity?>(null) }
+
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text("Notes", modifier = Modifier.semantics { heading() }) },
+                actions = {
+                    IconButton(onClick = onNewNote) {
+                        Icon(Icons.Outlined.Edit, contentDescription = "New note")
+                    }
+                },
+            )
+        },
+        floatingActionButton = {
+            ExtendedFloatingActionButton(
+                onClick = onRecord,
+                icon = { Icon(Icons.Filled.Mic, contentDescription = null) },
+                text = { Text("Record") },
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding),
+        ) {
+            OutlinedTextField(
+                value = query,
+                onValueChange = onQueryChange,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = spacing.md, vertical = spacing.xs),
+                singleLine = true,
+                leadingIcon = { Icon(Icons.Outlined.Search, contentDescription = null) },
+                trailingIcon = {
+                    if (query.isNotEmpty()) {
+                        IconButton(onClick = { onQueryChange("") }) {
+                            Icon(Icons.Outlined.Close, contentDescription = "Clear search")
+                        }
+                    }
+                },
+                placeholder = { Text("Search notes") },
+            )
+
+            if (notes.isEmpty()) {
+                NotesEmptyState(
+                    isSearching = query.isNotBlank(),
+                    query = query,
+                    modifier = Modifier.fillMaxSize(),
+                )
+            } else {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(
+                        start = spacing.md,
+                        end = spacing.md,
+                        top = spacing.xs,
+                        // Clear the FAB so the last row isn't trapped beneath it.
+                        bottom = spacing.xxxl,
+                    ),
+                    verticalArrangement = Arrangement.spacedBy(spacing.xs),
+                ) {
+                    items(notes, key = { it.id }) { note ->
+                        NoteRow(
+                            note = note,
+                            onOpen = { onOpenNote(note.id) },
+                            onDelete = { pendingDelete = note },
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    pendingDelete?.let { note ->
+        DeleteNoteDialog(
+            note = note,
+            onConfirm = {
+                onDelete(note)
+                pendingDelete = null
+            },
+            onDismiss = { pendingDelete = null },
+        )
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun NoteRow(
+    note: NoteEntity,
+    onOpen: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    val spacing = LocalSpacing.current
+    var menuOpen by remember { mutableStateOf(false) }
+    val isRecording = note.audioPath != null || note.durationMs != null
+    val snippet = remember(note.body, note.transcript) { noteSnippet(note) }
+
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        shape = MaterialTheme.shapes.large,
+        modifier = Modifier
+            .fillMaxWidth()
+            .combinedClickable(
+                onClick = onOpen,
+                onClickLabel = "Open note",
+                onLongClick = { menuOpen = true },
+                onLongClickLabel = "Note actions",
+            ),
+    ) {
+        Box {
+            Row(
+                modifier = Modifier.padding(spacing.md),
+                horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+                verticalAlignment = Alignment.Top,
+            ) {
+                Icon(
+                    imageVector = if (isRecording) Icons.Outlined.Mic else Icons.Outlined.Description,
+                    contentDescription = if (isRecording) "Recording" else "Typed note",
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier
+                        .padding(top = spacing.xxs)
+                        .size(20.dp),
+                )
+                Column(modifier = Modifier.fillMaxWidth()) {
+                    Text(
+                        text = note.title.ifBlank { "Untitled" },
+                        style = MaterialTheme.typography.titleMedium,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    if (snippet.isNotEmpty()) {
+                        Text(
+                            text = snippet,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.padding(top = spacing.xxs),
+                        )
+                    }
+                    Row(
+                        modifier = Modifier.padding(top = spacing.xs),
+                        horizontalArrangement = Arrangement.spacedBy(spacing.xs),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = DateUtils.getRelativeTimeSpanString(
+                                note.updatedAt,
+                                System.currentTimeMillis(),
+                                DateUtils.MINUTE_IN_MILLIS,
+                            ).toString(),
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                        note.durationMs?.let { ms ->
+                            MetaDot()
+                            Text(
+                                text = formatNoteDuration(ms),
+                                style = MaterialTheme.typography.labelMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                        TranscriptionStatusChip(note.transcriptionStatus)
+                    }
+                }
+            }
+
+            DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
+                DropdownMenuItem(
+                    text = { Text("Open") },
+                    leadingIcon = { Icon(Icons.Outlined.OpenInNew, contentDescription = null) },
+                    onClick = {
+                        menuOpen = false
+                        onOpen()
+                    },
+                )
+                DropdownMenuItem(
+                    text = { Text("Delete") },
+                    leadingIcon = { Icon(Icons.Outlined.Delete, contentDescription = null) },
+                    onClick = {
+                        menuOpen = false
+                        onDelete()
+                    },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun MetaDot() {
+    Text(
+        text = "·",
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+}
+
+/**
+ * A small status chip for a note's transcription lifecycle. Renders nothing for
+ * [TranscriptionStatus.NONE] (a typed note) and [TranscriptionStatus.DONE] (the
+ * transcript itself is the signal) — only the in-flight / failed states earn a chip.
+ */
+@Composable
+internal fun TranscriptionStatusChip(status: TranscriptionStatus) {
+    val label = transcriptionStatusLabel(status) ?: return
+    AssistChip(
+        onClick = {},
+        enabled = false,
+        label = { Text(label, style = MaterialTheme.typography.labelSmall) },
+        colors = AssistChipDefaults.assistChipColors(
+            disabledLabelColor = MaterialTheme.colorScheme.onSurfaceVariant,
+        ),
+    )
+}
+
+/** Human label for an in-flight/failed transcription, or null when no chip is warranted. */
+internal fun transcriptionStatusLabel(status: TranscriptionStatus): String? = when (status) {
+    TranscriptionStatus.PENDING -> "Pending"
+    TranscriptionStatus.RUNNING -> "Transcribing…"
+    TranscriptionStatus.FAILED -> "Failed"
+    TranscriptionStatus.NONE, TranscriptionStatus.DONE -> null
+}
+
+@Composable
+private fun DeleteNoteDialog(
+    note: NoteEntity,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val hasAudio = note.audioPath != null || note.durationMs != null
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        icon = { Icon(Icons.Outlined.Delete, contentDescription = null) },
+        title = { Text("Delete note?") },
+        text = {
+            Text(
+                if (hasAudio) {
+                    "This permanently deletes \"${note.title.ifBlank { "Untitled" }}\" and its recording. This can't be undone."
+                } else {
+                    "This permanently deletes \"${note.title.ifBlank { "Untitled" }}\". This can't be undone."
+                },
+            )
+        },
+        confirmButton = { TextButton(onClick = onConfirm) { Text("Delete") } },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+    )
+}
+
+@Composable
+private fun NotesEmptyState(
+    isSearching: Boolean,
+    query: String,
+    modifier: Modifier = Modifier,
+) {
+    val spacing = LocalSpacing.current
+    Box(modifier = modifier, contentAlignment = Alignment.Center) {
+        Text(
+            text = if (isSearching) {
+                "No notes match \"$query\"."
+            } else {
+                "No notes yet.\nTap Record to capture one, or the pencil for a typed note."
+            },
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(spacing.xl),
+        )
+    }
+}
+
+// ── Previews ──────────────────────────────────────────────────────────────
+
+private fun sampleNotes(): List<NoteEntity> = listOf(
+    NoteEntity(
+        id = "1",
+        title = "Standup ideas",
+        createdAt = 0L,
+        updatedAt = System.currentTimeMillis() - 5 * 60_000,
+        durationMs = 92_000,
+        audioPath = "/x/1.m4a",
+        transcript = "Sync on the release, then talk through the migration plan and the on-device tests.",
+        transcriptionStatus = TranscriptionStatus.DONE,
+    ),
+    NoteEntity(
+        id = "2",
+        title = "",
+        createdAt = 0L,
+        updatedAt = System.currentTimeMillis() - 3 * 3_600_000,
+        durationMs = 14_000,
+        audioPath = "/x/2.m4a",
+        transcriptionStatus = TranscriptionStatus.RUNNING,
+    ),
+    NoteEntity(
+        id = "3",
+        title = "Grocery list",
+        createdAt = 0L,
+        updatedAt = System.currentTimeMillis() - 2 * 86_400_000,
+        body = "Oat milk, coffee, lemons, a good loaf of sourdough.",
+        transcriptionStatus = TranscriptionStatus.NONE,
+    ),
+)
+
+@Preview(name = "Notes list", showBackground = true)
+@Preview(name = "Notes list · dark", uiMode = Configuration.UI_MODE_NIGHT_YES, showBackground = true)
+@Composable
+private fun NotesListPreview() {
+    LibraryNocturneTheme {
+        NotesListContent(
+            query = "",
+            notes = sampleNotes(),
+            onQueryChange = {},
+            onOpenNote = {},
+            onNewNote = {},
+            onRecord = {},
+            onDelete = {},
+        )
+    }
+}
+
+@Preview(name = "Notes list · empty", showBackground = true)
+@Composable
+private fun NotesListEmptyPreview() {
+    LibraryNocturneTheme {
+        NotesListContent(
+            query = "",
+            notes = emptyList(),
+            onQueryChange = {},
+            onOpenNote = {},
+            onNewNote = {},
+            onRecord = {},
+            onDelete = {},
+        )
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/notes/ui/NotesRecordViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/notes/ui/NotesRecordViewModel.kt
@@ -1,0 +1,170 @@
+package `in`.jphe.storyvox.feature.notes.ui
+
+import androidx.compose.runtime.Immutable
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import `in`.jphe.storyvox.data.notes.NoteEntity
+import `in`.jphe.storyvox.data.notes.NotesRepository
+import `in`.jphe.storyvox.data.notes.TranscriptionStatus
+import java.util.UUID
+import javax.inject.Inject
+import kotlin.math.abs
+import kotlin.math.sin
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/** Immutable snapshot of the [RecordScreen] — timer, waveform, transport state. */
+@Immutable
+data class RecordUiState(
+    val elapsedMs: Long = 0L,
+    val isRecording: Boolean = false,
+    val isPaused: Boolean = false,
+    /** Recent normalized amplitudes in `[0f, 1f]`, oldest → newest, for the waveform. */
+    val amplitudes: List<Float> = emptyList(),
+    val isSaving: Boolean = false,
+)
+
+/** One-shot events from the record VM to its screen. */
+sealed interface RecordEvent {
+    /** The recording was saved as a note — the screen opens its detail. */
+    data class Saved(val noteId: String) : RecordEvent
+}
+
+/**
+ * Voice Notes (epic #1657, Phase 4) — ViewModel for the [RecordScreen].
+ *
+ * **The recorder is stubbed for Phase 4.** The screen chrome (timer, animated
+ * waveform, record / pause / resume / stop / cancel controls, a11y) is final;
+ * the elapsed clock + amplitudes come from a deterministic *simulation* here,
+ * and Stop persists a note row with **no audio** yet. Phase 2a (morpheus-1619)
+ * swaps the simulation for the real `AudioRecorder` (MediaRecorder → `.m4a`
+ * under a microphone-typed foreground service) and Phase 2b enqueues the
+ * transcription worker. Both swap points are marked with `TODO(#1657 …)`.
+ */
+@HiltViewModel
+class NotesRecordViewModel @Inject constructor(
+    private val repo: NotesRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(RecordUiState())
+    val uiState: StateFlow<RecordUiState> = _uiState.asStateFlow()
+
+    private val _events = Channel<RecordEvent>(Channel.BUFFERED)
+    val events: Flow<RecordEvent> = _events.receiveAsFlow()
+
+    private var ticker: Job? = null
+    private var tick = 0
+
+    /** Begin (or restart) a recording session. */
+    fun start() {
+        if (_uiState.value.isRecording) return
+        tick = 0
+        _uiState.value = RecordUiState(isRecording = true, isPaused = false)
+        // TODO(#1657 P2a): replace this simulated ticker with morpheus-1619's
+        //  AudioRecorder — start the MediaRecorder into filesDir/recordings/<id>.m4a
+        //  under a microphone-typed FGS and feed real getMaxAmplitude() into the
+        //  waveform. The UI below (timer + waveform + transport) is unchanged.
+        ticker = viewModelScope.launch {
+            while (true) {
+                delay(TICK_MS)
+                if (_uiState.value.isPaused) continue
+                tick++
+                val amp = simulatedAmplitude(tick)
+                _uiState.update { s ->
+                    s.copy(
+                        elapsedMs = s.elapsedMs + TICK_MS,
+                        amplitudes = (s.amplitudes + amp).takeLast(MAX_BARS),
+                    )
+                }
+            }
+        }
+    }
+
+    fun pause() {
+        if (_uiState.value.isRecording) _uiState.update { it.copy(isPaused = true) }
+    }
+
+    fun resume() {
+        if (_uiState.value.isRecording) _uiState.update { it.copy(isPaused = false) }
+    }
+
+    /** Abandon the in-progress recording without persisting anything. */
+    fun cancel() {
+        ticker?.cancel()
+        ticker = null
+        tick = 0
+        _uiState.value = RecordUiState()
+    }
+
+    /**
+     * Stop and persist the recording as a new note row, then emit
+     * [RecordEvent.Saved] so the screen opens the note's detail.
+     *
+     * P4 writes a PENDING row with `audioPath = null` (no capture yet) — a
+     * documented placeholder; see the class KDoc + the TODOs below.
+     */
+    fun stopAndSave() {
+        if (_uiState.value.isSaving) return
+        val elapsed = _uiState.value.elapsedMs
+        ticker?.cancel()
+        ticker = null
+        _uiState.update { it.copy(isRecording = false, isPaused = false, isSaving = true) }
+        val id = UUID.randomUUID().toString()
+        val now = System.currentTimeMillis()
+        viewModelScope.launch {
+            repo.upsert(
+                NoteEntity(
+                    id = id,
+                    title = "",
+                    createdAt = now,
+                    updatedAt = now,
+                    // TODO(#1657 P2a): audioPath = the finalized recording path
+                    //  from AudioRecorder (filesDir/recordings/<id>.m4a). Null in
+                    //  P4 — there is no real capture yet.
+                    audioPath = null,
+                    durationMs = elapsed,
+                    // TODO(#1657 P2b): after insert, enqueue the TranscriptionWorker
+                    //  (WorkManager) which advances PENDING → RUNNING → DONE/FAILED
+                    //  and streams transcript segments back into the row.
+                    transcriptionStatus = TranscriptionStatus.PENDING,
+                ),
+            )
+            _uiState.update { it.copy(isSaving = false) }
+            _events.send(RecordEvent.Saved(id))
+        }
+    }
+
+    override fun onCleared() {
+        ticker?.cancel()
+        super.onCleared()
+    }
+
+    private companion object {
+        /** 10 Hz update — smooth waveform + timer without churn. */
+        const val TICK_MS = 100L
+        /** Rolling window of bars kept for the waveform. */
+        const val MAX_BARS = 48
+    }
+}
+
+/**
+ * Deterministic pseudo-amplitude in `[0.08f, 1f]` for the Phase-4 stub waveform
+ * (two mixed sines give an organic, non-repetitive envelope). Deterministic so
+ * previews + any future test are stable; replaced wholesale by real mic
+ * amplitude in Phase 2a.
+ */
+internal fun simulatedAmplitude(tick: Int): Float {
+    val a = sin(tick * 0.35).toFloat()
+    val b = sin(tick * 0.11 + 1.3).toFloat()
+    val mixed = a * 0.6f + b * 0.4f
+    return (0.08f + 0.92f * abs(mixed)).coerceIn(0.08f, 1f)
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/notes/ui/NotesViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/notes/ui/NotesViewModel.kt
@@ -1,0 +1,287 @@
+package `in`.jphe.storyvox.feature.notes.ui
+
+import androidx.compose.runtime.Immutable
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import `in`.jphe.storyvox.data.notes.NoteEntity
+import `in`.jphe.storyvox.data.notes.NotesRepository
+import `in`.jphe.storyvox.data.notes.TranscriptionStatus
+import javax.inject.Inject
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+/**
+ * Voice Notes (epic #1657, Phase 4) — ViewModel for the notes **list**
+ * ([NotesListScreen]). Mirrors [ScriptManagerViewModel][`in`.jphe.storyvox.feature.reader.script.ScriptManagerViewModel]:
+ * a search box bound to a `flatMapLatest` feed over [NotesRepository.search]
+ * (which is `LIKE`-based over title / body / transcript), plus delete.
+ *
+ * **Delete has no undo — by design.** [NotesRepository.delete] removes the row
+ * AND the backing `.m4a` recording (spec §3.4/§3.7 — no dangling audio). Unlike
+ * the Scripts list (pure text, so a swipe-undo just re-inserts the row), a note
+ * delete is destructive to an irreplaceable recording, so the screen guards it
+ * behind a confirm dialog instead of a swipe-to-dismiss + "Undo" snackbar. A
+ * true undo would need a Phase-1 soft-delete API that doesn't exist.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@HiltViewModel
+class NotesListViewModel @Inject constructor(
+    private val repo: NotesRepository,
+) : ViewModel() {
+
+    private val _query = MutableStateFlow("")
+    /** Live search text bound to the list screen's search bar. */
+    val query: StateFlow<String> = _query.asStateFlow()
+
+    /**
+     * The note feed for the current [query]. `search("")` matches every row
+     * (`LIKE '%%'`, ordered by `updatedAt DESC`), so one flow drives both the
+     * empty and non-empty query states — a single source of truth.
+     */
+    val notes: StateFlow<List<NoteEntity>> =
+        _query
+            .flatMapLatest { q -> repo.search(q.trim()) }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    fun onQueryChange(value: String) { _query.value = value }
+
+    /** Delete a note and its recording (see class KDoc — intentionally no undo). */
+    fun delete(note: NoteEntity) {
+        viewModelScope.launch { repo.delete(note.id) }
+    }
+}
+
+/**
+ * Immutable snapshot of the note **detail / editor** ([NoteDetailScreen]).
+ *
+ * A note is one row that can be a typed note, a recording-backed note, or both:
+ * [transcript] / [summary] / [audioPath] / [durationMs] are the recording +
+ * pipeline outputs (populated by Phases 2/3), while [title] / [body] / [tags]
+ * are the user-editable fields. [transcript] is shown read-only — it's the
+ * immutable ASR source of truth; the user edits [body], not the transcript.
+ */
+@Immutable
+data class NoteDetailUiState(
+    val id: String = "",
+    val title: String = "",
+    /** User-editable body (the [NoteEntity.body] column). */
+    val body: String = "",
+    val tags: String = "",
+    /** Read-only ASR transcript ([NoteEntity.transcript]); null until Phase 2b runs. */
+    val transcript: String? = null,
+    val transcriptLang: String? = null,
+    /** AI summary ([NoteEntity.summary]); null until the user consents (Phase 3). */
+    val summary: String? = null,
+    /** Recording path ([NoteEntity.audioPath]); null for a typed-only note. */
+    val audioPath: String? = null,
+    val durationMs: Long? = null,
+    val transcriptionStatus: TranscriptionStatus = TranscriptionStatus.NONE,
+    /** True until the first save — drives the top-bar title + unsaved-changes cue. */
+    val isNewDraft: Boolean = true,
+    /** True once the in-memory content diverges from what's persisted. Gates Save. */
+    val isDirty: Boolean = false,
+)
+
+/** One-shot events from the detail VM to its screen. */
+sealed interface NoteDetailEvent {
+    /** A save completed — the screen confirms with a snackbar. */
+    data object Saved : NoteDetailEvent
+    /** The note was deleted — the screen pops back to the list. */
+    data object Deleted : NoteDetailEvent
+    /** Share the assembled note text — the screen fires an ACTION_SEND chooser. */
+    data class Share(val text: String) : NoteDetailEvent
+    /** Summarize was tapped before Phase 3 landed — the screen shows a notice. */
+    data object SummarizeUnavailable : NoteDetailEvent
+}
+
+/**
+ * Voice Notes (#1657, Phase 4) — ViewModel for the note **detail / editor**
+ * ([NoteDetailScreen]). Mirrors [ScriptEditViewModel][`in`.jphe.storyvox.feature.reader.script.ScriptEditViewModel]:
+ * loads the note named by the `noteId` route arg (or seeds a blank new-draft
+ * with that id when no row exists yet — the list's "New note" action navigates
+ * with a fresh UUID, so the first [save] inserts it). The Record flow also
+ * lands here after it persists a recording-backed row.
+ */
+@HiltViewModel
+class NoteDetailViewModel @Inject constructor(
+    private val repo: NotesRepository,
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    private val noteId: String = checkNotNull(savedStateHandle[NOTE_ID_ARG]) {
+        "NoteDetailViewModel requires a $NOTE_ID_ARG route arg"
+    }
+
+    /** Preserved across saves so the created-at timestamp is stable (updatedAt moves). */
+    private var createdAt: Long = System.currentTimeMillis()
+
+    private val _uiState = MutableStateFlow(NoteDetailUiState(id = noteId))
+    val uiState: StateFlow<NoteDetailUiState> = _uiState.asStateFlow()
+
+    private val _events = Channel<NoteDetailEvent>(Channel.BUFFERED)
+    val events: Flow<NoteDetailEvent> = _events.receiveAsFlow()
+
+    init {
+        viewModelScope.launch {
+            val existing = repo.get(noteId)
+            if (existing != null) {
+                createdAt = existing.createdAt
+                _uiState.value = NoteDetailUiState(
+                    id = existing.id,
+                    title = existing.title,
+                    body = existing.body.orEmpty(),
+                    tags = existing.tags,
+                    transcript = existing.transcript,
+                    transcriptLang = existing.transcriptLang,
+                    summary = existing.summary,
+                    audioPath = existing.audioPath,
+                    durationMs = existing.durationMs,
+                    transcriptionStatus = existing.transcriptionStatus,
+                    isNewDraft = false,
+                    isDirty = false,
+                )
+            }
+            // No row → keep the blank new-draft state seeded above.
+        }
+    }
+
+    fun onTitleChange(value: String) {
+        _uiState.value = _uiState.value.copy(title = value, isDirty = true)
+    }
+
+    fun onBodyChange(value: String) {
+        _uiState.value = _uiState.value.copy(body = value, isDirty = true)
+    }
+
+    fun onTagsChange(value: String) {
+        _uiState.value = _uiState.value.copy(tags = value, isDirty = true)
+    }
+
+    /**
+     * Persist the current content. Preserves the recording fields (audio /
+     * transcript / summary / status) untouched — the editor only owns
+     * title / body / tags. Emits [NoteDetailEvent.Saved].
+     */
+    fun save() {
+        val s = _uiState.value
+        val now = System.currentTimeMillis()
+        viewModelScope.launch {
+            repo.upsert(
+                NoteEntity(
+                    id = s.id,
+                    title = s.title.trim(),
+                    createdAt = createdAt,
+                    updatedAt = now,
+                    tags = normalizeNoteTags(s.tags),
+                    audioPath = s.audioPath,
+                    durationMs = s.durationMs,
+                    transcript = s.transcript,
+                    transcriptLang = s.transcriptLang,
+                    summary = s.summary,
+                    // Store an empty body as null so it doesn't shadow the
+                    // transcript in the list snippet (see [noteSnippet]).
+                    body = s.body.ifBlank { null },
+                    transcriptionStatus = s.transcriptionStatus,
+                ),
+            )
+            _uiState.value = s.copy(isNewDraft = false, isDirty = false)
+            _events.send(NoteDetailEvent.Saved)
+        }
+    }
+
+    /** Delete this note (and its recording) then pop back to the list. */
+    fun delete() {
+        viewModelScope.launch {
+            repo.delete(_uiState.value.id)
+            _events.send(NoteDetailEvent.Deleted)
+        }
+    }
+
+    /** Share the note as plain text via the system chooser (title + body + transcript + summary). */
+    fun export() {
+        val s = _uiState.value
+        val text = buildNoteExportText(s.title, s.body, s.transcript, s.summary)
+        viewModelScope.launch { _events.send(NoteDetailEvent.Share(text)) }
+    }
+
+    /**
+     * TODO(#1657 P3): replace with `SummarizeTranscriptUseCase` (nebula) —
+     * build a prompt from the transcript, stream `LlmProvider`, and write
+     * [NoteEntity.summary] behind the explicit-consent gate (spec §3.3). Until
+     * Phase 3 lands, tapping Summarize surfaces a "not yet available" notice so
+     * the affordance is discoverable without pretending to work.
+     */
+    fun summarize() {
+        viewModelScope.launch { _events.send(NoteDetailEvent.SummarizeUnavailable) }
+    }
+
+    companion object {
+        const val NOTE_ID_ARG: String = "noteId"
+    }
+}
+
+/**
+ * Normalize a comma-separated tag string: trim each, drop blanks + case-
+ * insensitive duplicates, re-join with ", ". Keeps the `tags LIKE` search and
+ * the chip display predictable (mirrors the Scripts editor's `normalizeTags`).
+ */
+internal fun normalizeNoteTags(raw: String): String =
+    raw.split(',')
+        .map { it.trim() }
+        .filter { it.isNotEmpty() }
+        .distinctBy { it.lowercase() }
+        .joinToString(", ")
+
+/**
+ * A single-line snippet for the list card: the user's [NoteEntity.body] if it
+ * has content, else the [NoteEntity.transcript], else empty. Newlines collapse
+ * to spaces so a multi-line body doesn't blow out the card height.
+ */
+internal fun noteSnippet(note: NoteEntity): String {
+    val source = note.body?.takeIf { it.isNotBlank() } ?: note.transcript.orEmpty()
+    return source.replace(Regex("\\s+"), " ").trim()
+}
+
+/** Format a recording length in millis as `M:SS`, or `H:MM:SS` past an hour. */
+internal fun formatNoteDuration(durationMs: Long): String {
+    val totalSecs = (durationMs / 1000).coerceAtLeast(0)
+    val hours = totalSecs / 3600
+    val minutes = (totalSecs % 3600) / 60
+    val seconds = totalSecs % 60
+    return if (hours > 0) {
+        "%d:%02d:%02d".format(hours, minutes, seconds)
+    } else {
+        "%d:%02d".format(minutes, seconds)
+    }
+}
+
+/**
+ * Assemble a note into shareable plain text. Title first (or "Untitled"), then
+ * the user body, then the transcript, then the summary — each present section
+ * separated by a blank line. Used by the detail screen's Export → share sheet.
+ */
+internal fun buildNoteExportText(
+    title: String,
+    body: String,
+    transcript: String?,
+    summary: String?,
+): String {
+    val sections = buildList {
+        add(title.ifBlank { "Untitled" })
+        body.takeIf { it.isNotBlank() }?.let { add(it.trim()) }
+        transcript?.takeIf { it.isNotBlank() }?.let { add("Transcript\n${it.trim()}") }
+        summary?.takeIf { it.isNotBlank() }?.let { add("Summary\n${it.trim()}") }
+    }
+    return sections.joinToString("\n\n")
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/notes/ui/RecordScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/notes/ui/RecordScreen.kt
@@ -1,0 +1,299 @@
+package `in`.jphe.storyvox.feature.notes.ui
+
+import android.content.res.Configuration
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Mic
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Stop
+import androidx.compose.material.icons.outlined.Close
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledIconButton
+import androidx.compose.material3.FilledTonalIconButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import `in`.jphe.storyvox.ui.theme.LibraryNocturneTheme
+import `in`.jphe.storyvox.ui.theme.LocalSpacing
+
+/**
+ * Voice Notes (epic #1657, Phase 4) — the recording screen. A large timer, an
+ * animated waveform, and record / pause / resume / stop transport. Stop persists
+ * the recording as a note and opens its detail.
+ *
+ * **Capture is stubbed in Phase 4** (see [NotesRecordViewModel]) — the chrome is
+ * final; Phase 2a wires the real `AudioRecorder` + microphone FGS in behind it.
+ *
+ * @param onRecordingSaved open the detail of the just-saved note by id.
+ * @param onExit leave the screen (cancel / back) without saving.
+ */
+@Composable
+fun RecordScreen(
+    onRecordingSaved: (String) -> Unit,
+    onExit: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: NotesRecordViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+
+    androidx.compose.runtime.LaunchedEffect(Unit) {
+        viewModel.events.collect { event ->
+            when (event) {
+                is RecordEvent.Saved -> onRecordingSaved(event.noteId)
+            }
+        }
+    }
+
+    val cancelAndExit = {
+        viewModel.cancel()
+        onExit()
+    }
+    // System back mirrors the top-bar close: abandon the in-progress take.
+    BackHandler(enabled = true, onBack = cancelAndExit)
+
+    RecordContent(
+        state = state,
+        onStart = viewModel::start,
+        onPause = viewModel::pause,
+        onResume = viewModel::resume,
+        onStop = viewModel::stopAndSave,
+        onCancel = cancelAndExit,
+        modifier = modifier,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun RecordContent(
+    state: RecordUiState,
+    onStart: () -> Unit,
+    onPause: () -> Unit,
+    onResume: () -> Unit,
+    onStop: () -> Unit,
+    onCancel: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val spacing = LocalSpacing.current
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        topBar = {
+            TopAppBar(
+                title = { Text("Record") },
+                navigationIcon = {
+                    IconButton(onClick = onCancel) {
+                        Icon(Icons.Outlined.Close, contentDescription = "Cancel")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(horizontal = spacing.lg),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            Text(
+                text = formatNoteDuration(state.elapsedMs),
+                style = MaterialTheme.typography.displayMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Spacer(Modifier.height(spacing.xs))
+            Text(
+                text = when {
+                    state.isPaused -> "Paused"
+                    state.isRecording -> "Recording…"
+                    else -> "Tap to record"
+                },
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            Spacer(Modifier.height(spacing.xl))
+
+            Waveform(
+                amplitudes = state.amplitudes,
+                active = state.isRecording && !state.isPaused,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(96.dp),
+            )
+
+            Spacer(Modifier.height(spacing.xl))
+
+            if (!state.isRecording) {
+                // Idle → one big primary button to begin.
+                FilledIconButton(
+                    onClick = onStart,
+                    modifier = Modifier.size(88.dp),
+                ) {
+                    Icon(
+                        Icons.Filled.Mic,
+                        contentDescription = "Start recording",
+                        modifier = Modifier.size(40.dp),
+                    )
+                }
+            } else {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(spacing.xl),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    // Pause / Resume toggle.
+                    FilledTonalIconButton(
+                        onClick = if (state.isPaused) onResume else onPause,
+                        modifier = Modifier.size(64.dp),
+                    ) {
+                        Icon(
+                            imageVector = if (state.isPaused) Icons.Filled.PlayArrow else Icons.Filled.Pause,
+                            contentDescription = if (state.isPaused) "Resume" else "Pause",
+                            modifier = Modifier.size(32.dp),
+                        )
+                    }
+                    // Stop + save.
+                    FilledIconButton(
+                        onClick = onStop,
+                        enabled = !state.isSaving,
+                        modifier = Modifier.size(72.dp),
+                        colors = IconButtonDefaults.filledIconButtonColors(
+                            containerColor = MaterialTheme.colorScheme.error,
+                            contentColor = MaterialTheme.colorScheme.onError,
+                        ),
+                    ) {
+                        Icon(
+                            Icons.Filled.Stop,
+                            contentDescription = "Stop and save",
+                            modifier = Modifier.size(36.dp),
+                        )
+                    }
+                }
+            }
+
+            if (state.isRecording) {
+                Spacer(Modifier.height(spacing.lg))
+                // Honest cue for testers — removed when Phase 2a's real capture lands.
+                Text(
+                    text = "Simulated preview — real capture arrives in a later update.",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                )
+            }
+        }
+    }
+}
+
+/**
+ * A centered bar waveform over recent [amplitudes] (each in `[0f, 1f]`). When
+ * there's nothing to draw yet it shows a faint baseline so the area reads as a
+ * waveform surface rather than empty space.
+ */
+@Composable
+private fun Waveform(
+    amplitudes: List<Float>,
+    active: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val barColor = MaterialTheme.colorScheme.primary
+    val idleColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.25f)
+    Canvas(modifier = modifier) {
+        val bars = 48
+        val barSlot = size.width / bars
+        val barWidth = barSlot * 0.5f
+        val midY = size.height / 2f
+
+        if (amplitudes.isEmpty()) {
+            drawRoundRect(
+                color = idleColor,
+                topLeft = Offset(0f, midY - 1.5f),
+                size = Size(size.width, 3f),
+                cornerRadius = CornerRadius(1.5f, 1.5f),
+            )
+            return@Canvas
+        }
+
+        val recent = amplitudes.takeLast(bars)
+        // Right-align newest bars so the trace grows leftward like a real meter.
+        val startIndex = bars - recent.size
+        val color = if (active) barColor else idleColor
+        recent.forEachIndexed { i, amp ->
+            val barHeight = (size.height * 0.92f) * amp.coerceIn(0f, 1f)
+            val x = (startIndex + i) * barSlot + (barSlot - barWidth) / 2f
+            drawRoundRect(
+                color = color,
+                topLeft = Offset(x, midY - barHeight / 2f),
+                size = Size(barWidth, barHeight),
+                cornerRadius = CornerRadius(barWidth / 2f, barWidth / 2f),
+            )
+        }
+    }
+}
+
+// ── Previews ──────────────────────────────────────────────────────────────
+
+private fun sampleAmplitudes(): List<Float> =
+    (1..48).map { simulatedAmplitude(it) }
+
+@Preview(name = "Record · active", showBackground = true)
+@Preview(name = "Record · active dark", uiMode = Configuration.UI_MODE_NIGHT_YES, showBackground = true)
+@Composable
+private fun RecordActivePreview() {
+    LibraryNocturneTheme {
+        RecordContent(
+            state = RecordUiState(
+                elapsedMs = 73_000,
+                isRecording = true,
+                isPaused = false,
+                amplitudes = sampleAmplitudes(),
+            ),
+            onStart = {},
+            onPause = {},
+            onResume = {},
+            onStop = {},
+            onCancel = {},
+        )
+    }
+}
+
+@Preview(name = "Record · idle", showBackground = true)
+@Composable
+private fun RecordIdlePreview() {
+    LibraryNocturneTheme {
+        RecordContent(
+            state = RecordUiState(),
+            onStart = {},
+            onPause = {},
+            onResume = {},
+            onStop = {},
+            onCancel = {},
+        )
+    }
+}

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/notes/ui/FakeNoteDao.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/notes/ui/FakeNoteDao.kt
@@ -1,0 +1,43 @@
+package `in`.jphe.storyvox.feature.notes.ui
+
+import `in`.jphe.storyvox.data.notes.NoteDao
+import `in`.jphe.storyvox.data.notes.NoteEntity
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+
+/**
+ * In-memory [NoteDao] for the plain-JVM VM tests (the codebase's hand-rolled-
+ * fake posture). Mirrors the real DAO's observable semantics: `observeAll` /
+ * `search` are `updatedAt DESC`, and `search` is a case-insensitive substring
+ * match over title / body / transcript (the SQLite `LIKE '%q%'` the real DAO
+ * runs — an empty query matches every row via the non-null title).
+ */
+class FakeNoteDao : NoteDao {
+    private val rows = MutableStateFlow<List<NoteEntity>>(emptyList())
+
+    override suspend fun upsert(note: NoteEntity) {
+        rows.value = rows.value.filterNot { it.id == note.id } + note
+    }
+
+    override fun observeAll(): Flow<List<NoteEntity>> =
+        rows.map { list -> list.sortedByDescending { it.updatedAt } }
+
+    override suspend fun get(id: String): NoteEntity? = rows.value.firstOrNull { it.id == id }
+
+    override suspend fun all(): List<NoteEntity> = rows.value
+
+    override suspend fun delete(id: String) {
+        rows.value = rows.value.filterNot { it.id == id }
+    }
+
+    override fun search(query: String): Flow<List<NoteEntity>> =
+        rows.map { list ->
+            val q = query.lowercase()
+            list.filter { note ->
+                note.title.lowercase().contains(q) ||
+                    (note.body?.lowercase()?.contains(q) == true) ||
+                    (note.transcript?.lowercase()?.contains(q) == true)
+            }.sortedByDescending { it.updatedAt }
+        }
+}

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/notes/ui/NotesViewModelTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/notes/ui/NotesViewModelTest.kt
@@ -1,0 +1,258 @@
+package `in`.jphe.storyvox.feature.notes.ui
+
+import androidx.lifecycle.SavedStateHandle
+import `in`.jphe.storyvox.data.notes.NoteEntity
+import `in`.jphe.storyvox.data.notes.NotesRepository
+import `in`.jphe.storyvox.data.notes.TranscriptionStatus
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Voice Notes (epic #1657, Phase 4) — plain-JVM coverage for the notes VMs and
+ * pure helpers, using a [FakeNoteDao] wrapped in the *real* [NotesRepository]
+ * (the codebase's hand-rolled-fake posture; no Android / Room / files needed —
+ * a typed note carries no audio path, so delete never touches the temp dir).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class NotesViewModelTest {
+
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    // One shared UnconfinedTestDispatcher for Main + runTest, so viewModelScope,
+    // backgroundScope and the test body all run on the same eager scheduler —
+    // the WhileSubscribed stateIn feeds emit deterministically for `.value` reads.
+    private val dispatcher = UnconfinedTestDispatcher()
+    private lateinit var dao: FakeNoteDao
+    private lateinit var repo: NotesRepository
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        dao = FakeNoteDao()
+        repo = NotesRepository(dao, tmp.root)
+    }
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    private fun note(
+        id: String,
+        title: String = "",
+        body: String? = null,
+        transcript: String? = null,
+        updatedAt: Long = 0L,
+        audioPath: String? = null,
+        durationMs: Long? = null,
+        status: TranscriptionStatus = TranscriptionStatus.NONE,
+    ) = NoteEntity(
+        id = id,
+        title = title,
+        createdAt = 0L,
+        updatedAt = updatedAt,
+        body = body,
+        transcript = transcript,
+        audioPath = audioPath,
+        durationMs = durationMs,
+        transcriptionStatus = status,
+    )
+
+    private suspend fun seed(vararg notes: NoteEntity) = notes.forEach { dao.upsert(it) }
+
+    // ── List VM ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `empty query lists all notes, newest edit first`() = runTest(dispatcher) {
+        seed(note("a", updatedAt = 100), note("b", updatedAt = 300), note("c", updatedAt = 200))
+        val vm = NotesListViewModel(repo)
+        backgroundScope.launch { vm.notes.collect {} }
+        runCurrent()
+
+        assertEquals(listOf("b", "c", "a"), vm.notes.value.map { it.id })
+    }
+
+    @Test
+    fun `search matches title, body, and transcript`() = runTest(dispatcher) {
+        seed(
+            note("t", title = "Groceries", updatedAt = 1),
+            note("b", title = "Untitled", body = "buy milk and bread", updatedAt = 2),
+            note("x", title = "Meeting", transcript = "discuss the milk budget", updatedAt = 3),
+            note("n", title = "Nothing", body = "unrelated", updatedAt = 4),
+        )
+        val vm = NotesListViewModel(repo)
+        backgroundScope.launch { vm.notes.collect {} }
+
+        vm.onQueryChange("milk")
+        runCurrent()
+
+        assertEquals(setOf("b", "x"), vm.notes.value.map { it.id }.toSet())
+    }
+
+    @Test
+    fun `delete removes the note`() = runTest(dispatcher) {
+        seed(note("a", updatedAt = 1), note("b", updatedAt = 2))
+        val vm = NotesListViewModel(repo)
+        backgroundScope.launch { vm.notes.collect {} }
+        runCurrent()
+
+        vm.delete(note("a", updatedAt = 1))
+        runCurrent()
+
+        assertEquals(listOf("b"), vm.notes.value.map { it.id })
+    }
+
+    // ── Detail VM ────────────────────────────────────────────────────────
+
+    @Test
+    fun `detail loads an existing note into state`() = runTest(dispatcher) {
+        seed(
+            note(
+                "n1",
+                title = "Kept",
+                body = "body text",
+                transcript = "spoken words",
+                audioPath = "/x/n1.m4a",
+                durationMs = 5_000,
+                status = TranscriptionStatus.DONE,
+                updatedAt = 9,
+            ),
+        )
+        val vm = NoteDetailViewModel(repo, SavedStateHandle(mapOf("noteId" to "n1")))
+        runCurrent()
+
+        val s = vm.uiState.value
+        assertFalse("existing note is not a new draft", s.isNewDraft)
+        assertEquals("Kept", s.title)
+        assertEquals("body text", s.body)
+        assertEquals("spoken words", s.transcript)
+        assertEquals("/x/n1.m4a", s.audioPath)
+        assertEquals(TranscriptionStatus.DONE, s.transcriptionStatus)
+    }
+
+    @Test
+    fun `detail save inserts a new typed note with normalized tags`() = runTest(dispatcher) {
+        val vm = NoteDetailViewModel(repo, SavedStateHandle(mapOf("noteId" to "new1")))
+        runCurrent()
+        assertTrue("absent row seeds a new draft", vm.uiState.value.isNewDraft)
+
+        vm.onTitleChange("Fresh")
+        vm.onBodyChange("hello")
+        vm.onTagsChange("a, A , b")
+        vm.save()
+        runCurrent()
+
+        val stored = dao.get("new1")
+        assertNotNull(stored)
+        assertEquals("Fresh", stored!!.title)
+        assertEquals("hello", stored.body)
+        assertEquals("a, b", stored.tags)
+        assertFalse(vm.uiState.value.isNewDraft)
+        assertFalse(vm.uiState.value.isDirty)
+    }
+
+    @Test
+    fun `detail save preserves the recording fields and createdAt`() = runTest(dispatcher) {
+        seed(
+            NoteEntity(
+                id = "rec",
+                title = "",
+                createdAt = 111L,
+                updatedAt = 222L,
+                audioPath = "/x/rec.m4a",
+                durationMs = 8_000,
+                transcript = "hi there",
+                transcriptLang = "en",
+                transcriptionStatus = TranscriptionStatus.DONE,
+            ),
+        )
+        val vm = NoteDetailViewModel(repo, SavedStateHandle(mapOf("noteId" to "rec")))
+        runCurrent()
+
+        vm.onTitleChange("Titled now")
+        vm.save()
+        runCurrent()
+
+        val stored = dao.get("rec")!!
+        assertEquals("Titled now", stored.title)
+        assertEquals("createdAt preserved", 111L, stored.createdAt)
+        assertEquals("audio preserved", "/x/rec.m4a", stored.audioPath)
+        assertEquals(8_000L, stored.durationMs)
+        assertEquals("immutable transcript preserved", "hi there", stored.transcript)
+        assertEquals(TranscriptionStatus.DONE, stored.transcriptionStatus)
+        assertTrue("updatedAt bumped", stored.updatedAt > 222L)
+    }
+
+    @Test
+    fun `detail save stores a blank body as null so it doesn't shadow the transcript`() = runTest(dispatcher) {
+        seed(note("only-audio", transcript = "the spoken content", durationMs = 3_000, status = TranscriptionStatus.DONE))
+        val vm = NoteDetailViewModel(repo, SavedStateHandle(mapOf("noteId" to "only-audio")))
+        runCurrent()
+
+        // User opens the note and saves without typing a body.
+        vm.onTitleChange("A title")
+        vm.save()
+        runCurrent()
+
+        val stored = dao.get("only-audio")!!
+        assertNull("blank body persists as null", stored.body)
+        assertEquals("the spoken content", noteSnippet(stored))
+    }
+
+    // ── Pure helpers ─────────────────────────────────────────────────────
+
+    @Test
+    fun `noteSnippet prefers body, falls back to transcript, collapses whitespace`() {
+        assertEquals("hello world", noteSnippet(note("x", body = "hello\n  world", transcript = "T")))
+        assertEquals("transcribed", noteSnippet(note("x", body = "   ", transcript = "transcribed")))
+        assertEquals("", noteSnippet(note("x")))
+    }
+
+    @Test
+    fun `formatNoteDuration renders MSS and HMMSS`() {
+        assertEquals("0:14", formatNoteDuration(14_000))
+        assertEquals("1:32", formatNoteDuration(92_000))
+        assertEquals("1:01:01", formatNoteDuration(3_661_000))
+        assertEquals("0:00", formatNoteDuration(-5))
+    }
+
+    @Test
+    fun `normalizeNoteTags trims, dedupes case-insensitively, and rejoins`() {
+        assertEquals("a, b, c", normalizeNoteTags("a, A , b,, c"))
+        assertEquals("", normalizeNoteTags("  ,  "))
+    }
+
+    @Test
+    fun `buildNoteExportText assembles present sections`() {
+        assertEquals(
+            "T\n\nB\n\nTranscript\nX\n\nSummary\nY",
+            buildNoteExportText("T", "B", "X", "Y"),
+        )
+        assertEquals("Untitled", buildNoteExportText("", "", null, null))
+        assertEquals("Just a title", buildNoteExportText("Just a title", "  ", null, ""))
+    }
+
+    @Test
+    fun `transcriptionStatusLabel shows only in-flight and failed states`() {
+        assertEquals("Pending", transcriptionStatusLabel(TranscriptionStatus.PENDING))
+        assertEquals("Transcribing…", transcriptionStatusLabel(TranscriptionStatus.RUNNING))
+        assertEquals("Failed", transcriptionStatusLabel(TranscriptionStatus.FAILED))
+        assertNull(transcriptionStatusLabel(TranscriptionStatus.NONE))
+        assertNull(transcriptionStatusLabel(TranscriptionStatus.DONE))
+    }
+}


### PR DESCRIPTION
Voice Notes **Phase 4 — the UI** (epic #1657), the Compose surface over the merged Phase-1 storage (#1658). Rebased onto `main`, so it's built **directly against the real `core-data` `NotesRepository` / `NoteEntity` / `NoteDao`** — no fake-interface drift. The in-memory test double is a `FakeNoteDao` wrapped in the *real* `NotesRepository` (the plain-JVM posture morpheus's KDoc invites).

## What's here

**Three screens** (`feature/notes/ui/`, each a stateful wrapper → stateless `*Content` with dark/light `@Preview`s):
- **NotesListScreen** — search, note cards (recording/typed glyph · title · snippet · date · duration · transcription-status chip), primary **Record** FAB, top-bar **New note** (typed) action, empty state.
- **RecordScreen** — large timer, animated waveform, record / pause / resume / stop transport. Stop persists the recording and opens its detail.
- **NoteDetailScreen** — audio player, read-only transcript, summary + **Summarize**, editable body, tag chips, share + delete. Serves typed notes, recordings, or both.

**Nav / dock:**
- `NOTES` / `NOTES_RECORD` / `NOTES_DETAIL` routes in `StoryvoxNavHost` — list is a home surface (cross-fade + shares the dock); record + detail are push drill-downs. `NOTES` added to `HOME_ROUTES`.
- **Notes** added to `HomeTab` (one enum entry drives **both** `BottomTabBar` and `SideNavRail`; `TestTags.navTab` auto-covers it).

**ViewModels:** `NotesListViewModel` (search feed + delete), `NoteDetailViewModel` (`SavedStateHandle` note id; load/save/delete/export/summarize), `NotesRecordViewModel` (timer/waveform/transport). Injected the concrete `@Singleton NotesRepository` (DataModule already `@Provides` its deps → resolves at `:app`).

## 🔎 Decisions to eyeball (your call)

1. **Sixth bottom-bar tab.** "Notes nav destination" was a locked product Q, so Notes is a first-class dock pill — but this **deliberately crosses the "past five needs a UX review" threshold** that `NavStructureTest` + `BottomTabBar`'s own comment flagged (six cells crowd label rendering on the **Flip3 ~260 dp cover**). I updated the tripwire test to the conscious 6-tab record. **Please eyeball the dock on the Flip3 cover** — if it's too tight, alternatives: drop the tab labels, or reach Notes from the rail + a Library/Playing entry instead. Icon is a waveform (`GraphicEq`), distinct from Voices' `RecordVoiceOver`.
2. **Delete is confirm-gated, not swipe-to-undo.** `NotesRepository.delete` permanently removes the `.m4a` (no soft-delete API), so an "Undo" would be dishonest for recordings. Went with an AlertDialog confirm ("…also deletes its recording. Can't be undone.").
3. **Compose-UI tests deferred.** `feature` has **no `androidTest`/Compose-test toolchain** (all 85 tests are plain JVM). Rather than bolt one on (SDK-36/Java-21 Robolectric risk), I covered logic with **JVM VM tests** + rich `@Preview`s. Say the word if you want the Compose-test toolchain added as a separate task.

## Stub seams (all marked `TODO(#1657 …)`)
- **Record capture → P2a** (morpheus-1619): the recorder is a deterministic simulation (timer + waveform); Stop writes a `PENDING` row with `audioPath = null`. A subtle "simulated preview" caption keeps on-device testers honest. Chrome is final — P2a swaps the amplitude/elapsed source + file write in behind it.
- **Transcription enqueue → P2b**, **audio playback + tap-segment→seek → P2a/P2b**, **Summarize → P3** (nebula).

## Tests
`FakeNoteDao` + `NotesViewModelTest`: search over title/body/transcript, empty-query feed order, delete, detail load, detail save (new draft + **preserves recording fields & createdAt**, blank body → null), and every pure helper. Plain-JVM, matches the module idiom.

## Gates
EN-only (#1583) · a11y (TalkBack labels on glyphs/controls, `heading()` on section titles) · **never logs note content** (spec §3.7) · no local compile (CI is the gate).

Refs #1657

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new **Voice Notes** area with a notes list, recording flow, and note detail/editor screens.
  * Users can create, open, edit, delete, share, and search notes, with support for transcripts, summaries, tags, and audio playback.
  * Added a new bottom navigation tab for Notes.
* **Tests**
  * Updated and expanded navigation and notes-related tests to cover the new Notes tab and note management behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->