### PR TITLE
test: harden Voice Notes backup-rules exclusion gate (#1659)

### DIFF
--- a/app/src/test/kotlin/in/jphe/storyvox/notes/BackupRulesExclusionTest.kt
+++ b/app/src/test/kotlin/in/jphe/storyvox/notes/BackupRulesExclusionTest.kt
@@ -1,15 +1,29 @@
 package `in`.jphe.storyvox.notes
 
+import `in`.jphe.storyvox.data.notes.NotesDatabase
+import `in`.jphe.storyvox.data.notes.NotesRepository
 import java.io.File
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
  * Voice Notes (#1657, Phase 1) — **the privacy gate.** Asserts the backup
- * rules exclude the notes DB file AND the `recordings/` audio dir from BOTH
- * `cloud-backup` and `device-transfer` (spec §3.7). A mismatched or missing
- * exclude silently uploads plaintext notes + audio to Google's cloud — so
- * this test must pass before any note data ships.
+ * rules exclude the notes DB file (and every SQLite journal sibling) AND the
+ * `recordings/` audio dir from BOTH `cloud-backup` and `device-transfer`
+ * (spec §3.7). A mismatched or missing exclude silently uploads plaintext
+ * notes + audio to Google's cloud — so this test must pass before any note
+ * data ships.
+ *
+ * Hardened for #1659 so the gate can't silently rot:
+ *  - Each of `notes.db`, `-wal`, `-shm`, `-journal` is asserted **individually**
+ *    (the closing quote in the match is load-bearing — see [assertNoteExcludes]),
+ *    so deleting ANY single journal-exclusion line fails the test. The `-wal`
+ *    in particular holds recently-written, un-checkpointed note text under
+ *    Room's default WAL mode; excluding only `notes.db` would leak it.
+ *  - The DB-name prefix and the recordings dir are pinned to their
+ *    source-of-truth consts ([NotesDatabase.NAME], [NotesRepository.RECORDINGS_SUBDIR]),
+ *    so renaming a const without updating the XML breaks this test rather than
+ *    silently un-protecting the data.
  *
  * Pure-JVM: reads the res XML by path and checks the exclude lines land in the
  * right `<domain>` sections (no Android XML parser dependency).
@@ -30,13 +44,23 @@ class BackupRulesExclusionTest {
     }
 
     private fun assertNoteExcludes(section: String, where: String) {
+        // Every notes-DB journal sibling must be excluded INDIVIDUALLY. The
+        // trailing `\"` in each match is load-bearing: without it the base
+        // `path="notes.db"` line would satisfy the `-wal`/`-shm`/`-journal`
+        // assertions by prefix, so deleting those exclude lines would go
+        // undetected and leak un-checkpointed note text.
+        for (dbFile in NOTES_DB_FILES) {
+            assertTrue(
+                "$where must exclude the notes DB file '$dbFile' (domain=\"database\")",
+                section.contains("domain=\"database\" path=\"$dbFile\""),
+            )
+        }
+        val recordings = NotesRepository.RECORDINGS_SUBDIR
         assertTrue(
-            "$where must exclude the notes.db database file",
-            section.contains("domain=\"database\" path=\"notes.db"),
-        )
-        assertTrue(
-            "$where must exclude the recordings/ audio dir",
-            section.contains("domain=\"file\" path=\"recordings/"),
+            "$where must exclude the recordings/ audio dir — the path must match " +
+                "NotesRepository.RECORDINGS_SUBDIR ('$recordings'); a rename that " +
+                "misses the XML silently un-protects the audio (spec §3.7)",
+            section.contains("domain=\"file\" path=\"$recordings/\""),
         )
     }
 
@@ -51,5 +75,17 @@ class BackupRulesExclusionTest {
     fun legacyBackupRules_excludeNotesAndRecordings() {
         val xml = rulesFile("backup_rules.xml").readText()
         assertNoteExcludes(section(xml, "full-backup-content"), "full-backup-content")
+    }
+
+    private companion object {
+        /**
+         * The notes DB file plus every SQLite journal sibling that can hold
+         * un-checkpointed note text: `-wal`/`-shm` (Room's default WAL mode)
+         * and `-journal` (the rollback-journal fallback). Derived from
+         * [NotesDatabase.NAME] so a DB-name rename that misses the XML fails
+         * here instead of silently shipping the notes to the cloud.
+         */
+        val NOTES_DB_FILES: List<String> =
+            listOf("", "-wal", "-shm", "-journal").map { NotesDatabase.NAME + it }
     }
 }


### PR DESCRIPTION
Hardens `BackupRulesExclusionTest` — the privacy gate that keeps Voice Notes (#1657) plaintext + audio out of Google's cloud backup and device transfer.

## The gap
`assertNoteExcludes` matched the DB exclude by **prefix**: `path="notes.db` (no closing quote). So all four journal siblings satisfied one assertion — **deleting the `-wal` / `-shm` / `-journal` exclude lines went undetected**, even though `-wal` holds recently-written, un-checkpointed note text under Room's default WAL mode. The `recordings/` path was a hardcoded literal, uncoupled from the const the XML comments claim it mirrors.

## The hardening
- Assert **`notes.db`, `-wal`, `-shm`, `-journal` individually** — each with a **closing quote** (load-bearing: without it the base `notes.db` line prefix-satisfies the others) — in all three sections: `cloud-backup`, `device-transfer`, `full-backup-content`. Deleting any single journal exclude now fails the test.
- Pin the DB-name prefix to **`NotesDatabase.NAME`** and the recordings dir to **`NotesRepository.RECORDINGS_SUBDIR`** (both public consts in `core-data`; `app` depends on it). A const rename that misses the XML now breaks the test instead of silently un-protecting the data.

**Test-only** — the XML already carries all four excludes; no privacy gap, no runtime change.

## Verification (no local gradle — CI is the compile gate)
Simulated the exact assertions against the real XML: **passes** on current truth; **fails** on a single `-wal` deletion; **fails** on a `recordings/` rename; and confirmed the old prefix-match was blind to the `-wal` deletion. Kotlin reviewed for compile-correctness (imports, public-const visibility, syntax).

Closes #1659
Refs #1657 #1658

🤖 Generated with [Claude Code](https://claude.com/claude-code)