### PR TITLE
feat(notes): Voice Notes transcription — OfflineTranscriber + WorkManager (Phase 2b)

### DIFF
--- a/core-playback/build.gradle.kts
+++ b/core-playback/build.gradle.kts
@@ -161,6 +161,8 @@ dependencies {
 
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
+    // #1657 Phase 2b — WorkManager test harness for TranscriptionWorker.
+    testImplementation(libs.androidx.work.testing)
     // epic/plugin-dx B3 — VoiceEnginePluginContractTest (the voice twin
     // of the FictionSource contract kit) + its six engine retrofits.
     // #1504 — the kit now lives in :core-voice-testkit (split out of

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/di/PlaybackModule.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/di/PlaybackModule.kt
@@ -16,6 +16,8 @@ import `in`.jphe.storyvox.playback.cache.PcmRenderScheduler
 import `in`.jphe.storyvox.playback.cache.WorkManagerPcmRenderScheduler
 import `in`.jphe.storyvox.playback.transcribe.MicCaptureProcessor
 import `in`.jphe.storyvox.playback.transcribe.RecognizedWordSource
+import `in`.jphe.storyvox.playback.transcribe.offline.OfflineTranscriber
+import `in`.jphe.storyvox.playback.transcribe.offline.SherpaOfflineTranscriber
 import javax.inject.Singleton
 
 @Module
@@ -53,6 +55,17 @@ abstract class PlaybackModule {
     abstract fun bindRecognizedWordSource(
         impl: MicCaptureProcessor,
     ): RecognizedWordSource
+
+    /**
+     * Issue #1657 (Voice Notes, Phase 2b) — the offline batch transcriber for
+     * recorded notes (Whisper base int8). Self-gates on the downloaded model,
+     * so binding it is safe even before the model is present.
+     */
+    @Binds
+    @Singleton
+    abstract fun bindOfflineTranscriber(
+        impl: SherpaOfflineTranscriber,
+    ): OfflineTranscriber
 
     companion object {
         @Provides

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/transcribe/offline/AudioFileDecoder.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/transcribe/offline/AudioFileDecoder.kt
@@ -1,0 +1,104 @@
+package `in`.jphe.storyvox.playback.transcribe.offline
+
+import android.media.MediaCodec
+import android.media.MediaExtractor
+import android.media.MediaFormat
+import android.util.Log
+import `in`.jphe.storyvox.playback.transcribe.PcmDownsampler
+import java.io.ByteArrayOutputStream
+import java.nio.ByteBuffer
+
+/**
+ * Voice Notes (#1657, Phase 2b) — decodes a recorded audio file (AAC `.m4a`
+ * from Phase 2a) to **16 kHz mono float PCM** for the offline recognizer,
+ * via `MediaExtractor` + `MediaCodec` (no extra dependency).
+ *
+ * The whole file is decoded to interleaved PCM16 then resampled in **one**
+ * [PcmDownsampler.toMono16k] pass (resampling per output buffer would drift +
+ * add boundary artifacts). Transcription memory is then bounded by windowing
+ * the resulting buffer ([TranscriptionChunker]); a fully-streaming decode for
+ * multi-hour recordings is a tracked follow-up (typical notes are minutes).
+ *
+ * Device-validated wiring (same posture as `MicCaptureProcessor`): the codec
+ * loop is standard but its behaviour must be confirmed on-device. Any failure
+ * returns null → the caller keeps the audio + sets status FAILED, never crashes.
+ */
+object AudioFileDecoder {
+
+    private const val TAG = "AudioFileDecoder"
+    private const val DEQUEUE_TIMEOUT_US = 10_000L
+
+    /** Decode [path] to 16 kHz mono float PCM in `[-1, 1]`, or null on any failure. */
+    fun decodeToMono16k(path: String): FloatArray? = runCatching {
+        val extractor = MediaExtractor()
+        try {
+            extractor.setDataSource(path)
+            val trackIndex = (0 until extractor.trackCount).firstOrNull { i ->
+                extractor.getTrackFormat(i).getString(MediaFormat.KEY_MIME)?.startsWith("audio/") == true
+            } ?: error("no audio track in $path")
+            extractor.selectTrack(trackIndex)
+            val inputFormat = extractor.getTrackFormat(trackIndex)
+            val mime = inputFormat.getString(MediaFormat.KEY_MIME) ?: error("no mime")
+
+            val codec = MediaCodec.createDecoderByType(mime)
+            var srcRate = inputFormat.getInteger(MediaFormat.KEY_SAMPLE_RATE)
+            var channels = inputFormat.getInteger(MediaFormat.KEY_CHANNEL_COUNT)
+            codec.configure(inputFormat, null, null, 0)
+            codec.start()
+
+            val pcm = ByteArrayOutputStream()
+            val bufferInfo = MediaCodec.BufferInfo()
+            var sawInputEos = false
+            var sawOutputEos = false
+            try {
+                while (!sawOutputEos) {
+                    if (!sawInputEos) {
+                        val inIndex = codec.dequeueInputBuffer(DEQUEUE_TIMEOUT_US)
+                        if (inIndex >= 0) {
+                            val inBuf = codec.getInputBuffer(inIndex) ?: ByteBuffer.allocate(0)
+                            val sampleSize = extractor.readSampleData(inBuf, 0)
+                            if (sampleSize < 0) {
+                                codec.queueInputBuffer(inIndex, 0, 0, 0, MediaCodec.BUFFER_FLAG_END_OF_STREAM)
+                                sawInputEos = true
+                            } else {
+                                codec.queueInputBuffer(inIndex, 0, sampleSize, extractor.sampleTime, 0)
+                                extractor.advance()
+                            }
+                        }
+                    }
+                    val outIndex = codec.dequeueOutputBuffer(bufferInfo, DEQUEUE_TIMEOUT_US)
+                    when {
+                        outIndex >= 0 -> {
+                            val outBuf = codec.getOutputBuffer(outIndex)
+                            if (outBuf != null && bufferInfo.size > 0) {
+                                val chunk = ByteArray(bufferInfo.size)
+                                outBuf.position(bufferInfo.offset)
+                                outBuf.get(chunk, 0, bufferInfo.size)
+                                pcm.write(chunk)
+                            }
+                            codec.releaseOutputBuffer(outIndex, false)
+                            if (bufferInfo.flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM != 0) sawOutputEos = true
+                        }
+                        outIndex == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED -> {
+                            val f = codec.outputFormat
+                            srcRate = f.getInteger(MediaFormat.KEY_SAMPLE_RATE)
+                            channels = f.getInteger(MediaFormat.KEY_CHANNEL_COUNT)
+                        }
+                    }
+                }
+            } finally {
+                runCatching { codec.stop() }
+                runCatching { codec.release() }
+            }
+
+            val bytes = pcm.toByteArray()
+            if (bytes.isEmpty()) error("decoded 0 bytes from $path")
+            PcmDownsampler.toMono16k(bytes, srcRate, channels)
+        } finally {
+            runCatching { extractor.release() }
+        }
+    }.getOrElse {
+        Log.w(TAG, "decode failed for $path: ${it.message}")
+        null
+    }
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/transcribe/offline/OfflineTranscriber.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/transcribe/offline/OfflineTranscriber.kt
@@ -1,0 +1,85 @@
+package `in`.jphe.storyvox.playback.transcribe.offline
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Voice Notes (#1657, Phase 2b) — one punctuated transcript segment.
+ * Times are millis from the start of the recording.
+ */
+data class TranscriptionSegment(
+    val startMs: Long,
+    val endMs: Long,
+    val text: String,
+)
+
+/**
+ * Batch, file-based speech-to-text for recorded notes — the offline analog of
+ * the streaming teleprompter path ([`in`.jphe.storyvox.playback.transcribe.MicCaptureProcessor]).
+ *
+ * Loads a sherpa-onnx `OfflineRecognizer` (Whisper base int8 — EN+ES, native
+ * punctuation, javap-confirmed in the resolved 1.13.3 AAR, no dep bump) and
+ * decodes an audio file into punctuated [TranscriptionSegment]s, **streaming
+ * them as chunks complete** so a long meeting shows progress and stays within
+ * a bounded memory budget (one ~30 s window decoded at a time — never the whole
+ * hour at once).
+ *
+ * The recognizer + model are tens–hundreds of MB resident; the impl loads them
+ * for the duration of a [transcribe] and releases them at the end. Runs off the
+ * caller's thread (the impl uses `Dispatchers.Default`).
+ */
+interface OfflineTranscriber {
+
+    /**
+     * Decode [audioPath] to punctuated segments, emitting each as it completes.
+     * [languageHint] is a Whisper language code (`"en"`, `"es"`, …); `null`
+     * lets Whisper auto-detect. Throws / completes-empty on model-missing or
+     * decode failure — callers ([TranscriptionWorker]) map that to a status,
+     * never a crash.
+     */
+    fun transcribe(audioPath: String, languageHint: String?): Flow<TranscriptionSegment>
+
+    /** True once the offline model is downloaded and ready to load. */
+    fun isModelReady(): Boolean
+}
+
+/**
+ * Pure window arithmetic for chunked transcription — extracted so the
+ * bounded-memory chunking is unit-testable without sherpa or MediaCodec (the
+ * device-validated pieces). Splits [totalSamples] of 16 kHz mono PCM into
+ * consecutive windows of [windowSec] seconds; the last window is the remainder.
+ */
+object TranscriptionChunker {
+
+    /** Default Whisper decode window — matches Whisper's native 30 s receptive field. */
+    const val DEFAULT_WINDOW_SEC: Int = 30
+
+    /** A half-open sample range `[start, end)` plus its wall-clock offset. */
+    data class Window(val startSample: Int, val endSample: Int, val startMs: Long, val endMs: Long)
+
+    /**
+     * Windows covering `[0, totalSamples)`. Empty when [totalSamples] <= 0.
+     * `endMs` of the last window is clamped to the true audio length so a
+     * partial final window doesn't over-report duration.
+     */
+    fun windows(
+        totalSamples: Int,
+        sampleRate: Int = 16_000,
+        windowSec: Int = DEFAULT_WINDOW_SEC,
+    ): List<Window> {
+        if (totalSamples <= 0 || sampleRate <= 0 || windowSec <= 0) return emptyList()
+        val windowSamples = sampleRate.toLong() * windowSec
+        val out = ArrayList<Window>()
+        var start = 0
+        while (start < totalSamples) {
+            val end = minOf(start + windowSamples, totalSamples.toLong()).toInt()
+            out += Window(
+                startSample = start,
+                endSample = end,
+                startMs = start.toLong() * 1000 / sampleRate,
+                endMs = end.toLong() * 1000 / sampleRate,
+            )
+            start = end
+        }
+        return out
+    }
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/transcribe/offline/SherpaOfflineTranscriber.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/transcribe/offline/SherpaOfflineTranscriber.kt
@@ -1,0 +1,104 @@
+package `in`.jphe.storyvox.playback.transcribe.offline
+
+import android.util.Log
+import com.k2fsa.sherpa.onnx.FeatureConfig
+import com.k2fsa.sherpa.onnx.OfflineModelConfig
+import com.k2fsa.sherpa.onnx.OfflineRecognizer
+import com.k2fsa.sherpa.onnx.OfflineRecognizerConfig
+import com.k2fsa.sherpa.onnx.OfflineWhisperModelConfig
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+
+/**
+ * Voice Notes (#1657, Phase 2b) — the sherpa-onnx `OfflineRecognizer`
+ * implementation of [OfflineTranscriber] (Whisper base int8; javap-confirmed in
+ * the resolved 1.13.3 AAR — no dependency bump). Filesystem-path model loading,
+ * exactly like `MicCaptureProcessor`'s streaming `OnlineRecognizer(config = …)`.
+ *
+ * Decodes the file to 16 kHz mono float ([AudioFileDecoder]), then transcribes
+ * it in [TranscriptionChunker] windows — one ~30 s window decoded at a time,
+ * emitting a punctuated [TranscriptionSegment] per window so a long recording
+ * streams progress within a bounded sherpa memory budget. The recognizer +
+ * model are released when the flow completes or is cancelled.
+ *
+ * Device-validated wiring (per `MicCaptureProcessor`'s posture): the config is
+ * against the verified 1.13.3 API but decode latency / accuracy must be
+ * confirmed on a device. `numThreads`, `decodingMethod`, tail padding are left
+ * at sherpa defaults for now.
+ */
+@Singleton
+class SherpaOfflineTranscriber @Inject constructor(
+    private val modelProvider: TranscriptionModelProvider,
+) : OfflineTranscriber {
+
+    override fun isModelReady(): Boolean = modelProvider.isReady()
+
+    override fun transcribe(audioPath: String, languageHint: String?): Flow<TranscriptionSegment> = flow {
+        val model = modelProvider.readyModel()
+            ?: error("offline transcription model not downloaded")
+        val pcm = AudioFileDecoder.decodeToMono16k(audioPath)
+            ?: error("could not decode audio: $audioPath")
+
+        val recognizer = buildRecognizer(model, languageHint)
+            ?: error("OfflineRecognizer init failed")
+        try {
+            for (window in TranscriptionChunker.windows(pcm.size, SAMPLE_RATE)) {
+                currentCoroutineContext().ensureActive() // honor cancellation between windows
+                val samples = pcm.copyOfRange(window.startSample, window.endSample)
+                val stream = recognizer.createStream()
+                val text = try {
+                    stream.acceptWaveform(samples, SAMPLE_RATE)
+                    recognizer.decode(stream)
+                    recognizer.getResult(stream).text.trim()
+                } finally {
+                    stream.release()
+                }
+                if (text.isNotEmpty()) {
+                    emit(TranscriptionSegment(window.startMs, window.endMs, text))
+                }
+            }
+        } finally {
+            recognizer.release()
+        }
+    }.flowOn(Dispatchers.Default) // CPU-bound inference off the collector's thread (#585)
+
+    private fun buildRecognizer(model: OfflineAsrModel, languageHint: String?): OfflineRecognizer? = try {
+        OfflineRecognizer(
+            config = OfflineRecognizerConfig(
+                featConfig = FeatureConfig(sampleRate = SAMPLE_RATE, featureDim = FEATURE_DIM),
+                modelConfig = OfflineModelConfig(
+                    whisper = OfflineWhisperModelConfig(
+                        encoder = model.encoder,
+                        decoder = model.decoder,
+                        // "" → Whisper auto-detects the language.
+                        language = languageHint ?: "",
+                        task = "transcribe",
+                    ),
+                    tokens = model.tokens,
+                    numThreads = NUM_THREADS,
+                ),
+            ),
+        )
+    } catch (t: Throwable) {
+        Log.w(TAG, "OfflineRecognizer init failed: ${t.message}")
+        null
+    }
+
+    private companion object {
+        const val TAG = "SherpaOfflineTranscriber"
+
+        /** Whisper (like sherpa's streaming models) expects 16 kHz mono. */
+        const val SAMPLE_RATE = 16_000
+
+        /** Kaldi-style fbank feature dimension. */
+        const val FEATURE_DIM = 80
+
+        const val NUM_THREADS = 2
+    }
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/transcribe/offline/TranscriptionModelProvider.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/transcribe/offline/TranscriptionModelProvider.kt
@@ -1,0 +1,149 @@
+package `in`.jphe.storyvox.playback.transcribe.offline
+
+import android.content.Context
+import androidx.annotation.VisibleForTesting
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.File
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.coroutines.cancellation.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+/**
+ * Voice Notes (#1657, Phase 2b) — owns the on-device **offline** Whisper model
+ * that backs [SherpaOfflineTranscriber]. Mirrors
+ * [AsrModelProvider][`in`.jphe.storyvox.playback.transcribe.AsrModelProvider]'s
+ * download-to-disk + load-by-path pattern, but in a **separate** cache dir
+ * (`filesDir/asr-offline/<MODEL_ID>/`) so it never collides with the streaming
+ * teleprompter model.
+ *
+ * Default: **Whisper base int8** (multilingual — EN+ES + native punctuation,
+ * MIT), the only packaged option meeting Candela's bilingual bar (nebula's
+ * model research). Downloaded on first use (~200 MB — too big to bundle).
+ *
+ * ### URLs/sizes — CONFIRM before release (#1657)
+ * The [SPEC] host + filenames follow the csukuangfj HuggingFace whisper layout
+ * and the byte sizes are ballpark (nebula flagged them). A wrong URL surfaces
+ * as [DownloadProgress.Failed] → the note simply stays `PENDING` (graceful
+ * degrade), never a crash — same contract as `AsrModelProvider`. Verify the
+ * exact int8 asset names + sizes on-device before shipping a storage budget.
+ */
+@Singleton
+class TranscriptionModelProvider @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+    @VisibleForTesting
+    internal var http: OkHttpClient = OkHttpClient.Builder().build()
+
+    private val modelDir: File get() = File(context.filesDir, "asr-offline/$MODEL_ID")
+
+    /** True once every model file is present and non-empty. */
+    fun isReady(): Boolean = SPEC.all { f ->
+        val local = File(modelDir, f.localName)
+        local.exists() && local.length() > 0L
+    }
+
+    /** Absolute paths for the recognizer, or null if not fully downloaded. */
+    fun readyModel(): OfflineAsrModel? {
+        if (!isReady()) return null
+        fun path(name: String) = File(modelDir, name).absolutePath
+        return OfflineAsrModel(encoder = path(ENCODER), decoder = path(DECODER), tokens = path(TOKENS))
+    }
+
+    /** Stream a download of the model (mirrors AsrModelProvider). Idempotent. */
+    fun download(): Flow<DownloadProgress> = flow {
+        emit(DownloadProgress.Resolving)
+        if (isReady()) { emit(DownloadProgress.Done); return@flow }
+        modelDir.mkdirs()
+        val total = SPEC.sumOf { it.approxBytes }
+        var done = 0L
+        try {
+            for (f in SPEC) {
+                val target = File(modelDir, f.localName)
+                if (target.exists() && target.length() > 0L) {
+                    done += f.approxBytes
+                    emit(DownloadProgress.Downloading(done, total))
+                    continue
+                }
+                val base = done
+                downloadFile(f.url, target) { read -> emit(DownloadProgress.Downloading(base + read, total)) }
+                done += f.approxBytes
+            }
+            emit(DownloadProgress.Done)
+        } catch (ce: CancellationException) {
+            throw ce
+        } catch (t: Throwable) {
+            emit(DownloadProgress.Failed(t.message ?: t.javaClass.simpleName))
+        }
+    }.flowOn(Dispatchers.IO)
+
+    private suspend fun downloadFile(url: String, target: File, onBytes: suspend (Long) -> Unit) {
+        val part = File(target.parentFile, target.name + ".part")
+        http.newCall(Request.Builder().url(url).build()).execute().use { resp ->
+            if (!resp.isSuccessful) error("HTTP ${resp.code} for $url")
+            val body = resp.body ?: error("empty body for $url")
+            body.byteStream().use { input ->
+                part.outputStream().use { output ->
+                    val buf = ByteArray(64 * 1024)
+                    var read = 0L
+                    while (true) {
+                        val n = input.read(buf)
+                        if (n < 0) break
+                        output.write(buf, 0, n)
+                        read += n
+                        onBytes(read)
+                    }
+                }
+            }
+        }
+        if (!part.renameTo(target)) { part.copyTo(target, overwrite = true); part.delete() }
+    }
+
+    private data class Asset(val url: String, val localName: String, val approxBytes: Long)
+
+    /** Download progress frames (mirrors AsrModelProvider.DownloadProgress). */
+    sealed interface DownloadProgress {
+        data object Resolving : DownloadProgress
+        data class Downloading(val bytesRead: Long, val totalBytes: Long) : DownloadProgress
+        data object Done : DownloadProgress
+        data class Failed(val reason: String) : DownloadProgress
+    }
+
+    companion object {
+        /** Bump if the model is swapped — isolates the on-disk cache dir. */
+        const val MODEL_ID: String = "whisper-base-int8-multilingual"
+
+        private const val ENCODER = "base-encoder.int8.onnx"
+        private const val DECODER = "base-decoder.int8.onnx"
+        private const val TOKENS = "base-tokens.txt"
+
+        /** Ballpark (nebula-flagged) — confirm before a storage budget. */
+        const val APPROX_TOTAL_MB: Int = 200
+
+        // csukuangfj HuggingFace multilingual whisper-base layout — CONFIRM on-device (see kdoc).
+        private const val HOST =
+            "https://huggingface.co/csukuangfj/sherpa-onnx-whisper-base/resolve/main"
+
+        private val SPEC: List<Asset> = listOf(
+            Asset("$HOST/$ENCODER", ENCODER, 100_000_000L),
+            Asset("$HOST/$DECODER", DECODER, 100_000_000L),
+            Asset("$HOST/$TOKENS", TOKENS, 500_000L),
+        )
+    }
+}
+
+/**
+ * Absolute paths to a downloaded Whisper model (encoder + decoder + tokens —
+ * no joiner, unlike the streaming transducer). Produced by
+ * [TranscriptionModelProvider.readyModel], consumed by [SherpaOfflineTranscriber].
+ */
+data class OfflineAsrModel(
+    val encoder: String,
+    val decoder: String,
+    val tokens: String,
+)

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/transcribe/offline/TranscriptionScheduler.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/transcribe/offline/TranscriptionScheduler.kt
@@ -1,0 +1,48 @@
+package `in`.jphe.storyvox.playback.transcribe.offline
+
+import android.content.Context
+import androidx.work.BackoffPolicy
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkRequest
+import androidx.work.workDataOf
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Voice Notes (#1657, Phase 2b) — enqueues / cancels the durable
+ * [TranscriptionWorker] for a note. Injected by whoever creates a recording
+ * (Phase 2a) or retries from the UI (Phase 4); keeps WorkManager wiring out of
+ * those callers.
+ *
+ * Unique-per-note (`KEEP`) so re-enqueuing a note already queued/running is a
+ * no-op rather than a duplicate transcription. Exponential backoff for the
+ * worker's retryable failures (model-load / decode transients).
+ */
+@Singleton
+class TranscriptionScheduler @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+    fun enqueue(noteId: String) {
+        val request = OneTimeWorkRequestBuilder<TranscriptionWorker>()
+            .setInputData(workDataOf(TranscriptionWorker.KEY_NOTE_ID to noteId))
+            .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, WorkRequest.MIN_BACKOFF_MILLIS, TimeUnit.MILLISECONDS)
+            .build()
+        WorkManager.getInstance(context)
+            .enqueueUniqueWork(workName(noteId), ExistingWorkPolicy.KEEP, request)
+    }
+
+    /** Cancel an in-flight/queued transcription (worker resets the note to PENDING). */
+    fun cancel(noteId: String) {
+        WorkManager.getInstance(context).cancelUniqueWork(workName(noteId))
+    }
+
+    private fun workName(noteId: String): String = "$WORK_PREFIX$noteId"
+
+    companion object {
+        const val WORK_PREFIX: String = "notes-transcribe-"
+    }
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/transcribe/offline/TranscriptionWorker.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/transcribe/offline/TranscriptionWorker.kt
@@ -1,0 +1,136 @@
+package `in`.jphe.storyvox.playback.transcribe.offline
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.ForegroundInfo
+import androidx.work.WorkerParameters
+import `in`.jphe.storyvox.playback.R as PlaybackR
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import `in`.jphe.storyvox.data.notes.NoteEntity
+import `in`.jphe.storyvox.data.notes.NotesRepository
+import `in`.jphe.storyvox.data.notes.TranscriptionStatus
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.withContext
+
+/**
+ * Voice Notes (#1657, Phase 2b) — durable, background transcription of a
+ * recorded note. A **`WorkManager` job backed by a foreground service** (not a
+ * bare coroutine): a 1 h meeting must survive app backgrounding / process death,
+ * so it runs under an FGS and is resumable + cancellable (spec §3.2, §4).
+ *
+ * Flow: read the note → if no audio or model-not-downloaded, leave status
+ * `PENDING` and succeed (Phase 4 offers the download); else status
+ * `RUNNING` → stream punctuated segments from [OfflineTranscriber] into the
+ * transcript **as they complete** (bounded memory — text only) → `DONE`.
+ * Failure → `FAILED` + retry with backoff (capped); deliberate cancel →
+ * back to `PENDING`. The audio + any manual body are always retained.
+ *
+ * Mirrors `ChapterRenderJob`'s `@HiltWorker` + `DATA_SYNC` FGS shape.
+ */
+@HiltWorker
+class TranscriptionWorker @AssistedInject constructor(
+    @Assisted private val appContext: Context,
+    @Assisted params: WorkerParameters,
+    private val notes: NotesRepository,
+    private val transcriber: OfflineTranscriber,
+) : CoroutineWorker(appContext, params) {
+
+    override suspend fun doWork(): Result {
+        val noteId = inputData.getString(KEY_NOTE_ID) ?: return Result.failure()
+        val note = notes.get(noteId) ?: return Result.success() // deleted mid-flight → nothing to do
+        val audioPath = note.audioPath ?: return Result.success() // typed note → no transcription
+
+        if (!transcriber.isModelReady()) {
+            // Keep the audio; leave PENDING so a later download can re-enqueue.
+            Log.i(TAG, "model not ready — leaving note $noteId PENDING")
+            return Result.success()
+        }
+
+        runCatching { setForeground(buildForegroundInfo()) } // survive backgrounding
+        writeStatus(noteId, TranscriptionStatus.RUNNING)
+
+        return try {
+            val sb = StringBuilder()
+            transcriber.transcribe(audioPath, note.transcriptLang).collect { seg ->
+                if (seg.text.isBlank()) return@collect
+                if (sb.isNotEmpty()) sb.append(' ')
+                sb.append(seg.text.trim())
+                writeTranscript(noteId, sb.toString(), TranscriptionStatus.RUNNING)
+            }
+            writeTranscript(noteId, sb.toString(), TranscriptionStatus.DONE)
+            Result.success()
+        } catch (ce: CancellationException) {
+            // Deliberate cancel — reset to PENDING off the cancelled scope.
+            withContext(NonCancellable) { writeStatus(noteId, TranscriptionStatus.PENDING) }
+            throw ce
+        } catch (t: Throwable) {
+            Log.w(TAG, "transcription failed for $noteId: ${t.message}")
+            writeStatus(noteId, TranscriptionStatus.FAILED)
+            if (runAttemptCount + 1 >= MAX_ATTEMPTS) Result.failure() else Result.retry()
+        }
+    }
+
+    /** Re-read then copy so a concurrent body/title edit isn't clobbered. */
+    private suspend fun writeStatus(noteId: String, status: TranscriptionStatus) {
+        runCatching {
+            notes.get(noteId)?.let { notes.upsert(it.copy(transcriptionStatus = status, updatedAt = now())) }
+        }
+    }
+
+    private suspend fun writeTranscript(noteId: String, transcript: String, status: TranscriptionStatus) {
+        runCatching {
+            notes.get(noteId)?.let {
+                notes.upsert(
+                    it.copy(
+                        transcript = transcript,
+                        transcriptLang = it.transcriptLang,
+                        transcriptionStatus = status,
+                        updatedAt = now(),
+                    ),
+                )
+            }
+        }
+    }
+
+    private fun now(): Long = System.currentTimeMillis()
+
+    private fun buildForegroundInfo(): ForegroundInfo {
+        val nm = appContext.getSystemService(NotificationManager::class.java)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && nm?.getNotificationChannel(CHANNEL_ID) == null) {
+            nm?.createNotificationChannel(
+                NotificationChannel(CHANNEL_ID, CHANNEL_NAME, NotificationManager.IMPORTANCE_LOW),
+            )
+        }
+        val notif: Notification = NotificationCompat.Builder(appContext, CHANNEL_ID)
+            .setSmallIcon(PlaybackR.drawable.ic_storyvox_notif)
+            .setContentTitle(appContext.getString(PlaybackR.string.transcription_notif_title))
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setOngoing(true)
+            .build()
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            ForegroundInfo(NOTIFICATION_ID, notif, ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
+        } else {
+            ForegroundInfo(NOTIFICATION_ID, notif)
+        }
+    }
+
+    companion object {
+        const val KEY_NOTE_ID = "noteId"
+        private const val TAG = "TranscriptionWorker"
+        private const val MAX_ATTEMPTS = 3
+        private const val CHANNEL_ID = "notes-transcription"
+        private const val CHANNEL_NAME = "Note transcription"
+        private const val NOTIFICATION_ID = 0x0107 // #1657
+    }
+}

--- a/core-playback/src/main/res/values/strings.xml
+++ b/core-playback/src/main/res/values/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- core-playback user-facing strings. EN-only per #1583. -->
+<resources>
+    <!-- Voice Notes (#1657, Phase 2b) — foreground-service notification shown
+         while a recorded note is being transcribed on-device. -->
+    <string name="transcription_notif_title">Transcribing note…</string>
+</resources>

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/transcribe/offline/TranscriptionChunkerTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/transcribe/offline/TranscriptionChunkerTest.kt
@@ -1,0 +1,59 @@
+package `in`.jphe.storyvox.playback.transcribe.offline
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Voice Notes (#1657, Phase 2b) — pure window arithmetic for chunked
+ * transcription (bounded memory). No sherpa / MediaCodec — the device parts.
+ */
+class TranscriptionChunkerTest {
+
+    @Test
+    fun empty_forNonPositiveInputs() {
+        assertTrue(TranscriptionChunker.windows(0).isEmpty())
+        assertTrue(TranscriptionChunker.windows(-5).isEmpty())
+        assertTrue(TranscriptionChunker.windows(16_000, sampleRate = 0).isEmpty())
+        assertTrue(TranscriptionChunker.windows(16_000, windowSec = 0).isEmpty())
+    }
+
+    @Test
+    fun exactMultiple_producesFullContiguousWindows() {
+        val w = TranscriptionChunker.windows(totalSamples = 48_000, sampleRate = 16_000, windowSec = 1)
+        assertEquals(3, w.size)
+        assertEquals(listOf(0, 16_000, 32_000), w.map { it.startSample })
+        assertEquals(listOf(16_000, 32_000, 48_000), w.map { it.endSample })
+        assertEquals(listOf(0L, 1000L, 2000L), w.map { it.startMs })
+        assertEquals(listOf(1000L, 2000L, 3000L), w.map { it.endMs })
+    }
+
+    @Test
+    fun remainder_lastWindowIsPartial_andEndMsClampedToRealLength() {
+        val w = TranscriptionChunker.windows(totalSamples = 40_000, sampleRate = 16_000, windowSec = 1)
+        assertEquals(3, w.size)
+        assertEquals(32_000, w.last().startSample)
+        assertEquals(40_000, w.last().endSample)
+        assertEquals(2500L, w.last().endMs) // 40000 / 16000 s = 2.5 s, not a full 3 s
+    }
+
+    @Test
+    fun singleShortWindow_smallerThanWindowSize() {
+        val w = TranscriptionChunker.windows(totalSamples = 8_000, sampleRate = 16_000, windowSec = 30)
+        assertEquals(1, w.size)
+        assertEquals(0, w.first().startSample)
+        assertEquals(8_000, w.first().endSample)
+        assertEquals(0L, w.first().startMs)
+        assertEquals(500L, w.first().endMs)
+    }
+
+    @Test
+    fun windowsCoverEverythingContiguously() {
+        val w = TranscriptionChunker.windows(100_000, 16_000, 1)
+        assertEquals(0, w.first().startSample)
+        assertEquals(100_000, w.last().endSample)
+        for (i in 1 until w.size) {
+            assertEquals("window $i starts where ${i - 1} ends", w[i - 1].endSample, w[i].startSample)
+        }
+    }
+}

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/transcribe/offline/TranscriptionWorkerTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/transcribe/offline/TranscriptionWorkerTest.kt
@@ -1,0 +1,147 @@
+package `in`.jphe.storyvox.playback.transcribe.offline
+
+import android.content.Context
+import androidx.work.ListenableWorker
+import androidx.work.WorkerFactory
+import androidx.work.WorkerParameters
+import androidx.work.testing.TestListenableWorkerBuilder
+import androidx.work.workDataOf
+import `in`.jphe.storyvox.data.notes.NoteDao
+import `in`.jphe.storyvox.data.notes.NoteEntity
+import `in`.jphe.storyvox.data.notes.NotesRepository
+import `in`.jphe.storyvox.data.notes.TranscriptionStatus
+import java.io.File
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+/**
+ * Voice Notes (#1657, Phase 2b) — [TranscriptionWorker] status transitions via
+ * the WorkManager test harness, with a fake [OfflineTranscriber] and a
+ * fake-DAO-backed real [NotesRepository] (no Room, no sherpa). Covers the
+ * PENDING→RUNNING→DONE happy path, model-not-ready (stays PENDING), decode
+ * failure (FAILED + retry), and the typed-note no-op.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class TranscriptionWorkerTest {
+
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private lateinit var context: Context
+    private lateinit var notes: NotesRepository
+
+    @Before
+    fun setUp() {
+        context = RuntimeEnvironment.getApplication()
+        notes = NotesRepository(FakeNoteDao(), tmp.newFolder("recordings"))
+    }
+
+    private fun worker(transcriber: OfflineTranscriber): TranscriptionWorker =
+        TestListenableWorkerBuilder<TranscriptionWorker>(context)
+            .setInputData(workDataOf(TranscriptionWorker.KEY_NOTE_ID to NOTE_ID))
+            .setWorkerFactory(object : WorkerFactory() {
+                override fun createWorker(
+                    appContext: Context,
+                    workerClassName: String,
+                    workerParameters: WorkerParameters,
+                ): ListenableWorker = TranscriptionWorker(appContext, workerParameters, notes, transcriber)
+            })
+            .build()
+
+    @Test
+    fun modelNotReady_leavesNotePending_withNoTranscript() = runTest {
+        notes.upsert(note(TranscriptionStatus.PENDING, audioPath = "/x.m4a"))
+
+        val result = worker(FakeTranscriber(ready = false)).doWork()
+
+        assertTrue(result is ListenableWorker.Result.Success)
+        val n = notes.get(NOTE_ID)!!
+        assertEquals(TranscriptionStatus.PENDING, n.transcriptionStatus)
+        assertNull(n.transcript)
+    }
+
+    @Test
+    fun happyPath_streamsJoinedTranscript_andMarksDone() = runTest {
+        notes.upsert(note(TranscriptionStatus.PENDING, audioPath = "/x.m4a"))
+
+        val result = worker(
+            FakeTranscriber(ready = true, segments = listOf(seg("Hello."), seg("World."))),
+        ).doWork()
+
+        assertTrue(result is ListenableWorker.Result.Success)
+        val n = notes.get(NOTE_ID)!!
+        assertEquals(TranscriptionStatus.DONE, n.transcriptionStatus)
+        assertEquals("Hello. World.", n.transcript)
+    }
+
+    @Test
+    fun decodeFailure_marksFailed_andRetriesWhileUnderCap() = runTest {
+        notes.upsert(note(TranscriptionStatus.PENDING, audioPath = "/x.m4a"))
+
+        val result = worker(
+            FakeTranscriber(ready = true, error = RuntimeException("decode boom")),
+        ).doWork()
+
+        assertTrue(result is ListenableWorker.Result.Retry)
+        assertEquals(TranscriptionStatus.FAILED, notes.get(NOTE_ID)!!.transcriptionStatus)
+    }
+
+    @Test
+    fun typedNoteWithNoAudio_isNoOp() = runTest {
+        notes.upsert(note(TranscriptionStatus.NONE, audioPath = null))
+
+        val result = worker(FakeTranscriber(ready = true)).doWork()
+
+        assertTrue(result is ListenableWorker.Result.Success)
+        assertEquals(TranscriptionStatus.NONE, notes.get(NOTE_ID)!!.transcriptionStatus)
+    }
+
+    // ── Fakes / helpers ─────────────────────────────────────────────────
+
+    private fun note(status: TranscriptionStatus, audioPath: String?) = NoteEntity(
+        id = NOTE_ID, createdAt = 0L, updatedAt = 0L, audioPath = audioPath, transcriptionStatus = status,
+    )
+
+    private fun seg(text: String) = TranscriptionSegment(startMs = 0L, endMs = 1000L, text = text)
+
+    private class FakeTranscriber(
+        private val ready: Boolean,
+        private val segments: List<TranscriptionSegment> = emptyList(),
+        private val error: Throwable? = null,
+    ) : OfflineTranscriber {
+        override fun isModelReady(): Boolean = ready
+        override fun transcribe(audioPath: String, languageHint: String?): Flow<TranscriptionSegment> =
+            if (error != null) flow { throw error } else segments.asFlow()
+    }
+
+    private class FakeNoteDao : NoteDao {
+        private val rows = MutableStateFlow<List<NoteEntity>>(emptyList())
+        override suspend fun upsert(note: NoteEntity) {
+            rows.value = rows.value.filterNot { it.id == note.id } + note
+        }
+        override fun observeAll(): Flow<List<NoteEntity>> = rows
+        override suspend fun get(id: String): NoteEntity? = rows.value.find { it.id == id }
+        override suspend fun all(): List<NoteEntity> = rows.value
+        override suspend fun delete(id: String) { rows.value = rows.value.filterNot { it.id == id } }
+        override fun search(query: String): Flow<List<NoteEntity>> = rows
+    }
+
+    companion object {
+        private const val NOTE_ID = "n1"
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -186,6 +186,7 @@ androidx-room-testing = { module = "androidx.room:room-testing", version.ref = "
 
 # WorkManager
 androidx-work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "work" }
+androidx-work-testing = { module = "androidx.work:work-testing", version.ref = "work" }
 
 # DataStore (settings)
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastore" }


### PR DESCRIPTION
## Voice Notes epic #1657 — **Phase 2b: transcription** (needs P1 #1658, merged)

Batch, on-device transcription of recorded notes. Branched off clean main (post-P1); streams punctuated segments into the real `NotesRepository`.

### What — all in `core-playback/.../transcribe/offline/`
- **`OfflineTranscriber`** + `TranscriptionSegment(startMs,endMs,text)`; pure **`TranscriptionChunker`** (~30 s windows → bounded sherpa memory) — unit-tested.
- **`AudioFileDecoder`** — `.m4a` (AAC) → 16 kHz mono float via `MediaExtractor`/`MediaCodec` + reuse of `PcmDownsampler` (one resample pass, no boundary drift).
- **`SherpaOfflineTranscriber`** — `OfflineRecognizer(config=…)` filesystem path-load, **Whisper base int8** (javap-confirmed in the resolved sherpa-onnx 1.13.3 AAR — **no dependency bump**); mirrors `MicCaptureProcessor`'s seam posture (device-validated wiring).
- **`TranscriptionModelProvider`** — mirrors `AsrModelProvider` download-to-disk in a separate `asr-offline/` cache. Model URLs/sizes flagged **CONFIRM-before-release**; a bad URL degrades gracefully (note stays `PENDING`), never crashes.
- **`TranscriptionWorker`** — `@HiltWorker` + **`FOREGROUND_SERVICE_TYPE_DATA_SYNC`** FGS (perm already declared — no new permission): `PENDING→RUNNING→`(transcript streamed to the store)`→DONE/FAILED`; resumable, cancellable (cancel → `PENDING` via a `NonCancellable` write), retry-capped. **`TranscriptionScheduler`** enqueues unique-per-note. `@Binds OfflineTranscriber` in `PlaybackModule`.
- **Never logs note content** — only audio paths / ids / error messages (§3.7).

### Tests
- `TranscriptionChunkerTest` (pure JVM) — window boundaries + ms offsets + partial-tail clamping.
- `TranscriptionWorkerTest` (WorkManager `TestListenableWorkerBuilder` + Robolectric, fake DAO + fake transcriber) — model-not-ready→PENDING, happy→DONE + joined transcript, failure→FAILED + retry, typed-note no-op. (Added `androidx-work-testing` test dep.)

### Deviations (team-lead-approved)
1. **Worker in `core-playback`, not `feature`** — `feature` has no WorkManager; this is the right home next to `AudiobookExportJob`/`ChapterRenderJob`.
2. **Whole-file decode buffer** — transcription itself is windowed + bounded; fully-streaming decode for multi-hour recordings is a tracked follow-up.

### Verification
ubox0 pre-flight at branch tip: **`:app:assembleDebug` (Build APK gate) ✅** + **`:core-playback:testDebugUnitTest` (Test Compile gate + pure chunker run) ✅**. `git merge-tree` clean on current main.

Refs #1657

🤖 Generated with [Claude Code](https://claude.com/claude-code)