### PR TITLE
feat(notes): Voice Notes recording — AudioRecorder + mic FGS (Phase 2a)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,6 +15,11 @@
          type per AOSP docs. Required on API 34+ to avoid the
          "Missing foregroundServiceType" SecurityException. -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+    <!-- Voice Notes (#1657, Phase 2a) — RecordingService (feature/notes/record)
+         captures the mic under a microphone-typed FGS; API 34+ requires this
+         permission to start it. RECORD_AUDIO (declared below) is requested at
+         runtime before recording begins. -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 

--- a/feature/src/main/AndroidManifest.xml
+++ b/feature/src/main/AndroidManifest.xml
@@ -1,2 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+
+        <!-- Voice Notes (#1657, Phase 2a) — microphone-typed FGS that keeps mic
+             capture legal + visible while recording. Not exported: started only
+             via an explicit Intent from NotesRecordViewModel. The
+             FOREGROUND_SERVICE_MICROPHONE permission is declared in the app
+             manifest beside the other FGS permissions. -->
+        <service
+            android:name="in.jphe.storyvox.feature.notes.record.RecordingService"
+            android:exported="false"
+            android:foregroundServiceType="microphone" />
+
+    </application>
+</manifest>

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/notes/record/AudioRecorder.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/notes/record/AudioRecorder.kt
@@ -1,0 +1,250 @@
+package `in`.jphe.storyvox.feature.notes.record
+
+import android.content.Context
+import android.media.AudioAttributes
+import android.media.AudioFocusRequest
+import android.media.AudioManager
+import android.media.MediaRecorder
+import android.os.Build
+import android.os.SystemClock
+import android.util.Log
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.File
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.math.sqrt
+
+/**
+ * Voice Notes (#1657, Phase 2a) — the microphone-capture engine behind the
+ * record screen. Wraps [MediaRecorder] (AAC / `.m4a`, mono, ~96 kbps) writing to
+ * `filesDir/recordings/<noteId>.m4a`, and requests transient audio focus so the
+ * app's own TTS pauses while recording.
+ *
+ * ## Why a process-wide @Singleton (not VM-scoped)
+ * Capture must not be torn down by a configuration change (rotation) that
+ * recreates [`NotesRecordViewModel`][`in`.jphe.storyvox.feature.notes.ui.NotesRecordViewModel].
+ * Holding the recorder in a `@Singleton` lets a freshly-recreated VM re-attach to
+ * the still-running session ([isRecording] + [elapsedMs] rehydrate its UI).
+ * Timing is anchored to [SystemClock.elapsedRealtime] rather than a tick counter
+ * so the elapsed clock is correct across that recreation and independent of the
+ * UI ticker's cadence.
+ *
+ * ## Pause the app's TTS via audio focus
+ * We request our OWN transient [AudioFocusRequest]; the framework then delivers
+ * `AUDIOFOCUS_LOSS_TRANSIENT` to the playback service's focus listener, which
+ * pauses the engine. We deliberately do NOT reuse
+ * [`AudioFocusController`][`in`.jphe.storyvox.playback.AudioFocusController] —
+ * its single request object is playback-owned.
+ *
+ * Every framework call is defensively wrapped: a `MediaRecorder` state-machine
+ * slip must never crash the record screen — the take is salvaged or discarded.
+ */
+@Singleton
+class AudioRecorder @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+
+    private var recorder: MediaRecorder? = null
+    private var output: File? = null
+    private var focusRequest: AudioFocusRequest? = null
+
+    // Timing anchors (elapsedRealtime millis). See [computeElapsedMs].
+    private var startRealtime = 0L
+    private var pausedAccumMs = 0L
+    private var pauseStartedAt = 0L
+    private var pausedNow = false
+
+    /** True while a session is open (between [start] and [stop]/[discard]). */
+    val isRecording: Boolean get() = recorder != null
+
+    /** True while a live session is paused. */
+    val isPaused: Boolean get() = pausedNow
+
+    /**
+     * Configure + begin capturing [outputFile], and grab transient focus (pausing
+     * TTS). Returns true on success; on any failure the recorder is released and
+     * false is returned so the caller can abort without a half-open recorder.
+     */
+    fun start(outputFile: File): Boolean {
+        return try {
+            val mr = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                MediaRecorder(context)
+            } else {
+                @Suppress("DEPRECATION")
+                MediaRecorder()
+            }
+            mr.setAudioSource(MediaRecorder.AudioSource.MIC)
+            mr.setOutputFormat(MediaRecorder.OutputFormat.MPEG_4)
+            mr.setAudioChannels(1) // mono — speech; halves size, P2b downmixes anyway
+            mr.setAudioSamplingRate(SAMPLE_RATE_HZ)
+            mr.setAudioEncodingBitRate(BITRATE_BPS)
+            mr.setAudioEncoder(MediaRecorder.AudioEncoder.AAC)
+            mr.setOutputFile(outputFile)
+            mr.prepare()
+            mr.start()
+            recorder = mr
+            output = outputFile
+            startRealtime = SystemClock.elapsedRealtime()
+            pausedAccumMs = 0L
+            pauseStartedAt = 0L
+            pausedNow = false
+            requestTransientFocus()
+            true
+        } catch (e: Exception) {
+            Log.w(TAG, "start failed for ${outputFile.name}: ${e.message}", e)
+            runCatching { recorder?.release() }
+            recorder = null
+            output = null
+            abandonFocus()
+            false
+        }
+    }
+
+    /**
+     * The file the current session is writing to, or null when idle. Lives here
+     * (the @Singleton), not in the VM, so it survives a VM recreation mid-record:
+     * on stop the VM derives the note id from this file's name rather than a
+     * VM-local field that a rotation would have wiped.
+     */
+    val currentOutput: File? get() = output
+
+    /** Peak amplitude since the previous read (0..32767), or 0 if not recording. */
+    val maxAmplitude: Int
+        get() = runCatching { recorder?.maxAmplitude ?: 0 }.getOrDefault(0)
+
+    /** Elapsed capture time in millis, excluding paused spans. 0 when idle. */
+    fun elapsedMs(): Long {
+        if (recorder == null) return 0L
+        return computeElapsedMs(
+            startRealtime = startRealtime,
+            now = SystemClock.elapsedRealtime(),
+            pausedAccumMs = pausedAccumMs,
+            isPaused = pausedNow,
+            pauseStartedAt = pauseStartedAt,
+        )
+    }
+
+    fun pause() {
+        if (recorder == null || pausedNow) return
+        runCatching { recorder?.pause() }
+            .onSuccess {
+                pauseStartedAt = SystemClock.elapsedRealtime()
+                pausedNow = true
+            }
+            .onFailure { Log.w(TAG, "pause ignored: ${it.message}") }
+    }
+
+    fun resume() {
+        if (recorder == null || !pausedNow) return
+        runCatching { recorder?.resume() }
+            .onSuccess {
+                pausedAccumMs += SystemClock.elapsedRealtime() - pauseStartedAt
+                pausedNow = false
+            }
+            .onFailure { Log.w(TAG, "resume ignored: ${it.message}") }
+    }
+
+    /**
+     * Stop + finalize the `.m4a` and release the mic/focus. Returns the recording
+     * duration in millis, or -1 if the file was not written / is empty (a
+     * too-short take), in which case the partial file is deleted so it can't leak
+     * as an orphan or masquerade as valid audio.
+     */
+    fun stop(): Long {
+        val mr = recorder ?: return -1L
+        val file = output
+        val duration = elapsedMs()
+        val ok = try {
+            mr.stop()
+            true
+        } catch (e: Exception) {
+            Log.w(TAG, "stop failed: ${e.message}")
+            false
+        } finally {
+            runCatching { mr.release() }
+            recorder = null
+            abandonFocus()
+        }
+        val valid = ok && file != null && file.exists() && file.length() > 0L
+        if (!valid) {
+            runCatching { file?.takeIf(File::exists)?.delete() }
+        }
+        output = null
+        pausedNow = false
+        return if (valid) duration else -1L
+    }
+
+    /** Abort the take and delete any bytes written — used on cancel / VM clear. */
+    fun discard() {
+        val file = output
+        recorder?.let { mr ->
+            runCatching { mr.stop() }
+            runCatching { mr.release() }
+        }
+        recorder = null
+        abandonFocus()
+        runCatching { file?.takeIf(File::exists)?.delete() }
+        output = null
+        pausedNow = false
+    }
+
+    private fun requestTransientFocus() {
+        val am = context.getSystemService(AudioManager::class.java) ?: return
+        val req = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT)
+            .setAudioAttributes(
+                AudioAttributes.Builder()
+                    .setUsage(AudioAttributes.USAGE_MEDIA)
+                    .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+                    .build(),
+            )
+            // No reaction to focus changes during capture (P2a): MediaRecorder
+            // keeps capturing regardless; interruption handling is a follow-up.
+            .setOnAudioFocusChangeListener { }
+            .build()
+        focusRequest = req
+        runCatching { am.requestAudioFocus(req) }
+    }
+
+    private fun abandonFocus() {
+        val am = context.getSystemService(AudioManager::class.java) ?: return
+        focusRequest?.let { req -> runCatching { am.abandonAudioFocusRequest(req) } }
+        focusRequest = null
+    }
+
+    companion object {
+        private const val TAG = "AudioRecorder"
+        private const val SAMPLE_RATE_HZ = 44_100
+        private const val BITRATE_BPS = 96_000
+        private const val MAX_RAW_AMPLITUDE = 32_767f
+
+        /**
+         * Map a raw [MediaRecorder.getMaxAmplitude] reading (0..32767) to a
+         * `[0f, 1f]` waveform bar height. A linear map reads as nearly-flat
+         * because conversational speech rarely nears full scale; `sqrt` applies a
+         * perceptual boost that lifts the low end so quiet talking still shows
+         * motion. Pure — unit tested without a device.
+         */
+        internal fun normalizeAmplitude(raw: Int): Float {
+            if (raw <= 0) return 0f
+            val linear = (raw.toFloat() / MAX_RAW_AMPLITUDE).coerceIn(0f, 1f)
+            return sqrt(linear).coerceIn(0f, 1f)
+        }
+
+        /**
+         * Elapsed active-capture millis given the realtime anchors. Extracted pure
+         * so the (otherwise [SystemClock]-bound) timer logic is unit tested:
+         * subtract accumulated paused spans, plus the current open pause span when
+         * [isPaused]. Clamped to ≥0 defensively.
+         */
+        internal fun computeElapsedMs(
+            startRealtime: Long,
+            now: Long,
+            pausedAccumMs: Long,
+            isPaused: Boolean,
+            pauseStartedAt: Long,
+        ): Long {
+            val openPause = if (isPaused) (now - pauseStartedAt) else 0L
+            return (now - startRealtime - pausedAccumMs - openPause).coerceAtLeast(0L)
+        }
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/notes/record/RecordingService.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/notes/record/RecordingService.kt
@@ -1,0 +1,131 @@
+package `in`.jphe.storyvox.feature.notes.record
+
+import android.app.ForegroundServiceStartNotAllowedException
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.IBinder
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import `in`.jphe.storyvox.playback.R as PlaybackR
+
+/**
+ * Voice Notes (#1657, Phase 2a) — the microphone-typed foreground service that
+ * keeps mic capture legal + visible while a recording is in progress.
+ *
+ * ## Deliberately thin
+ * The recorder itself and the stop→persist→enqueue flow live in the VM +
+ * [AudioRecorder] (spec §3.1: capture code in `feature/.../notes/record/`, the
+ * VM as the "RecordingController"). This service exists ONLY to (a) satisfy the
+ * Android-14 requirement that background mic access run under a
+ * `microphone`-typed FGS with the `FOREGROUND_SERVICE_MICROPHONE` permission, and
+ * (b) surface an ongoing notification. It is started/stopped by the VM around a
+ * take and holds no recorder state — so there is no cross-process finalize path
+ * to keep consistent.
+ *
+ * Modeled on [`StoryvoxPlaybackService`][`in`.jphe.storyvox.playback.StoryvoxPlaybackService]'s
+ * channel + guarded-`startForeground` shape; it is a plain [Service] and does NOT
+ * subclass the Media3 session service.
+ */
+class RecordingService : Service() {
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        when (intent?.action) {
+            ACTION_STOP -> {
+                stopForegroundCompat()
+                stopSelf()
+            }
+            else -> startForegroundMic() // ACTION_START (or a redelivered start)
+        }
+        // Don't recreate a killed recording FGS with a null intent — the VM
+        // re-establishes it on the next explicit start.
+        return START_NOT_STICKY
+    }
+
+    private fun startForegroundMic() {
+        ensureChannel()
+        val notif = buildNotification()
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                startForeground(NOTIFICATION_ID, notif, ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE)
+            } else {
+                startForeground(NOTIFICATION_ID, notif)
+            }
+        } catch (e: Exception) {
+            // ForegroundServiceStartNotAllowedException is API 31+; runtime-guard
+            // the type check so a typed catch can't crash at class-load on older
+            // devices.
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
+                e is ForegroundServiceStartNotAllowedException
+            ) {
+                Log.w(TAG, "mic FG-start denied by OS", e)
+            } else {
+                Log.w(TAG, "startForeground(microphone) failed: ${e.message}", e)
+            }
+            stopSelf()
+        }
+    }
+
+    private fun buildNotification(): Notification {
+        // Tapping the notification reopens the app (launcher activity) — no
+        // compile dependency on :app's MainActivity.
+        val launch = packageManager.getLaunchIntentForPackage(packageName)
+        val contentIntent = launch?.let {
+            PendingIntent.getActivity(
+                this,
+                0,
+                it,
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+            )
+        }
+        return NotificationCompat.Builder(this, CHANNEL_RECORDING)
+            .setSmallIcon(PlaybackR.drawable.ic_storyvox_notif)
+            .setContentTitle("Recording voice note")
+            .setContentText("Recording in progress")
+            .setOngoing(true)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .apply { if (contentIntent != null) setContentIntent(contentIntent) }
+            .build()
+    }
+
+    private fun ensureChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val nm = getSystemService(NotificationManager::class.java) ?: return
+            if (nm.getNotificationChannel(CHANNEL_RECORDING) == null) {
+                nm.createNotificationChannel(
+                    NotificationChannel(
+                        CHANNEL_RECORDING,
+                        "Voice note recording",
+                        NotificationManager.IMPORTANCE_LOW,
+                    ),
+                )
+            }
+        }
+    }
+
+    private fun stopForegroundCompat() {
+        runCatching {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                stopForeground(STOP_FOREGROUND_REMOVE)
+            } else {
+                @Suppress("DEPRECATION")
+                stopForeground(true)
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "RecordingService"
+        private const val CHANNEL_RECORDING = "notes_recording"
+        private const val NOTIFICATION_ID = 1057
+        const val ACTION_START = "in.jphe.storyvox.notes.action.START"
+        const val ACTION_STOP = "in.jphe.storyvox.notes.action.STOP"
+    }
+}

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/notes/ui/NotesRecordViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/notes/ui/NotesRecordViewModel.kt
@@ -1,14 +1,23 @@
 package `in`.jphe.storyvox.feature.notes.ui
 
+import android.content.Context
+import android.content.Intent
 import androidx.compose.runtime.Immutable
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import `in`.jphe.storyvox.data.notes.NoteEntity
 import `in`.jphe.storyvox.data.notes.NotesRepository
 import `in`.jphe.storyvox.data.notes.TranscriptionStatus
+import `in`.jphe.storyvox.feature.notes.record.AudioRecorder
+import `in`.jphe.storyvox.feature.notes.record.RecordingService
+import `in`.jphe.storyvox.playback.transcribe.offline.TranscriptionScheduler
+import java.io.File
 import java.util.UUID
 import javax.inject.Inject
+import javax.inject.Named
 import kotlin.math.abs
 import kotlin.math.sin
 import kotlinx.coroutines.Job
@@ -20,6 +29,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 
 /** Immutable snapshot of the [RecordScreen] — timer, waveform, transport state. */
@@ -40,19 +50,28 @@ sealed interface RecordEvent {
 }
 
 /**
- * Voice Notes (epic #1657, Phase 4) — ViewModel for the [RecordScreen].
+ * Voice Notes (#1657) — ViewModel for the [RecordScreen]; the spec's
+ * "RecordingController" (§3.1). Phase 4 (luna) shipped the final chrome against a
+ * deterministic simulation; **Phase 2a swaps in real capture** via [AudioRecorder]
+ * (`MediaRecorder` → `filesDir/recordings/<id>.m4a`) under a microphone-typed
+ * [RecordingService], and persists on stop.
  *
- * **The recorder is stubbed for Phase 4.** The screen chrome (timer, animated
- * waveform, record / pause / resume / stop / cancel controls, a11y) is final;
- * the elapsed clock + amplitudes come from a deterministic *simulation* here,
- * and Stop persists a note row with **no audio** yet. Phase 2a (morpheus-1619)
- * swaps the simulation for the real `AudioRecorder` (MediaRecorder → `.m4a`
- * under a microphone-typed foreground service) and Phase 2b enqueues the
- * transcription worker. Both swap points are marked with `TODO(#1657 …)`.
+ * The heavy state (open recorder + output file + elapsed clock) lives in the
+ * `@Singleton` [AudioRecorder], so a configuration change that recreates this VM
+ * re-attaches to the still-running take ([init]) instead of dropping it. The VM
+ * itself only owns the display ticker + the persistence-on-stop flow.
+ *
+ * The `RECORD_AUDIO` runtime permission is gated by [RecordScreen] before
+ * [start] is ever called (kept out of the VM so it stays free of Android
+ * permission plumbing).
  */
 @HiltViewModel
 class NotesRecordViewModel @Inject constructor(
-    private val repo: NotesRepository,
+    @ApplicationContext private val context: Context,
+    private val audioRecorder: AudioRecorder,
+    private val notesRepository: NotesRepository,
+    private val transcriptionScheduler: TranscriptionScheduler,
+    @Named(NotesRepository.RECORDINGS_DIR_QUALIFIER) private val recordingsDir: File,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(RecordUiState())
@@ -62,26 +81,116 @@ class NotesRecordViewModel @Inject constructor(
     val events: Flow<RecordEvent> = _events.receiveAsFlow()
 
     private var ticker: Job? = null
-    private var tick = 0
 
-    /** Begin (or restart) a recording session. */
+    init {
+        // VM recreated (e.g. rotation) while a take is still running in the
+        // singleton recorder — re-attach the UI to it rather than orphan it.
+        if (audioRecorder.isRecording) {
+            _uiState.value = RecordUiState(
+                isRecording = true,
+                isPaused = audioRecorder.isPaused,
+                elapsedMs = audioRecorder.elapsedMs(),
+            )
+            startTicker()
+        }
+    }
+
+    /** Begin a recording. Caller ([RecordScreen]) guarantees RECORD_AUDIO is granted. */
     fun start() {
-        if (_uiState.value.isRecording) return
-        tick = 0
-        _uiState.value = RecordUiState(isRecording = true, isPaused = false)
-        // TODO(#1657 P2a): replace this simulated ticker with morpheus-1619's
-        //  AudioRecorder — start the MediaRecorder into filesDir/recordings/<id>.m4a
-        //  under a microphone-typed FGS and feed real getMaxAmplitude() into the
-        //  waveform. The UI below (timer + waveform + transport) is unchanged.
+        if (audioRecorder.isRecording) return
+        val noteId = UUID.randomUUID().toString()
+        val file = File(recordingsDir, "$noteId.m4a")
+        // Promote to the mic FGS first (so background capture is attributed to
+        // it), then open the recorder. Roll back the FGS if capture won't start.
+        startFgs()
+        if (!audioRecorder.start(file)) {
+            stopFgs()
+            _uiState.value = RecordUiState()
+            return
+        }
+        _uiState.value = RecordUiState(isRecording = true)
+        startTicker()
+    }
+
+    fun pause() {
+        if (!audioRecorder.isRecording) return
+        audioRecorder.pause()
+        _uiState.update { it.copy(isPaused = true) }
+    }
+
+    fun resume() {
+        if (!audioRecorder.isRecording) return
+        audioRecorder.resume()
+        _uiState.update { it.copy(isPaused = false) }
+    }
+
+    /** Abandon the in-progress take without persisting anything. */
+    fun cancel() {
+        ticker?.cancel()
+        ticker = null
+        audioRecorder.discard()
+        stopFgs()
+        _uiState.value = RecordUiState()
+    }
+
+    /**
+     * Stop capture and persist it as a PENDING note, then enqueue transcription
+     * (Phase 2b) and emit [RecordEvent.Saved]. A too-short/failed take (no usable
+     * audio) is silently discarded — no empty note row is created.
+     */
+    fun stopAndSave() {
+        if (_uiState.value.isSaving) return
+        ticker?.cancel()
+        ticker = null
+        _uiState.update { it.copy(isRecording = false, isPaused = false, isSaving = true) }
+
+        // Capture the file BEFORE stop() (which clears it); derive the id from the
+        // filename so this survives a VM recreation mid-take.
+        val file: File? = audioRecorder.currentOutput
+        val durationMs = audioRecorder.stop()
+        stopFgs()
+
+        val noteId = file?.nameWithoutExtension
+        if (durationMs < 0L || file == null || noteId == null) {
+            _uiState.value = RecordUiState()
+            return
+        }
+
+        val now = System.currentTimeMillis()
+        viewModelScope.launch {
+            notesRepository.upsert(
+                NoteEntity(
+                    id = noteId,
+                    title = "",
+                    createdAt = now,
+                    updatedAt = now,
+                    audioPath = file.absolutePath,
+                    durationMs = durationMs,
+                    // Phase 2b's worker advances PENDING → RUNNING → DONE/FAILED.
+                    transcriptionStatus = TranscriptionStatus.PENDING,
+                ),
+            )
+            // Close the P2b enqueue seam — the scheduler's KDoc names Phase 2a as
+            // its caller. KEEP-unique, so a UI retry later is a no-op not a dupe.
+            transcriptionScheduler.enqueue(noteId)
+            _uiState.update { it.copy(isSaving = false) }
+            _events.send(RecordEvent.Saved(noteId))
+        }
+    }
+
+    private fun startTicker() {
+        ticker?.cancel()
         ticker = viewModelScope.launch {
-            while (true) {
+            while (isActive) {
                 delay(TICK_MS)
-                if (_uiState.value.isPaused) continue
-                tick++
-                val amp = simulatedAmplitude(tick)
+                val paused = audioRecorder.isPaused
+                val amp = if (paused) 0f else AudioRecorder.normalizeAmplitude(audioRecorder.maxAmplitude)
+                val elapsed = audioRecorder.elapsedMs()
                 _uiState.update { s ->
                     s.copy(
-                        elapsedMs = s.elapsedMs + TICK_MS,
+                        isRecording = true,
+                        isPaused = paused,
+                        elapsedMs = elapsed,
                         amplitudes = (s.amplitudes + amp).takeLast(MAX_BARS),
                     )
                 }
@@ -89,62 +198,29 @@ class NotesRecordViewModel @Inject constructor(
         }
     }
 
-    fun pause() {
-        if (_uiState.value.isRecording) _uiState.update { it.copy(isPaused = true) }
-    }
-
-    fun resume() {
-        if (_uiState.value.isRecording) _uiState.update { it.copy(isPaused = false) }
-    }
-
-    /** Abandon the in-progress recording without persisting anything. */
-    fun cancel() {
-        ticker?.cancel()
-        ticker = null
-        tick = 0
-        _uiState.value = RecordUiState()
-    }
-
-    /**
-     * Stop and persist the recording as a new note row, then emit
-     * [RecordEvent.Saved] so the screen opens the note's detail.
-     *
-     * P4 writes a PENDING row with `audioPath = null` (no capture yet) — a
-     * documented placeholder; see the class KDoc + the TODOs below.
-     */
-    fun stopAndSave() {
-        if (_uiState.value.isSaving) return
-        val elapsed = _uiState.value.elapsedMs
-        ticker?.cancel()
-        ticker = null
-        _uiState.update { it.copy(isRecording = false, isPaused = false, isSaving = true) }
-        val id = UUID.randomUUID().toString()
-        val now = System.currentTimeMillis()
-        viewModelScope.launch {
-            repo.upsert(
-                NoteEntity(
-                    id = id,
-                    title = "",
-                    createdAt = now,
-                    updatedAt = now,
-                    // TODO(#1657 P2a): audioPath = the finalized recording path
-                    //  from AudioRecorder (filesDir/recordings/<id>.m4a). Null in
-                    //  P4 — there is no real capture yet.
-                    audioPath = null,
-                    durationMs = elapsed,
-                    // TODO(#1657 P2b): after insert, enqueue the TranscriptionWorker
-                    //  (WorkManager) which advances PENDING → RUNNING → DONE/FAILED
-                    //  and streams transcript segments back into the row.
-                    transcriptionStatus = TranscriptionStatus.PENDING,
-                ),
-            )
-            _uiState.update { it.copy(isSaving = false) }
-            _events.send(RecordEvent.Saved(id))
+    private fun startFgs() {
+        val intent = Intent(context, RecordingService::class.java).apply {
+            action = RecordingService.ACTION_START
         }
+        runCatching { ContextCompat.startForegroundService(context, intent) }
+    }
+
+    private fun stopFgs() {
+        val intent = Intent(context, RecordingService::class.java).apply {
+            action = RecordingService.ACTION_STOP
+        }
+        runCatching { context.startService(intent) }
     }
 
     override fun onCleared() {
         ticker?.cancel()
+        // If the screen is torn down (not merely rotated) mid-take, abandon it —
+        // don't leave a mic FGS running with no UI. (Rotation recreates the VM
+        // synchronously, so isRecording re-attaches in init before this matters.)
+        if (audioRecorder.isRecording) {
+            audioRecorder.discard()
+            stopFgs()
+        }
         super.onCleared()
     }
 
@@ -157,10 +233,9 @@ class NotesRecordViewModel @Inject constructor(
 }
 
 /**
- * Deterministic pseudo-amplitude in `[0.08f, 1f]` for the Phase-4 stub waveform
- * (two mixed sines give an organic, non-repetitive envelope). Deterministic so
- * previews + any future test are stable; replaced wholesale by real mic
- * amplitude in Phase 2a.
+ * Deterministic pseudo-amplitude in `[0.08f, 1f]` — retained for the [RecordScreen]
+ * Compose previews (stable sample data). No longer used by the live recorder
+ * (Phase 2a feeds real mic amplitude).
  */
 internal fun simulatedAmplitude(tick: Int): Float {
     val a = sin(tick * 0.35).toFloat()

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/notes/ui/RecordScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/notes/ui/RecordScreen.kt
@@ -1,7 +1,11 @@
 package `in`.jphe.storyvox.feature.notes.ui
 
+import android.Manifest
+import android.content.pm.PackageManager
 import android.content.res.Configuration
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -35,9 +39,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import `in`.jphe.storyvox.ui.theme.LibraryNocturneTheme
@@ -62,12 +67,30 @@ fun RecordScreen(
     viewModel: NotesRecordViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val context = LocalContext.current
 
     androidx.compose.runtime.LaunchedEffect(Unit) {
         viewModel.events.collect { event ->
             when (event) {
                 is RecordEvent.Saved -> onRecordingSaved(event.noteId)
             }
+        }
+    }
+
+    // RECORD_AUDIO is requested the moment the user first taps record: granted →
+    // start immediately; denied → no-op (the button stays available to retry).
+    // Capture + the microphone FGS both require it.
+    val permissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission(),
+    ) { granted -> if (granted) viewModel.start() }
+    val onStartRecording: () -> Unit = {
+        if (
+            ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) ==
+            PackageManager.PERMISSION_GRANTED
+        ) {
+            viewModel.start()
+        } else {
+            permissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
         }
     }
 
@@ -80,7 +103,7 @@ fun RecordScreen(
 
     RecordContent(
         state = state,
-        onStart = viewModel::start,
+        onStart = onStartRecording,
         onPause = viewModel::pause,
         onResume = viewModel::resume,
         onStop = viewModel::stopAndSave,
@@ -195,17 +218,6 @@ internal fun RecordContent(
                         )
                     }
                 }
-            }
-
-            if (state.isRecording) {
-                Spacer(Modifier.height(spacing.lg))
-                // Honest cue for testers — removed when Phase 2a's real capture lands.
-                Text(
-                    text = "Simulated preview — real capture arrives in a later update.",
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    textAlign = TextAlign.Center,
-                )
             }
         }
     }

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/notes/record/AudioRecorderTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/notes/record/AudioRecorderTest.kt
@@ -1,0 +1,99 @@
+package `in`.jphe.storyvox.feature.notes.record
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-function tests for [AudioRecorder]'s device-independent logic. The
+ * `MediaRecorder`/FGS surface can't be exercised on plain JVM, so — following the
+ * house "test the extracted pure decision fns" pattern — the amplitude
+ * normalization and the pause-aware elapsed math are pulled into companion
+ * functions and pinned here.
+ */
+class AudioRecorderTest {
+
+    // ── normalizeAmplitude ────────────────────────────────────────────────────
+
+    @Test
+    fun `normalize maps silence to zero`() {
+        assertEquals(0f, AudioRecorder.normalizeAmplitude(0), 0f)
+        assertEquals(0f, AudioRecorder.normalizeAmplitude(-5), 0f)
+    }
+
+    @Test
+    fun `normalize maps full scale to one`() {
+        assertEquals(1f, AudioRecorder.normalizeAmplitude(32_767), 1e-4f)
+    }
+
+    @Test
+    fun `normalize clamps above full scale to one`() {
+        assertEquals(1f, AudioRecorder.normalizeAmplitude(99_999), 0f)
+    }
+
+    @Test
+    fun `normalize stays within unit range and is monotonic`() {
+        var prev = -1f
+        for (raw in 0..32_767 step 512) {
+            val v = AudioRecorder.normalizeAmplitude(raw)
+            assertTrue("in [0,1] for raw=$raw (was $v)", v in 0f..1f)
+            assertTrue("monotonic non-decreasing at raw=$raw", v >= prev)
+            prev = v
+        }
+    }
+
+    @Test
+    fun `normalize applies a perceptual boost above linear`() {
+        // sqrt lifts the low end: a quarter-scale reading should render taller
+        // than its linear 0.25 so quiet speech is visible.
+        val v = AudioRecorder.normalizeAmplitude(32_767 / 4)
+        assertTrue("expected boost above linear 0.25, got $v", v > 0.25f)
+    }
+
+    // ── computeElapsedMs ──────────────────────────────────────────────────────
+
+    @Test
+    fun `elapsed while running is now minus start`() {
+        val e = AudioRecorder.computeElapsedMs(
+            startRealtime = 1_000L, now = 5_000L,
+            pausedAccumMs = 0L, isPaused = false, pauseStartedAt = 0L,
+        )
+        assertEquals(4_000L, e)
+    }
+
+    @Test
+    fun `elapsed subtracts accumulated paused spans`() {
+        val e = AudioRecorder.computeElapsedMs(
+            startRealtime = 1_000L, now = 5_000L,
+            pausedAccumMs = 1_000L, isPaused = false, pauseStartedAt = 0L,
+        )
+        assertEquals(3_000L, e)
+    }
+
+    @Test
+    fun `elapsed freezes during an open pause span`() {
+        // Started at 1000, now 5000 (4000 raw), currently paused since 3000
+        // (open pause = 2000) → 2000 active.
+        val e = AudioRecorder.computeElapsedMs(
+            startRealtime = 1_000L, now = 5_000L,
+            pausedAccumMs = 0L, isPaused = true, pauseStartedAt = 3_000L,
+        )
+        assertEquals(2_000L, e)
+
+        // Advancing `now` while still paused must not increase elapsed.
+        val later = AudioRecorder.computeElapsedMs(
+            startRealtime = 1_000L, now = 8_000L,
+            pausedAccumMs = 0L, isPaused = true, pauseStartedAt = 3_000L,
+        )
+        assertEquals(2_000L, later)
+    }
+
+    @Test
+    fun `elapsed never goes negative`() {
+        val e = AudioRecorder.computeElapsedMs(
+            startRealtime = 5_000L, now = 1_000L,
+            pausedAccumMs = 0L, isPaused = false, pauseStartedAt = 0L,
+        )
+        assertEquals(0L, e)
+    }
+}


### PR DESCRIPTION
## Voice Notes Phase 2a — recording (Refs #1657)

Swaps luna's Phase-4 **simulated** recorder for **real microphone capture** behind her finished record UI. The chrome (timer, waveform, transport, a11y) is unchanged; this fills the two `TODO(#1657 P2a)` seams in `NotesRecordViewModel` and adds the capture engine + mic FGS.

### What's here
- **`AudioRecorder`** (`feature/notes/record/`) — `MediaRecorder` → **mono AAC `.m4a`** at `filesDir/recordings/<id>.m4a` (44.1 kHz / 96 kbps; Phase 2b's `AudioFileDecoder` is format-agnostic and resamples to 16 kHz, so this only affects size/fidelity). `@Singleton` so a **config-change mid-take re-attaches** rather than orphaning the recording. Requests its **own transient audio-focus** → the framework delivers `AUDIOFOCUS_LOSS_TRANSIENT` to the playback service's listener → **TTS pauses** (no direct coupling to playback internals). Pure `normalizeAmplitude` + `computeElapsedMs` extracted and unit-tested.
- **`RecordingService`** — **`microphone`-typed FGS** + `FOREGROUND_SERVICE_MICROPHONE`. Modeled on `StoryvoxPlaybackService`'s channel + guarded-`startForeground` shape; a plain `Service` (deliberately **not** a Media3 subclass). Ongoing notification; tapping it reopens the app.
- **`NotesRecordViewModel`** (filled) — drives the recorder + FGS; on stop `upsert`s a **`PENDING` `NoteEntity(audioPath, durationMs)`** then `TranscriptionScheduler.enqueue(id)` — **closing the Phase-2b enqueue seam** (that scheduler's own KDoc names Phase 2a as its caller). Too-short / failed takes discard cleanly — **no empty note row**.
- **`RecordScreen`** — `RECORD_AUDIO` runtime gate on the record button (canonical `rememberLauncherForActivityResult` idiom, matching `OcrCaptureScreen`); removed the "Simulated preview" cue (luna's own comment said to remove it once real capture lands).
- **Manifests** — mic `<service>` (feature manifest) + `FOREGROUND_SERVICE_MICROPHONE` (app manifest; `RECORD_AUDIO` was already declared).

### Design decisions
- **Placement + naming per spec §3.1**: capture lives in `feature/.../notes/record/`; the spec's "`RecordingController` (VM)" **is** luna's already-merged `NotesRecordViewModel` (the spec predated her naming), so I filled it instead of adding a parallel controller. *(My first pass built a service-owned bridge in `core-playback`; I scrapped it to honor the spec's placement — simpler and one fewer class.)*
- **"Survive process death" = no half-written row** (spec §3.1): the row is written only after the `.m4a` finalizes; a crash leaves an orphan file that P1's `sweepOrphanAudio` reclaims on next launch. I did **not** build background-recording-across-in-app-navigation or a notification-Stop-that-finalizes (heavier; not required by the spec). Close/back = cancel the take (luna's existing semantics preserved); backgrounding the whole app (home) keeps recording alive via the FGS.
- Call-interruption **during** capture: we take transient focus (pausing our own TTS) but don't react to focus loss mid-record — flagged as a follow-up.

### Tests
`AudioRecorderTest` (plain JVM): amplitude normalization (bounds / monotonic / perceptual boost) + pause-aware elapsed math. The `MediaRecorder`/FGS surface is device-bound (not JVM-testable) — to validate on-device after CI.

### Blast radius
`feature` only, plus one app-manifest permission line. No changes to `core-playback` / `core-data`. luna's `RecordScreen` chrome unchanged except the permission gate + the removed sim-cue. `NotesRecordViewModel`'s constructor widened (no existing test constructs it).

CI-gated. 🌙
