### PR TITLE
feat(notes): non-tab nav entry for Voice Notes (rail + Library top-bar waveform)

### DIFF
--- a/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
+++ b/app/src/main/kotlin/in/jphe/storyvox/navigation/StoryvoxNavHost.kt
@@ -882,6 +882,14 @@ private fun StoryvoxNavHostContent(
                     sharedUrl = sharedUrl,
                     onOpenFiction = { id -> navController.navigate(StoryvoxRoutes.fictionDetail(id)) },
                     onOpenReader = { f, c -> navController.navigate(StoryvoxRoutes.reader(f, c)) },
+                    // Voice Notes (epic #1657) — the phone-reachable entry to
+                    // the Notes list. Notes is rail-only on the bottom nav
+                    // (HomeTab.Notes.inBottomBar = false), so phones (< 600 dp,
+                    // no SideNavRail) reach it via this Library top-bar waveform
+                    // action. Tablets keep the rail pill; NOTES stays in
+                    // HOME_ROUTES so the rail (and phone bottom bar) stay
+                    // visible on the Notes surface.
+                    onOpenNotes = { navController.navigate(StoryvoxRoutes.NOTES) },
                     // Issue #995 — "Scan a page" add-flow entry routes to
                     // the OCR capture surface.
                     onScanPage = { navController.navigate(StoryvoxRoutes.OCR_CAPTURE) },

--- a/app/src/test/kotlin/in/jphe/storyvox/navigation/NavStructureTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/navigation/NavStructureTest.kt
@@ -34,30 +34,62 @@ import org.junit.Test
 class NavStructureTest {
 
     @Test
-    fun `bottom nav exposes exactly six primary destinations`() {
-        // v0.5.72 — Playing + Library + Browse + Voices + Settings (5).
-        // Voice Notes (epic #1657) adds Notes as a sixth first-class dock
-        // pill. This deliberately crosses the "past five needs a UX
-        // review" threshold the prior revision flagged: six cells narrow
-        // each cell (notably on the Flip3's ~260 dp cover), so label
-        // rendering must be eyeballed there. Notes was a locked product
-        // decision (a first-class "Notes" destination), so the sixth pill
-        // is intentional — this assertion is the conscious record of it.
+    fun `bottom nav exposes exactly five primary destinations`() {
+        // Phone dock = the tabs with inBottomBar=true. Voice Notes (#1657)
+        // kept the bar at five: Notes is RAIL-ONLY. Notes still lives in
+        // HomeTab (so HomeTab.entries is 6, driving the tablet SideNavRail),
+        // but it's excluded from the phone BottomTabBar — six pills crowd the
+        // Flip3's ~260 dp cover. Phones reach Notes via the Library top-bar
+        // waveform action instead (onOpenNotes → NOTES). See the `rail-only`
+        // and `Library top-bar` tests below.
+        assertEquals(5, HomeTab.entries.count { it.inBottomBar })
+        // The rail still carries all six (the five dock tabs + Notes).
         assertEquals(6, HomeTab.entries.size)
     }
 
     @Test
-    fun `bottom nav primary destinations are Playing Library Browse Voices Notes Settings`() {
-        // Order matters — BottomTabBar uses ordinal to position the
-        // indicator pill. Playing leads (most-touched during a listening
-        // session); Library second (cold-launch landing); Browse third
-        // (discovery between "your shelves" and "playback ops"); Voices
-        // fourth; Notes fifth (Voice Notes, epic #1657 — grouped next to
-        // the voice-forward Voices pill); Settings always last.
-        val labels = HomeTab.entries.map { it.label }
-        assertEquals(listOf("Playing", "Library", "Browse", "Voices", "Notes", "Settings"), labels)
+    fun `bottom nav primary destinations are Playing Library Browse Voices Settings`() {
+        // Order matters — BottomTabBar uses ordinal to position the indicator
+        // pill. Playing leads (most-touched during a listening session);
+        // Library second (cold-launch landing); Browse third (discovery
+        // between "your shelves" and "playback ops"); Voices fourth; Settings
+        // always last. (Notes is rail-only, not in this dock — see below.)
+        val bottomBar = HomeTab.entries.filter { it.inBottomBar }.map { it.label }
+        assertEquals(listOf("Playing", "Library", "Browse", "Voices", "Settings"), bottomBar)
         assertEquals(HomeTab.Playing, HomeTab.entries.first())
         assertEquals(HomeTab.Settings, HomeTab.entries.last())
+    }
+
+    @Test
+    fun `Notes is a rail-only destination, not a phone bottom-bar tab`() {
+        // #1657 — Notes stays first-class via the tablet SideNavRail + the
+        // NOTES route, but is deliberately excluded from the phone
+        // BottomTabBar (indicator-pill density on the Flip3 cover). Phones
+        // reach it via the Library top-bar waveform action (onOpenNotes). This
+        // pins the decision so re-adding Notes to the dock is a conscious change.
+        assertTrue("Notes still exists for the rail", HomeTab.entries.contains(HomeTab.Notes))
+        assertFalse("Notes is excluded from the phone dock", HomeTab.Notes.inBottomBar)
+    }
+
+    @Test
+    fun `every non-Notes tab still renders in the phone bottom bar`() {
+        // The rail-only carve-out is Notes and Notes alone — every other
+        // HomeTab must stay a phone dock pill. Guards against a future tab
+        // accidentally inheriting inBottomBar=false and vanishing from phones.
+        HomeTab.entries.filter { it != HomeTab.Notes }.forEach {
+            assertTrue("${it.name} must render in the phone bottom bar", it.inBottomBar)
+        }
+    }
+
+    @Test
+    fun `Notes is a home route so the nav surface stays visible`() {
+        // NOTES must stay in HOME_ROUTES so the tablet SideNavRail (gated on
+        // showHomeNav) renders on the Notes screen — dropping it would strand
+        // the rail. On phones the bottom bar also stays visible there. The
+        // NOTES constant is the target of both the rail pill and the Library
+        // top-bar waveform action, so pin it too.
+        assertTrue(StoryvoxRoutes.isHome(StoryvoxRoutes.NOTES))
+        assertEquals("notes", StoryvoxRoutes.NOTES)
     }
 
     @Test

--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/BottomTabBar.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/BottomTabBar.kt
@@ -88,8 +88,13 @@ import androidx.compose.ui.unit.dp
  * other dock metaphors (Playing = transport, Library = your shelves,
  * Voices = TTS, Settings = gear).
  *
- * Six tabs now in the dock: `{Playing, Library, Browse, Voices, Notes, Settings}`
- * — Notes added for Voice Notes (epic #1657); Settings stays last.
+ * Phone dock is five pills: `{Playing, Library, Browse, Voices, Settings}`.
+ * Voice Notes (epic #1657) is **rail-only** — [HomeTab.Notes] shows in the
+ * [SideNavRail] (tablets, ≥600 dp) but is excluded from this bar
+ * (`inBottomBar = false`) so the dock stays at five (six crowd the Flip3
+ * cover). Phones reach Notes via the Library top-bar waveform action
+ * (`onOpenNotes`, wired in `StoryvoxNavHost`), not a dock pill. Settings
+ * stays last.
  */
 // Order matters — entries' ordinal positions the sliding indicator
 // pill left-to-right in the bar. v0.5.72 final order: Playing leads
@@ -101,14 +106,31 @@ import androidx.compose.ui.unit.dp
 // last. Library + Browse adjacent is intentional — a user finishing
 // a book in Library can swipe one tab to discover the next.
 @Immutable
-enum class HomeTab(val label: String, val filled: ImageVector, val outlined: ImageVector) {
+enum class HomeTab(
+    val label: String,
+    val filled: ImageVector,
+    val outlined: ImageVector,
+    /**
+     * Whether this tab renders in the phone [BottomTabBar]. All true except
+     * [Notes], which is **rail-only** (#1657): shown in the tablet [SideNavRail]
+     * but kept out of the phone dock so the bar stays at five pills (six crowd
+     * label rendering on the Flip3's ~260 dp cover). Phones reach Notes via the
+     * Library top-bar waveform action instead (see `onOpenNotes` in
+     * `StoryvoxNavHost`). The NOTES route still exists (rail + top-bar action +
+     * deep-links), so Notes stays first-class; a future product call can promote
+     * it to the dock by flipping this to true.
+     */
+    val inBottomBar: Boolean = true,
+) {
     Playing("Playing", Icons.Filled.PlayArrow, Icons.Outlined.PlayArrow),
     Library("Library", Icons.Filled.AutoStories, Icons.Outlined.AutoStories),
     Browse("Browse", Icons.Filled.Explore, Icons.Outlined.Explore),
     Voices("Voices", Icons.Filled.RecordVoiceOver, Icons.Outlined.RecordVoiceOver),
-    // Voice Notes (epic #1657) — a waveform glyph, distinct from Voices'
-    // RecordVoiceOver head. Positioned before Settings (dock invariant: gear last).
-    Notes("Notes", Icons.Filled.GraphicEq, Icons.Outlined.GraphicEq),
+    // Voice Notes (epic #1657) — waveform glyph, distinct from Voices'
+    // RecordVoiceOver head. RAIL-ONLY: shown in the SideNavRail, not the phone
+    // dock (phones use the Library top-bar action). Same GraphicEq glyph is
+    // reused by that action so the entry reads as one design family.
+    Notes("Notes", Icons.Filled.GraphicEq, Icons.Outlined.GraphicEq, inBottomBar = false),
     Settings("Settings", Icons.Filled.Settings, Icons.Outlined.Settings),
 }
 
@@ -144,7 +166,9 @@ fun BottomTabBar(
     onSelect: (HomeTab) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val tabs = HomeTab.entries
+    // Rail-only tabs (Notes, #1657) are excluded from the phone dock; the
+    // SideNavRail renders the full HomeTab.entries instead.
+    val tabs = HomeTab.entries.filter { it.inBottomBar }
     val selectedIndex = tabs.indexOf(selected).coerceAtLeast(0)
     val indicatorColor = MaterialTheme.colorScheme.primaryContainer
 

--- a/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/TestTags.kt
+++ b/core-ui/src/main/kotlin/in/jphe/storyvox/ui/component/TestTags.kt
@@ -45,6 +45,11 @@ object TestTags {
     const val LibraryItem = "library-item"
     const val LibraryFab = "library-fab"
 
+    /** Voice Notes (#1657) — the waveform action in the Library top bar. This
+     *  is the phone-reachable entry to the Notes list (Notes is rail-only on
+     *  the bottom nav, so phones have no dock pill for it). */
+    const val LibraryOpenNotes = "library-open-notes"
+
     // ── Browse ───────────────────────────────────────────────────────────
     const val BrowseSearchField = "browse-search-field"
     const val BrowseSourceList = "browse-source-list"

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.DocumentScanner
+import androidx.compose.material.icons.outlined.GraphicEq
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Badge
 import androidx.compose.material3.Card
@@ -165,6 +166,15 @@ fun LibraryScreen(
      * no-op so test / preview surfaces that don't exercise it still compile.
      */
     onFillForm: () -> Unit = {},
+    /**
+     * Voice Notes (epic #1657) — the phone-reachable entry to the Notes list.
+     * Notes is rail-only on the bottom nav ([HomeTab.Notes] has `inBottomBar =
+     * false`), so on phones (< 600 dp, no [SideNavRail]) the only first-class
+     * way in is this Library top-bar waveform action. The production wiring in
+     * [StoryvoxNavHost] routes it to [StoryvoxRoutes.NOTES]. Default no-op so
+     * test / preview surfaces that don't exercise it still compile.
+     */
+    onOpenNotes: () -> Unit = {},
     viewModel: LibraryViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -295,6 +305,23 @@ fun LibraryScreen(
                     `in`.jphe.storyvox.feature.sync.SyncCloudIcon(
                         onClick = { syncSheetOpen = true },
                     )
+                    Spacer(Modifier.width(spacing.xs))
+                    // Voice Notes (epic #1657) — the phone-reachable entry.
+                    // Notes is rail-only in the bottom nav (HomeTab.Notes,
+                    // inBottomBar = false), so phones (no SideNavRail below
+                    // 600 dp) reach it here. Reuses HomeTab.Notes' GraphicEq
+                    // waveform glyph so the top-bar action and the tablet rail
+                    // pill read as the same destination.
+                    androidx.compose.material3.IconButton(
+                        onClick = onOpenNotes,
+                        modifier = Modifier.testTag(TestTags.LibraryOpenNotes),
+                    ) {
+                        Icon(
+                            imageVector = Icons.Outlined.GraphicEq,
+                            contentDescription = stringResource(R.string.library_open_notes_cd),
+                            tint = MaterialTheme.colorScheme.primary,
+                        )
+                    }
                 },
             )
         },

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -1227,6 +1227,8 @@
     <string name="ocr_remove_page_cd">Remove %1$s</string>
     <string name="ocr_save_and_read">Save and read</string>
     <string name="library_scan_page_cd">Scan a printed page to read aloud</string>
+    <!-- #1657 — Library top-bar waveform action: the phone entry to Voice Notes. -->
+    <string name="library_open_notes_cd">Voice Notes</string>
 
 
     <!-- Issue #1235 — Listening statistics dashboard -->


### PR DESCRIPTION
Refs #1657

## Problem
Voice Notes (merged on `main` at f6c16440) had a 6th bottom-tab (`HomeTab.Notes`). Six pills crowd the indicator-pill/label rendering on the Flip3's ~260 dp cover. The prior attempt (closed PR #1667) dropped Notes from the bottom bar and relied on the tablet-only `SideNavRail` — which **stranded Notes on phones** (no rail below 600 dp). This PR keeps Notes reachable on **every** form factor.

## Change (6 files)
- **core-ui `BottomTabBar`** — `HomeTab` gains `inBottomBar: Boolean = true`; `Notes` sets it `false`. The bar renders `HomeTab.entries.filter { it.inBottomBar }` (five pills). `SideNavRail` is untouched — it still renders the full `HomeTab.entries`, so Notes stays a **tablet rail** destination. `HomeTab.entries` stays 6, so `TestTags.navTab`, `BottomTabBarSemanticsTest`, and the `StoryvoxNavHost` route-tab mappings are unchanged. (This is the `inBottomBar` idea from #1667.)
- **feature `LibraryScreen`** — new `onOpenNotes` callback + a waveform `IconButton` in the shared `MagicTitleBar` top-bar `actions` (alongside the TechEmpower help + Sync-cloud icons). Reuses `HomeTab.Notes`' `Icons.Outlined.GraphicEq` glyph so the top-bar action and the tablet rail pill read as the **same destination**. TalkBack content-description via `library_open_notes_cd`; UI-test tag `TestTags.LibraryOpenNotes`.
- **app `StoryvoxNavHost`** — wires `onOpenNotes = { navController.navigate(StoryvoxRoutes.NOTES) }`.
- **app `NavStructureTest`** — five-bottom-tab invariant (`count { inBottomBar } == 5`, order `Playing, Library, Browse, Voices, Settings`) + `HomeTab.entries.size == 6` (rail) + new asserts: Notes is rail-only, every non-Notes tab stays in the dock, and `NOTES` is a home route.

## Phone entry chosen
**A waveform `IconButton` in the Library top app bar** (the `MagicTitleBar` `actions` slot). Library is the cold-launch landing (`startDestination`) and a dock pill on every form factor, so this shortcut is present the moment the app opens. Chosen over the Library-card fallback because the top bar already hosts action icons and cleanly accepts one more.

## Reachability verification
- **Phone (< 600 dp -> `BottomTabBar`)**: dock shows **five** pills (Playing, Library, Browse, Voices, Settings) — no Notes pill. A phone user reaches Notes by tapping the **waveform icon in the Library top bar** -> navigates to `StoryvoxRoutes.NOTES`. Library is the cold-launch landing, so the entry is present at first open (and one tap away from any other tab via the Library pill).
- **Tablet (>= 600 dp -> `SideNavRail`)**: rail renders all **six** `HomeTab.entries`, so the **Notes** pill is present and highlighted correctly (route-collapse maps `NOTES` -> `HomeTab.Notes`). The Library top-bar waveform action is also present (harmless redundancy).
- `NOTES` stays in `HOME_ROUTES`, so on the Notes screen the nav surface stays visible on both form factors (tablet rail keeps showing; benign known edge: on a phone the bottom-bar pill defaults to Playing since Notes has no cell — same edge #1667 flagged).

## Not compiled locally
Per project convention (no local gradle on this host) — CI's `Build APK` is the compile gate. Changes are a superset of the proven #1667 pattern (enum ctor param + `filter`) plus a standard `IconButton`; no R8-sensitive surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Voice Notes action to the Library screen for quick access to notes.
  * Voice Notes remain available through navigation and deep links.

* **UI Changes**
  * Simplified the phone bottom bar to five destinations: Playing, Library, Browse, Voices, and Settings.
  * Voice Notes are now accessible from the Library instead of the phone bottom bar.
  * Tablets retain Voice Notes in the navigation rail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->