### PR TITLE
fix(notes): Notes nav is rail-only — drop from phone dock, keep in side rail (#1657)

### DIFF
--- a/app/src/test/kotlin/in/jphe/storyvox/navigation/NavStructureTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/navigation/NavStructureTest.kt
@@ -34,30 +34,37 @@ import org.junit.Test
 class NavStructureTest {
 
     @Test
-    fun `bottom nav exposes exactly six primary destinations`() {
-        // v0.5.72 — Playing + Library + Browse + Voices + Settings (5).
-        // Voice Notes (epic #1657) adds Notes as a sixth first-class dock
-        // pill. This deliberately crosses the "past five needs a UX
-        // review" threshold the prior revision flagged: six cells narrow
-        // each cell (notably on the Flip3's ~260 dp cover), so label
-        // rendering must be eyeballed there. Notes was a locked product
-        // decision (a first-class "Notes" destination), so the sixth pill
-        // is intentional — this assertion is the conscious record of it.
-        assertEquals(6, HomeTab.entries.size)
+    fun `bottom nav exposes exactly five primary destinations`() {
+        // Phone dock = the tabs with inBottomBar=true. Voice Notes (#1657)
+        // kept the bar at five: Notes is RAIL-ONLY — the 6th-tab decision
+        // (JP away → team-lead full-auto call) chose the side rail over a
+        // sixth dock pill, since six crowd the Flip3's ~260 dp cover. Notes
+        // still lives in HomeTab (so HomeTab.entries is 6) for the rail; it's
+        // just excluded from this bar. See the `rail-only` test below.
+        assertEquals(5, HomeTab.entries.count { it.inBottomBar })
     }
 
     @Test
-    fun `bottom nav primary destinations are Playing Library Browse Voices Notes Settings`() {
-        // Order matters — BottomTabBar uses ordinal to position the
-        // indicator pill. Playing leads (most-touched during a listening
-        // session); Library second (cold-launch landing); Browse third
-        // (discovery between "your shelves" and "playback ops"); Voices
-        // fourth; Notes fifth (Voice Notes, epic #1657 — grouped next to
-        // the voice-forward Voices pill); Settings always last.
-        val labels = HomeTab.entries.map { it.label }
-        assertEquals(listOf("Playing", "Library", "Browse", "Voices", "Notes", "Settings"), labels)
+    fun `bottom nav primary destinations are Playing Library Browse Voices Settings`() {
+        // Order matters — BottomTabBar uses ordinal to position the indicator
+        // pill. Playing leads (most-touched during a listening session);
+        // Library second (cold-launch landing); Browse third (discovery
+        // between "your shelves" and "playback ops"); Voices fourth; Settings
+        // always last. (Notes is rail-only, not in this dock — see below.)
+        val bottomBar = HomeTab.entries.filter { it.inBottomBar }.map { it.label }
+        assertEquals(listOf("Playing", "Library", "Browse", "Voices", "Settings"), bottomBar)
         assertEquals(HomeTab.Playing, HomeTab.entries.first())
         assertEquals(HomeTab.Settings, HomeTab.entries.last())
+    }
+
+    @Test
+    fun `Notes is a rail-only destination, not a phone bottom-bar tab`() {
+        // #1657 6th-tab decision — Notes stays first-class via the SideNavRail
+        // + the NOTES route, but is deliberately excluded from the phone
+        // BottomTabBar (indicator-pill density on the Flip3 cover). This pins
+        // the decision so re-adding Notes to the dock is a conscious change.
+        assertTrue("Notes still exists for the rail", HomeTab.entries.contains(HomeTab.Notes))
+        assertFalse("Notes is excluded from the phone dock", HomeTab.Notes.inBottomBar)
     }
 
     @Test

--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/BottomTabBar.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/BottomTabBar.kt
@@ -88,8 +88,10 @@ import androidx.compose.ui.unit.dp
  * other dock metaphors (Playing = transport, Library = your shelves,
  * Voices = TTS, Settings = gear).
  *
- * Six tabs now in the dock: `{Playing, Library, Browse, Voices, Notes, Settings}`
- * — Notes added for Voice Notes (epic #1657); Settings stays last.
+ * Phone dock is five pills: `{Playing, Library, Browse, Voices, Settings}`.
+ * Voice Notes (epic #1657) is **rail-only** — [HomeTab.Notes] shows in the
+ * [SideNavRail] but is excluded from this bar (`inBottomBar = false`) so the
+ * dock stays at five (six crowd the Flip3 cover). Settings stays last.
  */
 // Order matters — entries' ordinal positions the sliding indicator
 // pill left-to-right in the bar. v0.5.72 final order: Playing leads
@@ -101,14 +103,27 @@ import androidx.compose.ui.unit.dp
 // last. Library + Browse adjacent is intentional — a user finishing
 // a book in Library can swipe one tab to discover the next.
 @Immutable
-enum class HomeTab(val label: String, val filled: ImageVector, val outlined: ImageVector) {
+enum class HomeTab(
+    val label: String,
+    val filled: ImageVector,
+    val outlined: ImageVector,
+    /**
+     * Whether this tab renders in the phone [BottomTabBar]. All true except
+     * [Notes], which is **rail-only** (#1657): shown in the tablet [SideNavRail]
+     * but kept out of the phone dock so the bar stays at five pills (six crowd
+     * label rendering on the Flip3's ~260 dp cover). The NOTES route still
+     * exists (side rail + deep-links), so Notes stays first-class; a future
+     * product call can promote it to the dock by flipping this to true.
+     */
+    val inBottomBar: Boolean = true,
+) {
     Playing("Playing", Icons.Filled.PlayArrow, Icons.Outlined.PlayArrow),
     Library("Library", Icons.Filled.AutoStories, Icons.Outlined.AutoStories),
     Browse("Browse", Icons.Filled.Explore, Icons.Outlined.Explore),
     Voices("Voices", Icons.Filled.RecordVoiceOver, Icons.Outlined.RecordVoiceOver),
-    // Voice Notes (epic #1657) — a waveform glyph, distinct from Voices'
-    // RecordVoiceOver head. Positioned before Settings (dock invariant: gear last).
-    Notes("Notes", Icons.Filled.GraphicEq, Icons.Outlined.GraphicEq),
+    // Voice Notes (epic #1657) — waveform glyph, distinct from Voices'
+    // RecordVoiceOver head. RAIL-ONLY: shown in the SideNavRail, not the phone dock.
+    Notes("Notes", Icons.Filled.GraphicEq, Icons.Outlined.GraphicEq, inBottomBar = false),
     Settings("Settings", Icons.Filled.Settings, Icons.Outlined.Settings),
 }
 
@@ -144,7 +159,9 @@ fun BottomTabBar(
     onSelect: (HomeTab) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val tabs = HomeTab.entries
+    // Rail-only tabs (Notes, #1657) are excluded from the phone dock; the
+    // SideNavRail renders the full HomeTab.entries instead.
+    val tabs = HomeTab.entries.filter { it.inBottomBar }
     val selectedIndex = tabs.indexOf(selected).coerceAtLeast(0)
     val indicatorColor = MaterialTheme.colorScheme.primaryContainer
 


### PR DESCRIPTION
The **6th-tab decision** (JP away → team-lead full-auto call): make Notes **rail-only** — keep it first-class via the tablet `SideNavRail` + the `NOTES` route, but drop it from the phone `BottomTabBar` so the dock stays at **five** pills. Six crowd the indicator-pill/label rendering on the Flip3's ~260 dp cover — the guardrail `NavStructureTest` + `BottomTabBar`'s own comment flagged going past five.

## Change (2 files, ~50 lines)
- **core-ui `BottomTabBar`** — `HomeTab` gains `inBottomBar: Boolean = true`; `Notes` sets it `false`. The bar renders `HomeTab.entries.filter { it.inBottomBar }` (five pills). `SideNavRail` is **untouched** — it still renders the full `HomeTab.entries`, so Notes remains a rail destination on tablets. `HomeTab.entries` stays 6, so `TestTags.navTab`, `BottomTabBarSemanticsTest`, and the `StoryvoxNavHost` route↔tab mappings are all unchanged.
- **app `NavStructureTest`** — reverted to the five-bottom-tab invariant (asserting the `inBottomBar`-filtered dock = `Playing, Library, Browse, Voices, Settings`) + a new test pinning **Notes as rail-only** (in `entries`, `!inBottomBar`).

## Notes
- **Reversible in one line** — flip `Notes(..., inBottomBar = true)` to promote it back to the dock whenever JP calls it.
- **Minor known edge:** on a *phone*, deep-linking to the `NOTES` route shows the bottom bar with the pill defaulting to Playing (no Notes cell to highlight). Benign — phones have no Notes dock entry by design here; the rail (tablet) highlights Notes correctly.
- Notes stays reachable on phones via the `NOTES` route (deep-link) and is fully first-class on tablets via the rail.

Refs #1657

🤖 Generated with [Claude Code](https://claude.com/claude-code)
