### PR TITLE
ci: disable Dependabot auto-rebase to stop the build-swarm OOM

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,15 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 10
+    # Dependabot's default rebase-strategy ("auto") rebases EVERY open bot PR
+    # whenever `main` moves — so merging any one PR fires a rebase across all
+    # the others, each triggering the required Build APK at once. On the
+    # self-hosted runners (familiar, 5g heap) that concurrent swarm OOM-kills
+    # the build daemon (seen during the #1610 merge cascade: 7 open gradle PRs
+    # → 7 simultaneous Android builds). "disabled" keeps the open PRs static;
+    # rebase one on demand with `@dependabot rebase`, or let the serialized
+    # merge cascade update each as it's picked up.
+    rebase-strategy: "disabled"
     assignees:
       - "jphein"
     labels:


### PR DESCRIPTION
## Root cause

Dependabot's default `rebase-strategy` is **`auto`**: whenever `main` moves, it rebases **every** open bot PR, and each rebase re-triggers the required **Build APK** check. So merging any single PR fires **N concurrent Android builds** — during tonight's #1610 merge cascade that was **7 open gradle PRs → 7 simultaneous builds**, which OOM-kills the self-hosted build daemon (familiar, 5g heap).

## Fix

Set **`rebase-strategy: "disabled"`** on the `gradle` ecosystem — the only ecosystem in this config, and all 7 currently-open bot PRs (#1611–#1617) are gradle, so this one setting covers the whole swarm.

- Open bot PRs now stay **static** until explicitly rebased.
- **Manual `@dependabot rebase` still works** (per-PR, on demand).
- The serialized merge cascade updates each PR as it's picked up — **one build at a time**, no swarm, no OOM.

Config-only; no code touched. YAML validated; `groups` / `ignore` / `labels` untouched.

Refs #1610 (the cascade that surfaced this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)