### PR TITLE
feat(notes): Voice Notes summarization — consent-gated LLM summary (Phase 3)

### DIFF
--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/notes/NoteDao.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/notes/NoteDao.kt
@@ -74,4 +74,14 @@ interface NoteDao {
             "ORDER BY updatedAt DESC",
     )
     fun search(query: String): Flow<List<NoteEntity>>
+
+    /**
+     * Voice Notes (#1657, Phase 3) — write ONLY the summary (+ updatedAt),
+     * never the whole row. A full-row upsert here would let a concurrent
+     * title/body edit clobber (or be clobbered by) the summary write — the
+     * lost-update class #1663 addresses for transcript/status. `summary` is a
+     * disjoint column, so this targeted UPDATE composes cleanly with those.
+     */
+    @Query("UPDATE note SET summary = :summary, updatedAt = :updatedAt WHERE id = :id")
+    suspend fun updateSummary(id: String, summary: String?, updatedAt: Long)
 }

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/notes/NotesRepository.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/notes/NotesRepository.kt
@@ -38,9 +38,9 @@ class NotesRepository @Inject constructor(
 
     /**
      * #1663 — column-scoped writes. Prefer these over [upsert] for in-place
-     * changes: the transcription worker and the detail-screen edit touch
-     * disjoint columns, so concurrent updates never clobber each other. Use
-     * [upsert] only to INSERT a new row (create/record).
+     * changes: the transcription worker, the detail-screen edit, and the summary
+     * write touch disjoint columns, so concurrent updates never clobber each
+     * other. Use [upsert] only to INSERT a new row (create/record).
      */
     suspend fun updateTranscription(
         id: String,
@@ -54,6 +54,14 @@ class NotesRepository @Inject constructor(
 
     suspend fun updateEdit(id: String, title: String, body: String?, tags: String, updatedAt: Long) =
         dao.updateEdit(id, title, body, tags, updatedAt)
+
+    /**
+     * Persist ONLY the AI summary (#1657, Phase 3) — column-scoped like the
+     * writes above, so it can't clobber a concurrent title/body edit nor be
+     * clobbered by one (unlike a full-row upsert). See [NoteDao.updateSummary].
+     */
+    suspend fun setSummary(id: String, summary: String?, updatedAt: Long) =
+        dao.updateSummary(id, summary, updatedAt)
 
     /**
      * Delete a note AND its recording. No-op if the id is absent. The row is

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/notes/NotesRepositoryTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/notes/NotesRepositoryTest.kt
@@ -119,5 +119,8 @@ class NotesRepositoryTest {
         override suspend fun updateEdit(id: String, title: String, body: String?, tags: String, updatedAt: Long) {
             rows.value = rows.value.map { if (it.id == id) it.copy(title = title, body = body, tags = tags, updatedAt = updatedAt) else it }
         }
+        override suspend fun updateSummary(id: String, summary: String?, updatedAt: Long) {
+            rows.value = rows.value.map { if (it.id == id) it.copy(summary = summary, updatedAt = updatedAt) else it }
+        }
     }
 }

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/di/LlmModule.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/di/LlmModule.kt
@@ -3,6 +3,8 @@ package `in`.jphe.storyvox.llm.di
 import `in`.jphe.storyvox.llm.LlmConfig
 import `in`.jphe.storyvox.llm.LlmConfigProvider
 import `in`.jphe.storyvox.llm.auth.AnthropicTeamsAuthApi
+import `in`.jphe.storyvox.llm.feature.DefaultSummarizeTranscriptUseCase
+import `in`.jphe.storyvox.llm.feature.SummarizeTranscriptUseCase
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -82,4 +84,13 @@ object LlmModule {
     @Singleton
     fun provideAnthropicTeamsAuthApi(@LlmHttp http: OkHttpClient): AnthropicTeamsAuthApi =
         AnthropicTeamsAuthApi(http)
+
+    /** Voice Notes (#1657, Phase 3) — bind the summarize use-case interface to
+     *  its default impl, so `NoteDetailViewModel` depends on the seam and tests
+     *  use a trivial fake (no `LlmRepository` construction). */
+    @Provides
+    @Singleton
+    fun provideSummarizeTranscriptUseCase(
+        impl: DefaultSummarizeTranscriptUseCase,
+    ): SummarizeTranscriptUseCase = impl
 }

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/feature/SummarizeTranscriptUseCase.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/feature/SummarizeTranscriptUseCase.kt
@@ -14,40 +14,44 @@ import kotlinx.coroutines.flow.flow
 
 /**
  * Voice Notes (#1657, Phase 3) — summarize a recording's transcript into a
- * title + key points + action items, via the existing provider-agnostic
- * [LlmRepository.stream]. A thin flow wrapper that mirrors [ChapterRecap]:
- * build a prompt, stream the response as text deltas.
+ * title + key points + action items, streamed from the active LLM provider.
  *
- * **Consent / privacy gate (spec §3.3):** summarization is the ONLY path that
- * sends note text off-device. It runs only when BOTH hold:
- *  1. the caller invokes it on an explicit user action (the "Summarize" tap, or
- *     an opt-in auto-summarize) — the tap *is* the consent; and
- *  2. an LLM provider is configured ([LlmConfig.provider] != null).
- * If no provider is configured it throws [LlmError.NotConfigured] and the
- * transcript is left untouched — nothing leaves the device.
+ * An **interface** (impl [DefaultSummarizeTranscriptUseCase]) so consumers
+ * (`NoteDetailViewModel`) depend on the abstraction and tests use a trivial
+ * hand-rolled fake — no `LlmRepository`/provider construction in the feature
+ * test (the same reason `PlaybackController` / `SettingsRepositoryUi` are seams).
  *
- * The summary language follows the transcript's `transcriptLang` (EN/ES), so a
- * Spanish memo gets a Spanish summary.
- *
- * NOTE: unlike [ChapterRecap], this does NOT gate on
- * [LlmConfig.sendChapterTextEnabled] — that toggle governs *chapter* text; a
- * note summary's consent is the explicit Summarize action itself.
+ * **Consent / privacy gate (spec §3.3):** summarizing is the ONLY path that
+ * sends note text off-device. Implementations run only when BOTH hold: the
+ * caller invokes it on an explicit user action (the "Summarize" tap *is* the
+ * consent), AND an LLM provider is configured — otherwise they throw
+ * [LlmError.NotConfigured] and the transcript is left untouched.
  */
-@Singleton
-class SummarizeTranscriptUseCase @Inject constructor(
-    private val llm: LlmRepository,
-    private val configFlow: Flow<LlmConfig>,
-) {
+interface SummarizeTranscriptUseCase {
     /**
-     * Stream a summary (title + key points + action items) of [transcript].
-     * Emits text deltas in arrival order; collect on a scope bound to a Cancel
-     * affordance (cancellation propagates through the flow into the LLM call).
-     * A blank transcript yields an empty flow (nothing to send).
+     * Stream a summary of [transcript] (text deltas, in order). A blank
+     * transcript yields an empty flow. The summary language follows
+     * [transcriptLang] (EN/ES).
      *
      * @throws LlmError.NotConfigured when no LLM provider is configured — the
      *   consent/provider gate; the transcript is not sent off-device.
      */
-    fun summarize(transcript: String, transcriptLang: String? = null): Flow<String> = flow {
+    fun summarize(transcript: String, transcriptLang: String? = null): Flow<String>
+}
+
+/**
+ * Default [SummarizeTranscriptUseCase] — a thin wrapper over
+ * [LlmRepository.stream] that mirrors [ChapterRecap]. Does NOT gate on
+ * [LlmConfig.sendChapterTextEnabled] (that toggle governs *chapter* text; a note
+ * summary's consent is the explicit Summarize action itself).
+ */
+@Singleton
+class DefaultSummarizeTranscriptUseCase @Inject constructor(
+    private val llm: LlmRepository,
+    private val configFlow: Flow<LlmConfig>,
+) : SummarizeTranscriptUseCase {
+
+    override fun summarize(transcript: String, transcriptLang: String?): Flow<String> = flow {
         val cfg = configFlow.first()
         if (cfg.provider == null) throw LlmError.NotConfigured(ProviderId.Claude)
         if (transcript.isBlank()) return@flow

--- a/core-llm/src/main/kotlin/in/jphe/storyvox/llm/feature/SummarizeTranscriptUseCase.kt
+++ b/core-llm/src/main/kotlin/in/jphe/storyvox/llm/feature/SummarizeTranscriptUseCase.kt
@@ -1,0 +1,103 @@
+package `in`.jphe.storyvox.llm.feature
+
+import `in`.jphe.storyvox.llm.LlmConfig
+import `in`.jphe.storyvox.llm.LlmError
+import `in`.jphe.storyvox.llm.LlmMessage
+import `in`.jphe.storyvox.llm.LlmRepository
+import `in`.jphe.storyvox.llm.ProviderId
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+
+/**
+ * Voice Notes (#1657, Phase 3) — summarize a recording's transcript into a
+ * title + key points + action items, via the existing provider-agnostic
+ * [LlmRepository.stream]. A thin flow wrapper that mirrors [ChapterRecap]:
+ * build a prompt, stream the response as text deltas.
+ *
+ * **Consent / privacy gate (spec §3.3):** summarization is the ONLY path that
+ * sends note text off-device. It runs only when BOTH hold:
+ *  1. the caller invokes it on an explicit user action (the "Summarize" tap, or
+ *     an opt-in auto-summarize) — the tap *is* the consent; and
+ *  2. an LLM provider is configured ([LlmConfig.provider] != null).
+ * If no provider is configured it throws [LlmError.NotConfigured] and the
+ * transcript is left untouched — nothing leaves the device.
+ *
+ * The summary language follows the transcript's `transcriptLang` (EN/ES), so a
+ * Spanish memo gets a Spanish summary.
+ *
+ * NOTE: unlike [ChapterRecap], this does NOT gate on
+ * [LlmConfig.sendChapterTextEnabled] — that toggle governs *chapter* text; a
+ * note summary's consent is the explicit Summarize action itself.
+ */
+@Singleton
+class SummarizeTranscriptUseCase @Inject constructor(
+    private val llm: LlmRepository,
+    private val configFlow: Flow<LlmConfig>,
+) {
+    /**
+     * Stream a summary (title + key points + action items) of [transcript].
+     * Emits text deltas in arrival order; collect on a scope bound to a Cancel
+     * affordance (cancellation propagates through the flow into the LLM call).
+     * A blank transcript yields an empty flow (nothing to send).
+     *
+     * @throws LlmError.NotConfigured when no LLM provider is configured — the
+     *   consent/provider gate; the transcript is not sent off-device.
+     */
+    fun summarize(transcript: String, transcriptLang: String? = null): Flow<String> = flow {
+        val cfg = configFlow.first()
+        if (cfg.provider == null) throw LlmError.NotConfigured(ProviderId.Claude)
+        if (transcript.isBlank()) return@flow
+
+        val userPrompt = buildString {
+            append("Summarize the following transcript.\n\n")
+            append(transcript.truncateForBudget(MAX_TRANSCRIPT_CHARS))
+        }
+        emitAll(
+            llm.stream(
+                messages = listOf(LlmMessage(LlmMessage.Role.user, userPrompt)),
+                systemPrompt = systemPrompt(transcriptLang),
+            ),
+        )
+    }
+
+    private fun systemPrompt(lang: String?): String =
+        BASE_SYSTEM_PROMPT.trimIndent().trim() + " " + languageInstruction(lang)
+
+    companion object {
+        /**
+         * Transcript truncation budget (~3k input tokens). Claude has ~200k of
+         * context; Ollama's default is ~8k, of which we leave room for the
+         * summary + scaffolding. 12k chars ≈ 3k tokens fits both.
+         */
+        const val MAX_TRANSCRIPT_CHARS: Int = 12_000
+
+        /** Summarizer persona — careful, won't invent, structured output. */
+        internal const val BASE_SYSTEM_PROMPT: String = """
+            You summarize a spoken-audio transcript (a voice memo or a meeting)
+            for someone who was not there. Using Markdown, output: a one-line
+            **Title**; then **Key points** as 3–7 concise bullets; then
+            **Action items** as bullets (omit that section entirely if there are
+            none). Base everything ONLY on the transcript — do not invent names,
+            numbers, dates, or commitments. Be concise and neutral.
+        """
+
+        /** Instruct the model to write in the transcript's language. */
+        internal fun languageInstruction(lang: String?): String =
+            when (lang?.lowercase()?.take(2)) {
+                null, "" -> "Write the summary in the same language as the transcript."
+                "en" -> "Write the summary in English."
+                "es" -> "Write the summary in Spanish."
+                else ->
+                    "Write the summary in the same language as the transcript " +
+                        "(BCP-47/ISO language code: $lang)."
+            }
+    }
+}
+
+private fun String.truncateForBudget(maxChars: Int): String =
+    if (length <= maxChars) this
+    else take(maxChars) + "\n[…truncated for AI context budget…]"

--- a/core-llm/src/test/kotlin/in/jphe/storyvox/llm/feature/SummarizeTranscriptUseCaseTest.kt
+++ b/core-llm/src/test/kotlin/in/jphe/storyvox/llm/feature/SummarizeTranscriptUseCaseTest.kt
@@ -47,7 +47,7 @@ class SummarizeTranscriptUseCaseTest {
             bedrock = fakeProvider.asBedrock(),
             teams = fakeProvider.asTeams(),
         )
-        return SummarizeTranscriptUseCase(llm = llm, configFlow = flowOf(LlmConfig(provider = provider)))
+        return DefaultSummarizeTranscriptUseCase(llm = llm, configFlow = flowOf(LlmConfig(provider = provider)))
     }
 
     @Test

--- a/core-llm/src/test/kotlin/in/jphe/storyvox/llm/feature/SummarizeTranscriptUseCaseTest.kt
+++ b/core-llm/src/test/kotlin/in/jphe/storyvox/llm/feature/SummarizeTranscriptUseCaseTest.kt
@@ -1,0 +1,192 @@
+package `in`.jphe.storyvox.llm.feature
+
+import `in`.jphe.storyvox.llm.LlmConfig
+import `in`.jphe.storyvox.llm.LlmError
+import `in`.jphe.storyvox.llm.LlmMessage
+import `in`.jphe.storyvox.llm.LlmRepository
+import `in`.jphe.storyvox.llm.ProbeResult
+import `in`.jphe.storyvox.llm.ProviderId
+import `in`.jphe.storyvox.llm.provider.AzureFoundryProvider
+import `in`.jphe.storyvox.llm.provider.BedrockProvider
+import `in`.jphe.storyvox.llm.provider.ClaudeApiProvider
+import `in`.jphe.storyvox.llm.provider.FakeStore
+import `in`.jphe.storyvox.llm.provider.OllamaProvider
+import `in`.jphe.storyvox.llm.provider.OpenAiApiProvider
+import `in`.jphe.storyvox.llm.provider.VertexProvider
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import okhttp3.OkHttpClient
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class SummarizeTranscriptUseCaseTest {
+
+    private val fakeProvider = FakeProvider()
+
+    private fun useCase(provider: ProviderId? = ProviderId.Claude): SummarizeTranscriptUseCase {
+        val llm = LlmRepository(
+            configFlow = flowOf(LlmConfig(provider = provider)),
+            claude = fakeProvider.asClaude(),
+            openAi = fakeProvider.asOpenAi(),
+            ollama = fakeProvider.asOllama(),
+            vertex = fakeProvider.asVertex(),
+            foundry = fakeProvider.asFoundry(),
+            bedrock = fakeProvider.asBedrock(),
+            teams = fakeProvider.asTeams(),
+        )
+        return SummarizeTranscriptUseCase(llm = llm, configFlow = flowOf(LlmConfig(provider = provider)))
+    }
+
+    @Test
+    fun `summarize streams provider tokens in order`() = runTest {
+        fakeProvider.tokens = listOf("**Title**\n", "- point one\n", "- point two")
+        val out = useCase().summarize("We shipped the thing and agreed to follow up Friday.").toList()
+        assertEquals("**Title**\n- point one\n- point two", out.joinToString(""))
+    }
+
+    @Test
+    fun `prompt asks for title, key points, action items and includes the transcript`() = runTest {
+        fakeProvider.tokens = listOf("ok")
+        val transcript = "Alice will send the report; Bob books the room."
+        useCase().summarize(transcript).toList()
+
+        val sys = fakeProvider.lastSystemPrompt.orEmpty()
+        assertTrue("system prompt asks for a Title", sys.contains("Title"))
+        assertTrue("system prompt asks for Key points", sys.contains("Key points"))
+        assertTrue("system prompt asks for Action items", sys.contains("Action items"))
+        assertTrue("system prompt forbids inventing", sys.contains("do not invent", ignoreCase = true))
+
+        val userMsg = fakeProvider.lastMessages!!.first { it.role == LlmMessage.Role.user }.content
+        assertTrue("user message carries the transcript", userMsg.contains(transcript))
+    }
+
+    @Test
+    fun `summary language follows the transcript language`() = runTest {
+        fakeProvider.tokens = listOf("ok")
+        useCase().summarize("Hola, esto es una prueba.", transcriptLang = "es").toList()
+        assertTrue(fakeProvider.lastSystemPrompt!!.contains("Spanish"))
+
+        useCase().summarize("Hello, this is a test.", transcriptLang = "en").toList()
+        assertTrue(fakeProvider.lastSystemPrompt!!.contains("English"))
+
+        // Unknown / null → defer to the model, don't force a language.
+        useCase().summarize("…", transcriptLang = null).toList()
+        assertTrue(fakeProvider.lastSystemPrompt!!.contains("same language"))
+    }
+
+    @Test
+    fun `throws NotConfigured and sends nothing when no provider is configured`() {
+        fakeProvider.tokens = listOf("should not be sent")
+        assertThrows(LlmError.NotConfigured::class.java) {
+            runBlocking { useCase(provider = null).summarize("secret transcript").toList() }
+        }
+        // Consent/provider gate: the transcript must never reach a provider.
+        assertNull("no provider call on the gate path", fakeProvider.lastMessages)
+    }
+
+    @Test
+    fun `blank transcript yields an empty flow and no provider call`() = runTest {
+        fakeProvider.tokens = listOf("should not be sent")
+        val out = useCase().summarize("   \n  ").toList()
+        assertTrue("empty flow for blank transcript", out.isEmpty())
+        assertNull("no provider call for blank transcript", fakeProvider.lastMessages)
+    }
+
+    @Test
+    fun `long transcript is truncated for the context budget`() = runTest {
+        fakeProvider.tokens = listOf("ok")
+        val huge = "word ".repeat(6_000) // ~30k chars, over the 12k budget
+        useCase().summarize(huge).toList()
+        val userMsg = fakeProvider.lastMessages!!.first { it.role == LlmMessage.Role.user }.content
+        assertTrue("truncation marker present", userMsg.contains("truncated for AI context budget"))
+        assertFalse("full transcript not sent", userMsg.length > 20_000)
+    }
+}
+
+/** Single-shape fake provider (mirrors ChapterRecapTest): one canned token list
+ *  for every id slot, capturing the last messages + system prompt. */
+private class FakeProvider {
+    var tokens: List<String> = emptyList()
+    var lastMessages: List<LlmMessage>? = null
+    var lastSystemPrompt: String? = null
+
+    private fun cannedStream(messages: List<LlmMessage>, systemPrompt: String?): Flow<String> {
+        lastMessages = messages
+        lastSystemPrompt = systemPrompt
+        return flowOf(*tokens.toTypedArray())
+    }
+
+    fun asClaude(): ClaudeApiProvider = object : ClaudeApiProvider(
+        http = OkHttpClient(), store = FakeStore(), configFlow = flowOf(LlmConfig()), json = Json,
+    ) {
+        override fun stream(messages: List<LlmMessage>, systemPrompt: String?, model: String?) =
+            cannedStream(messages, systemPrompt)
+        override suspend fun probe(): ProbeResult = ProbeResult.Ok
+    }
+
+    fun asOpenAi(): OpenAiApiProvider = object : OpenAiApiProvider(
+        http = OkHttpClient(), store = FakeStore(), configFlow = flowOf(LlmConfig()), json = Json,
+    ) {
+        override fun stream(messages: List<LlmMessage>, systemPrompt: String?, model: String?) =
+            cannedStream(messages, systemPrompt)
+        override suspend fun probe(): ProbeResult = ProbeResult.Ok
+    }
+
+    fun asOllama(): OllamaProvider = object : OllamaProvider(
+        http = OkHttpClient(), configFlow = flowOf(LlmConfig()), json = Json,
+    ) {
+        override fun stream(messages: List<LlmMessage>, systemPrompt: String?, model: String?) =
+            cannedStream(messages, systemPrompt)
+        override suspend fun probe(): ProbeResult = ProbeResult.Ok
+    }
+
+    fun asVertex(): VertexProvider = object : VertexProvider(
+        http = OkHttpClient(), store = FakeStore(), configFlow = flowOf(LlmConfig()), json = Json,
+        tokenSource = `in`.jphe.storyvox.llm.auth.GoogleOAuthTokenSource(OkHttpClient()),
+    ) {
+        override fun stream(messages: List<LlmMessage>, systemPrompt: String?, model: String?) =
+            cannedStream(messages, systemPrompt)
+        override suspend fun probe(): ProbeResult = ProbeResult.Ok
+    }
+
+    fun asFoundry(): AzureFoundryProvider = object : AzureFoundryProvider(
+        http = OkHttpClient(), store = FakeStore(), configFlow = flowOf(LlmConfig()), json = Json,
+    ) {
+        override fun stream(messages: List<LlmMessage>, systemPrompt: String?, model: String?) =
+            cannedStream(messages, systemPrompt)
+        override suspend fun probe(): ProbeResult = ProbeResult.Ok
+    }
+
+    fun asBedrock(): BedrockProvider = object : BedrockProvider(
+        http = OkHttpClient(), store = FakeStore(), configFlow = flowOf(LlmConfig()), json = Json,
+    ) {
+        override fun stream(messages: List<LlmMessage>, systemPrompt: String?, model: String?) =
+            cannedStream(messages, systemPrompt)
+        override suspend fun probe(): ProbeResult = ProbeResult.Ok
+    }
+
+    fun asTeams(): `in`.jphe.storyvox.llm.provider.AnthropicTeamsProvider =
+        object : `in`.jphe.storyvox.llm.provider.AnthropicTeamsProvider(
+            http = OkHttpClient(), store = FakeStore(), configFlow = flowOf(LlmConfig()),
+            authApi = `in`.jphe.storyvox.llm.auth.AnthropicTeamsAuthApi(OkHttpClient()),
+            authRepo = `in`.jphe.storyvox.llm.auth.AnthropicTeamsAuthRepository(FakeStore()),
+            json = Json,
+        ) {
+            override fun stream(messages: List<LlmMessage>, systemPrompt: String?, model: String?) =
+                cannedStream(messages, systemPrompt)
+            override suspend fun probe(): ProbeResult = ProbeResult.Ok
+        }
+}

--- a/core-llm/src/test/kotlin/in/jphe/storyvox/llm/feature/SummarizeTranscriptUseCaseTest.kt
+++ b/core-llm/src/test/kotlin/in/jphe/storyvox/llm/feature/SummarizeTranscriptUseCaseTest.kt
@@ -34,7 +34,7 @@ import org.robolectric.annotation.Config
 @Config(manifest = Config.NONE)
 class SummarizeTranscriptUseCaseTest {
 
-    private val fakeProvider = FakeProvider()
+    private val fakeProvider = FakeSummarizeProvider()
 
     private fun useCase(provider: ProviderId? = ProviderId.Claude): SummarizeTranscriptUseCase {
         val llm = LlmRepository(
@@ -118,7 +118,7 @@ class SummarizeTranscriptUseCaseTest {
 
 /** Single-shape fake provider (mirrors ChapterRecapTest): one canned token list
  *  for every id slot, capturing the last messages + system prompt. */
-private class FakeProvider {
+private class FakeSummarizeProvider {
     var tokens: List<String> = emptyList()
     var lastMessages: List<LlmMessage>? = null
     var lastSystemPrompt: String? = null

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/transcribe/offline/TranscriptionWorkerTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/transcribe/offline/TranscriptionWorkerTest.kt
@@ -148,6 +148,9 @@ class TranscriptionWorkerTest {
         override suspend fun updateEdit(id: String, title: String, body: String?, tags: String, updatedAt: Long) {
             rows.value = rows.value.map { if (it.id == id) it.copy(title = title, body = body, tags = tags, updatedAt = updatedAt) else it }
         }
+        override suspend fun updateSummary(id: String, summary: String?, updatedAt: Long) {
+            rows.value = rows.value.map { if (it.id == id) it.copy(summary = summary, updatedAt = updatedAt) else it }
+        }
     }
 
     companion object {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/notes/ui/NoteDetailScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/notes/ui/NoteDetailScreen.kt
@@ -87,7 +87,9 @@ fun NoteDetailScreen(
                 NoteDetailEvent.Saved -> snackbarHostState.showSnackbar("Saved")
                 NoteDetailEvent.Deleted -> onExit()
                 NoteDetailEvent.SummarizeUnavailable ->
-                    snackbarHostState.showSnackbar("Summaries arrive in a later update.")
+                    snackbarHostState.showSnackbar(
+                        "Couldn't summarize — set up an AI provider in Settings, then try again.",
+                    )
                 is NoteDetailEvent.Share -> {
                     val send = Intent(Intent.ACTION_SEND).apply {
                         type = "text/plain"

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/notes/ui/NotesViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/notes/ui/NotesViewModel.kt
@@ -10,6 +10,7 @@ import `in`.jphe.storyvox.data.notes.NotesRepository
 import `in`.jphe.storyvox.data.notes.TranscriptionStatus
 import `in`.jphe.storyvox.llm.feature.SummarizeTranscriptUseCase
 import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -255,29 +256,27 @@ class NoteDetailViewModel @Inject constructor(
      */
     fun summarize() {
         val s = _uiState.value
-        val transcript = s.transcript
-        if (s.isSummarizing || transcript.isNullOrBlank()) return
+        val transcript = s.transcript?.takeIf { it.isNotBlank() }
+        if (s.isSummarizing || transcript == null) return
         viewModelScope.launch {
             _uiState.value = _uiState.value.copy(isSummarizing = true)
             val sb = StringBuilder()
-            val result = runCatching {
+            try {
                 summarizeUseCase.summarize(transcript, s.transcriptLang).collect { delta ->
                     sb.append(delta)
                     _uiState.value = _uiState.value.copy(summary = sb.toString())
                 }
+                val summary = sb.toString().ifBlank { null }
+                repo.setSummary(noteId, summary, System.currentTimeMillis())
+                _uiState.value = _uiState.value.copy(summary = summary, isSummarizing = false)
+            } catch (ce: CancellationException) {
+                throw ce // structured cancellation (VM cleared) — not a failure
+            } catch (t: Throwable) {
+                // A real error (NotConfigured / network) — revert the partial
+                // stream (transcript untouched) and surface a notice.
+                _uiState.value = _uiState.value.copy(summary = s.summary, isSummarizing = false)
+                _events.send(NoteDetailEvent.SummarizeUnavailable)
             }
-            result.fold(
-                onSuccess = {
-                    val summary = sb.toString().ifBlank { null }
-                    repo.setSummary(noteId, summary, System.currentTimeMillis())
-                    _uiState.value = _uiState.value.copy(summary = summary, isSummarizing = false)
-                },
-                onFailure = {
-                    // Revert any partial stream; the transcript is never touched.
-                    _uiState.value = _uiState.value.copy(summary = s.summary, isSummarizing = false)
-                    _events.send(NoteDetailEvent.SummarizeUnavailable)
-                },
-            )
         }
     }
 

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/notes/ui/NotesViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/notes/ui/NotesViewModel.kt
@@ -8,6 +8,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import `in`.jphe.storyvox.data.notes.NoteEntity
 import `in`.jphe.storyvox.data.notes.NotesRepository
 import `in`.jphe.storyvox.data.notes.TranscriptionStatus
+import `in`.jphe.storyvox.llm.feature.SummarizeTranscriptUseCase
 import javax.inject.Inject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
@@ -16,6 +17,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
@@ -91,6 +93,8 @@ data class NoteDetailUiState(
     val isNewDraft: Boolean = true,
     /** True once the in-memory content diverges from what's persisted. Gates Save. */
     val isDirty: Boolean = false,
+    /** True while a summary is streaming from the LLM (Phase 3) — gates re-tap + drives a spinner. */
+    val isSummarizing: Boolean = false,
 )
 
 /** One-shot events from the detail VM to its screen. */
@@ -101,7 +105,11 @@ sealed interface NoteDetailEvent {
     data object Deleted : NoteDetailEvent
     /** Share the assembled note text — the screen fires an ACTION_SEND chooser. */
     data class Share(val text: String) : NoteDetailEvent
-    /** Summarize was tapped before Phase 3 landed — the screen shows a notice. */
+    /**
+     * Summarize couldn't run or complete — no AI provider configured
+     * (`LlmError.NotConfigured`) or the stream failed. The screen shows a notice
+     * pointing at Settings; the transcript is left untouched.
+     */
     data object SummarizeUnavailable : NoteDetailEvent
 }
 
@@ -116,6 +124,7 @@ sealed interface NoteDetailEvent {
 @HiltViewModel
 class NoteDetailViewModel @Inject constructor(
     private val repo: NotesRepository,
+    private val summarizeUseCase: SummarizeTranscriptUseCase,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
@@ -233,14 +242,43 @@ class NoteDetailViewModel @Inject constructor(
     }
 
     /**
-     * TODO(#1657 P3): replace with `SummarizeTranscriptUseCase` (nebula) —
-     * build a prompt from the transcript, stream `LlmProvider`, and write
-     * [NoteEntity.summary] behind the explicit-consent gate (spec §3.3). Until
-     * Phase 3 lands, tapping Summarize surfaces a "not yet available" notice so
-     * the affordance is discoverable without pretending to work.
+     * Voice Notes (#1657, Phase 3) — summarize the transcript via
+     * [SummarizeTranscriptUseCase] and persist [NoteEntity.summary].
+     *
+     * Consent gate (spec §3.3): runs only on the explicit Summarize tap (the tap
+     * *is* consent) and the use-case additionally requires a configured LLM
+     * provider — otherwise it throws and we surface
+     * [NoteDetailEvent.SummarizeUnavailable], leaving the transcript untouched.
+     * The summary streams into [uiState] live and is persisted **column-scoped**
+     * ([NotesRepository.setSummary]) — never a full-row upsert, so it can't
+     * clobber a concurrent body/title edit. Re-tap is gated by [isSummarizing].
      */
     fun summarize() {
-        viewModelScope.launch { _events.send(NoteDetailEvent.SummarizeUnavailable) }
+        val s = _uiState.value
+        val transcript = s.transcript
+        if (s.isSummarizing || transcript.isNullOrBlank()) return
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isSummarizing = true)
+            val sb = StringBuilder()
+            val result = runCatching {
+                summarizeUseCase.summarize(transcript, s.transcriptLang).collect { delta ->
+                    sb.append(delta)
+                    _uiState.value = _uiState.value.copy(summary = sb.toString())
+                }
+            }
+            result.fold(
+                onSuccess = {
+                    val summary = sb.toString().ifBlank { null }
+                    repo.setSummary(noteId, summary, System.currentTimeMillis())
+                    _uiState.value = _uiState.value.copy(summary = summary, isSummarizing = false)
+                },
+                onFailure = {
+                    // Revert any partial stream; the transcript is never touched.
+                    _uiState.value = _uiState.value.copy(summary = s.summary, isSummarizing = false)
+                    _events.send(NoteDetailEvent.SummarizeUnavailable)
+                },
+            )
+        }
     }
 
     companion object {

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/notes/ui/FakeNoteDao.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/notes/ui/FakeNoteDao.kt
@@ -60,4 +60,10 @@ class FakeNoteDao : NoteDao {
             if (it.id == id) it.copy(title = title, body = body, tags = tags, updatedAt = updatedAt) else it
         }
     }
+
+    override suspend fun updateSummary(id: String, summary: String?, updatedAt: Long) {
+        rows.value = rows.value.map {
+            if (it.id == id) it.copy(summary = summary, updatedAt = updatedAt) else it
+        }
+    }
 }

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/notes/ui/NotesViewModelTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/notes/ui/NotesViewModelTest.kt
@@ -4,8 +4,11 @@ import androidx.lifecycle.SavedStateHandle
 import `in`.jphe.storyvox.data.notes.NoteEntity
 import `in`.jphe.storyvox.data.notes.NotesRepository
 import `in`.jphe.storyvox.data.notes.TranscriptionStatus
+import `in`.jphe.storyvox.llm.feature.SummarizeTranscriptUseCase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
@@ -34,6 +37,13 @@ class NotesViewModelTest {
 
     @get:Rule
     val tmp = TemporaryFolder()
+
+    /** #1657 Phase 3 — the detail VM gained a summarize seam; this suite doesn't
+     *  exercise summarization, so a no-op fake satisfies the constructor
+     *  (interface seam → no `LlmRepository` needed here). */
+    private val fakeSummarize = object : SummarizeTranscriptUseCase {
+        override fun summarize(transcript: String, transcriptLang: String?): Flow<String> = emptyFlow()
+    }
 
     // One shared UnconfinedTestDispatcher for Main + runTest, so viewModelScope,
     // backgroundScope and the test body all run on the same eager scheduler —
@@ -133,7 +143,7 @@ class NotesViewModelTest {
                 updatedAt = 9,
             ),
         )
-        val vm = NoteDetailViewModel(repo, SavedStateHandle(mapOf("noteId" to "n1")))
+        val vm = NoteDetailViewModel(repo, fakeSummarize, SavedStateHandle(mapOf("noteId" to "n1")))
         runCurrent()
 
         val s = vm.uiState.value
@@ -147,7 +157,7 @@ class NotesViewModelTest {
 
     @Test
     fun `detail save inserts a new typed note with normalized tags`() = runTest(dispatcher) {
-        val vm = NoteDetailViewModel(repo, SavedStateHandle(mapOf("noteId" to "new1")))
+        val vm = NoteDetailViewModel(repo, fakeSummarize, SavedStateHandle(mapOf("noteId" to "new1")))
         runCurrent()
         assertTrue("absent row seeds a new draft", vm.uiState.value.isNewDraft)
 
@@ -181,7 +191,7 @@ class NotesViewModelTest {
                 transcriptionStatus = TranscriptionStatus.DONE,
             ),
         )
-        val vm = NoteDetailViewModel(repo, SavedStateHandle(mapOf("noteId" to "rec")))
+        val vm = NoteDetailViewModel(repo, fakeSummarize, SavedStateHandle(mapOf("noteId" to "rec")))
         runCurrent()
 
         vm.onTitleChange("Titled now")
@@ -201,7 +211,7 @@ class NotesViewModelTest {
     @Test
     fun `detail save stores a blank body as null so it doesn't shadow the transcript`() = runTest(dispatcher) {
         seed(note("only-audio", transcript = "the spoken content", durationMs = 3_000, status = TranscriptionStatus.DONE))
-        val vm = NoteDetailViewModel(repo, SavedStateHandle(mapOf("noteId" to "only-audio")))
+        val vm = NoteDetailViewModel(repo, fakeSummarize, SavedStateHandle(mapOf("noteId" to "only-audio")))
         runCurrent()
 
         // User opens the note and saves without typing a body.


### PR DESCRIPTION
## What (Phase 3 of #1657)
Wires luna's Phase-4 **Summarize** stub to a real, consent-gated LLM summary.

## Pieces
- **`SummarizeTranscriptUseCase`** (`core-llm/…/llm/feature/`, beside `ChapterRecap`) — a thin `Flow<String>` wrapper: builds a **title + key points + action items** prompt and streams `LlmRepository.stream()`. Summary **language follows `transcriptLang`** (EN/ES), so a Spanish memo gets a Spanish summary.
- **Consent / privacy gate (spec §3.3):** summarization is the *only* path that sends note text off-device. It runs only when **(1)** the user taps Summarize (the tap *is* consent) **and (2)** an LLM provider is configured — otherwise it throws `LlmError.NotConfigured` and **the transcript is not sent**. Deliberately does **not** reuse `sendChapterTextEnabled` (that governs *chapter* text). Blank transcript → empty flow (nothing sent).
- **`NoteDetailViewModel.summarize()`** — streams the summary **live** into `uiState`, then persists it **column-scoped** via new `NotesRepository.setSummary` → `NoteDao.updateSummary` (`UPDATE note SET summary…`). This is deliberately **not** a full-row upsert, so a summary write can't clobber a concurrent body/title edit — it's the disjoint-column complement to the #1663 lost-update fix. Re-tap gated by `isSummarizing`; a mid-stream failure reverts the partial and notifies, transcript untouched.
- **Honesty fix:** the detail screen's `"Summaries arrive in a later update."` snackbar is now false post-Phase-3 → replaced with a "set up an AI provider in Settings" notice (same #1608 no-over-claim principle).

## TDD
`SummarizeTranscriptUseCaseTest` (fake providers, mirrors `ChapterRecapTest`): streamed assembly · prompt shape (Title/Key points/Action items + carries the transcript) · EN/ES language selection · **`NotConfigured` consent gate asserts nothing reaches a provider** · blank-transcript no-op · budget truncation.

## Notes
- No dependency bump — reuses the existing `LlmRepository`/`LlmConfig` graph (`Flow<LlmConfig>` already provided by `LlmModule`). DI resolves at `:app`.
- No local gradle — CI is the compile gate.
- Coordinates with **#1663** (both add column-scoped `NoteDao` updates for disjoint fields — additive, no conflict).

Refs #1657

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notes can now generate AI summaries from transcripts and stream the result in real time.
  * A progress/loading indicator appears while summarization is running.

* **Bug Fixes**
  * Saving an AI summary no longer overwrites other concurrent note updates.
  * If summarization fails or the AI provider isn’t configured, the previous summary is restored and the user sees clearer setup guidance.
  * Blank transcripts won’t trigger summarization; long transcripts are handled safely.

* **Tests**
  * Added coverage for summary streaming order, prompt/language behavior, and truncation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->