### PR TITLE
fix(notes): eliminate bidirectional lost-update via column-scoped writes (#1663)

### DIFF
--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/notes/NoteDao.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/notes/NoteDao.kt
@@ -33,6 +33,32 @@ interface NoteDao {
     @Query("DELETE FROM note WHERE id = :id")
     suspend fun delete(id: String)
 
+    // ── #1663 — column-scoped updates with DISJOINT write sets. The worker
+    // (transcript columns) and the detail-screen edit (title/body/tags) update
+    // non-overlapping columns, so a concurrent transcription + user edit can no
+    // longer clobber each other — the lost-update window a full-row read-copy-
+    // upsert left open. Both touch only `updatedAt` in common (benign LWW).
+
+    /**
+     * Worker path — writes ONLY the transcript + status (never title/body/tags).
+     * `transcriptLang` is deliberately left untouched (the worker doesn't yet
+     * surface Whisper's detected language; add a param here when it does).
+     */
+    @Query(
+        "UPDATE note SET transcript = :transcript, " +
+            "transcriptionStatus = :status, updatedAt = :updatedAt WHERE id = :id",
+    )
+    suspend fun updateTranscription(id: String, transcript: String?, status: TranscriptionStatus, updatedAt: Long)
+
+    /** Worker path — status-only transition (start / fail / cancel); leaves any
+     *  partial transcript intact. */
+    @Query("UPDATE note SET transcriptionStatus = :status, updatedAt = :updatedAt WHERE id = :id")
+    suspend fun updateTranscriptionStatus(id: String, status: TranscriptionStatus, updatedAt: Long)
+
+    /** Edit path — writes ONLY the user-owned columns (never transcript/status). */
+    @Query("UPDATE note SET title = :title, body = :body, tags = :tags, updatedAt = :updatedAt WHERE id = :id")
+    suspend fun updateEdit(id: String, title: String, body: String?, tags: String, updatedAt: Long)
+
     /**
      * Substring search over title / body / transcript, newest-edited first.
      * An empty [query] degenerates to `LIKE '%%'`, which matches every row via

--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/notes/NotesRepository.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/notes/NotesRepository.kt
@@ -37,6 +37,25 @@ class NotesRepository @Inject constructor(
     suspend fun upsert(note: NoteEntity) = dao.upsert(note)
 
     /**
+     * #1663 — column-scoped writes. Prefer these over [upsert] for in-place
+     * changes: the transcription worker and the detail-screen edit touch
+     * disjoint columns, so concurrent updates never clobber each other. Use
+     * [upsert] only to INSERT a new row (create/record).
+     */
+    suspend fun updateTranscription(
+        id: String,
+        transcript: String?,
+        status: TranscriptionStatus,
+        updatedAt: Long,
+    ) = dao.updateTranscription(id, transcript, status, updatedAt)
+
+    suspend fun updateTranscriptionStatus(id: String, status: TranscriptionStatus, updatedAt: Long) =
+        dao.updateTranscriptionStatus(id, status, updatedAt)
+
+    suspend fun updateEdit(id: String, title: String, body: String?, tags: String, updatedAt: Long) =
+        dao.updateEdit(id, title, body, tags, updatedAt)
+
+    /**
      * Delete a note AND its recording. No-op if the id is absent. The row is
      * removed first, then the audio file — so a delete failure on the file
      * never leaves a row pointing at a deleted-then-half-gone file; a stray

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/notes/NoteDaoTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/notes/NoteDaoTest.kt
@@ -66,6 +66,57 @@ class NoteDaoTest {
         assertEquals(TranscriptionStatus.DONE, got.transcriptionStatus)
     }
 
+    // ── #1663 — column-scoped updates: worker (transcript/status) and editor
+    // (title/body/tags) writes must not clobber each other. ────────────────
+
+    @Test
+    fun scopedUpdates_transcriptWriteAndEdit_doNotClobber() = runTest {
+        dao.upsert(note("n1", title = "orig", body = "orig", tags = "old", status = TranscriptionStatus.PENDING))
+
+        // Worker writes the transcript; user concurrently saves an edit.
+        dao.updateTranscription("n1", transcript = "hello world", status = TranscriptionStatus.DONE, updatedAt = 2000L)
+        dao.updateEdit("n1", title = "edited", body = "edited body", tags = "new", updatedAt = 3000L)
+
+        val n = dao.get("n1")!!
+        // Worker's columns survived the edit…
+        assertEquals("hello world", n.transcript)
+        assertEquals(TranscriptionStatus.DONE, n.transcriptionStatus)
+        // …and the editor's columns survived the transcription.
+        assertEquals("edited", n.title)
+        assertEquals("edited body", n.body)
+        assertEquals("new", n.tags)
+    }
+
+    @Test
+    fun scopedUpdates_reverseOrder_stillNoClobber() = runTest {
+        dao.upsert(note("n1", title = "orig", body = "orig", status = TranscriptionStatus.PENDING))
+
+        dao.updateEdit("n1", title = "T", body = "B", tags = "G", updatedAt = 3000L)
+        dao.updateTranscription("n1", transcript = "TR", status = TranscriptionStatus.DONE, updatedAt = 2000L)
+
+        val n = dao.get("n1")!!
+        assertEquals("TR", n.transcript)
+        assertEquals(TranscriptionStatus.DONE, n.transcriptionStatus)
+        assertEquals("T", n.title)
+        assertEquals("B", n.body)
+        assertEquals("G", n.tags)
+    }
+
+    @Test
+    fun updateTranscriptionStatus_leavesEditorColumnsAndPartialTranscriptIntact() = runTest {
+        dao.upsert(
+            note("n1", title = "keep", body = "keep", transcript = "partial", status = TranscriptionStatus.RUNNING),
+        )
+
+        dao.updateTranscriptionStatus("n1", TranscriptionStatus.FAILED, updatedAt = 2000L)
+
+        val n = dao.get("n1")!!
+        assertEquals(TranscriptionStatus.FAILED, n.transcriptionStatus)
+        assertEquals("keep", n.title)
+        assertEquals("keep", n.body)
+        assertEquals("partial", n.transcript) // status-only update preserves the partial transcript
+    }
+
     @Test
     fun upsertSameId_replacesInPlace() = runTest {
         dao.upsert(note("n1", title = "draft", at = 1000L))

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/notes/NotesRepositoryTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/notes/NotesRepositoryTest.kt
@@ -110,5 +110,14 @@ class NotesRepositoryTest {
                     (it.transcript?.contains(query) ?: false)
             }.sortedByDescending { it.updatedAt },
         )
+        override suspend fun updateTranscription(id: String, transcript: String?, status: TranscriptionStatus, updatedAt: Long) {
+            rows.value = rows.value.map { if (it.id == id) it.copy(transcript = transcript, transcriptionStatus = status, updatedAt = updatedAt) else it }
+        }
+        override suspend fun updateTranscriptionStatus(id: String, status: TranscriptionStatus, updatedAt: Long) {
+            rows.value = rows.value.map { if (it.id == id) it.copy(transcriptionStatus = status, updatedAt = updatedAt) else it }
+        }
+        override suspend fun updateEdit(id: String, title: String, body: String?, tags: String, updatedAt: Long) {
+            rows.value = rows.value.map { if (it.id == id) it.copy(title = title, body = body, tags = tags, updatedAt = updatedAt) else it }
+        }
     }
 }

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/transcribe/offline/TranscriptionWorker.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/transcribe/offline/TranscriptionWorker.kt
@@ -81,26 +81,15 @@ class TranscriptionWorker @AssistedInject constructor(
         }
     }
 
-    /** Re-read then copy so a concurrent body/title edit isn't clobbered. */
+    // #1663 — column-scoped writes (transcript/status only). Disjoint from the
+    // detail-screen edit's write set (title/body/tags), so a concurrent user
+    // edit can't be clobbered — no read-modify-write of the full row.
     private suspend fun writeStatus(noteId: String, status: TranscriptionStatus) {
-        runCatching {
-            notes.get(noteId)?.let { notes.upsert(it.copy(transcriptionStatus = status, updatedAt = now())) }
-        }
+        runCatching { notes.updateTranscriptionStatus(noteId, status, now()) }
     }
 
     private suspend fun writeTranscript(noteId: String, transcript: String, status: TranscriptionStatus) {
-        runCatching {
-            notes.get(noteId)?.let {
-                notes.upsert(
-                    it.copy(
-                        transcript = transcript,
-                        transcriptLang = it.transcriptLang,
-                        transcriptionStatus = status,
-                        updatedAt = now(),
-                    ),
-                )
-            }
-        }
+        runCatching { notes.updateTranscription(noteId, transcript, status, now()) }
     }
 
     private fun now(): Long = System.currentTimeMillis()

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/transcribe/offline/TranscriptionWorkerTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/transcribe/offline/TranscriptionWorkerTest.kt
@@ -139,6 +139,15 @@ class TranscriptionWorkerTest {
         override suspend fun all(): List<NoteEntity> = rows.value
         override suspend fun delete(id: String) { rows.value = rows.value.filterNot { it.id == id } }
         override fun search(query: String): Flow<List<NoteEntity>> = rows
+        override suspend fun updateTranscription(id: String, transcript: String?, status: TranscriptionStatus, updatedAt: Long) {
+            rows.value = rows.value.map { if (it.id == id) it.copy(transcript = transcript, transcriptionStatus = status, updatedAt = updatedAt) else it }
+        }
+        override suspend fun updateTranscriptionStatus(id: String, status: TranscriptionStatus, updatedAt: Long) {
+            rows.value = rows.value.map { if (it.id == id) it.copy(transcriptionStatus = status, updatedAt = updatedAt) else it }
+        }
+        override suspend fun updateEdit(id: String, title: String, body: String?, tags: String, updatedAt: Long) {
+            rows.value = rows.value.map { if (it.id == id) it.copy(title = title, body = body, tags = tags, updatedAt = updatedAt) else it }
+        }
     }
 
     companion object {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/notes/ui/NotesViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/notes/ui/NotesViewModel.kt
@@ -177,24 +177,41 @@ class NoteDetailViewModel @Inject constructor(
         val s = _uiState.value
         val now = System.currentTimeMillis()
         viewModelScope.launch {
-            repo.upsert(
-                NoteEntity(
+            if (s.isNewDraft) {
+                // First save of a new typed draft → INSERT the full row. (No
+                // concurrent transcription exists for a brand-new typed note.)
+                repo.upsert(
+                    NoteEntity(
+                        id = s.id,
+                        title = s.title.trim(),
+                        createdAt = createdAt,
+                        updatedAt = now,
+                        tags = normalizeNoteTags(s.tags),
+                        audioPath = s.audioPath,
+                        durationMs = s.durationMs,
+                        transcript = s.transcript,
+                        transcriptLang = s.transcriptLang,
+                        summary = s.summary,
+                        // Store an empty body as null so it doesn't shadow the
+                        // transcript in the list snippet (see [noteSnippet]).
+                        body = s.body.ifBlank { null },
+                        transcriptionStatus = s.transcriptionStatus,
+                    ),
+                )
+            } else {
+                // #1663 — existing note: write ONLY the editor-owned columns
+                // (title/body/tags) via a column-scoped UPDATE, so a concurrent
+                // transcription writing transcript/status is never clobbered
+                // (and vice versa). A full-row upsert(copy) here re-wrote the
+                // stale transcript snapshot loaded into the editor.
+                repo.updateEdit(
                     id = s.id,
                     title = s.title.trim(),
-                    createdAt = createdAt,
-                    updatedAt = now,
-                    tags = normalizeNoteTags(s.tags),
-                    audioPath = s.audioPath,
-                    durationMs = s.durationMs,
-                    transcript = s.transcript,
-                    transcriptLang = s.transcriptLang,
-                    summary = s.summary,
-                    // Store an empty body as null so it doesn't shadow the
-                    // transcript in the list snippet (see [noteSnippet]).
                     body = s.body.ifBlank { null },
-                    transcriptionStatus = s.transcriptionStatus,
-                ),
-            )
+                    tags = normalizeNoteTags(s.tags),
+                    updatedAt = now,
+                )
+            }
             _uiState.value = s.copy(isNewDraft = false, isDirty = false)
             _events.send(NoteDetailEvent.Saved)
         }

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/notes/ui/FakeNoteDao.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/notes/ui/FakeNoteDao.kt
@@ -2,6 +2,7 @@ package `in`.jphe.storyvox.feature.notes.ui
 
 import `in`.jphe.storyvox.data.notes.NoteDao
 import `in`.jphe.storyvox.data.notes.NoteEntity
+import `in`.jphe.storyvox.data.notes.TranscriptionStatus
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.map
@@ -40,4 +41,23 @@ class FakeNoteDao : NoteDao {
                     (note.transcript?.lowercase()?.contains(q) == true)
             }.sortedByDescending { it.updatedAt }
         }
+
+    // #1663 — column-scoped updates (disjoint write sets).
+    override suspend fun updateTranscription(id: String, transcript: String?, status: TranscriptionStatus, updatedAt: Long) {
+        rows.value = rows.value.map {
+            if (it.id == id) it.copy(transcript = transcript, transcriptionStatus = status, updatedAt = updatedAt) else it
+        }
+    }
+
+    override suspend fun updateTranscriptionStatus(id: String, status: TranscriptionStatus, updatedAt: Long) {
+        rows.value = rows.value.map {
+            if (it.id == id) it.copy(transcriptionStatus = status, updatedAt = updatedAt) else it
+        }
+    }
+
+    override suspend fun updateEdit(id: String, title: String, body: String?, tags: String, updatedAt: Long) {
+        rows.value = rows.value.map {
+            if (it.id == id) it.copy(title = title, body = body, tags = tags, updatedAt = updatedAt) else it
+        }
+    }
 }


### PR DESCRIPTION
## #1663 — bidirectional lost-update fix (fast-follow to #1662 + #1660)

nebula found a lost-update window spanning the transcription worker (#1662) and the detail-screen edit (#1660): both persisted the **full row** via read → copy → `upsert`, so a concurrent transcription and a user edit clobbered each other's columns.

### Fix — disjoint column-scoped `@Query` UPDATEs on `NoteDao`
- `updateTranscription` / `updateTranscriptionStatus` — write **only** transcript/status (worker path).
- `updateEdit` — writes **only** title/body/tags (edit path).

Non-overlapping write sets → clobber is impossible **by construction** (only the benign `updatedAt` sort key is written by both). `transcriptLang` is deliberately left untouched by the worker update (it doesn't yet surface Whisper's detected language).

### Call-site swaps
- `TranscriptionWorker.writeStatus/writeTranscript` → the scoped updates (no more read-modify-write of the full row).
- `NotesViewModel.save()` (detail VM) → a **new draft INSERTs** (`upsert`); an **existing note uses `updateEdit`** — so it no longer re-writes the stale transcript snapshot the editor loaded.
- `NotesRepository` delegates; all **three** hand-rolled `FakeNoteDao`s (core-data, core-playback, feature) implement the new methods (interface-addition-breaks-fakes).

### Disjoint from Phase 3 (#1664)
nebula's #1664 adds `updateSummary` (summary-scope) + `summarize()`. My columns (transcript/status, title/body/tags) don't overlap nebula's (summary), and the methods are distinct — the fixes **compose**. Only textual overlap is both editing `NotesViewModel.kt` (my `save()` swap vs nebula's `summarize()` add); if #1664 merges first this is a trivial rebase.

### Test
`NoteDaoTest` — a concurrent transcript-write + a title/body/tags edit (**both orderings**) preserve each other; a status-only update keeps the partial transcript + the editor columns intact.

### Verification
ubox0 pre-flight at branch tip: `:app:assembleDebug` (Build APK gate + Room `@Query` SQL validation) ✅ + `:core-data`/`:core-playback`/`:feature` `compileDebugUnitTestKotlin` (Test Compile gate) ✅. `git merge-tree` clean on current main.

Refs #1663

🤖 Generated with [Claude Code](https://claude.com/claude-code)