### PR TITLE
build: bundle FULL native debug symbols in release (#1674)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -368,6 +368,17 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro",
             )
+            // #1674 — bundle FULL native debug symbols into the release
+            // artifact so the Play Console can symbolicate native crash
+            // traces. Candela ships no native code of its own, but the
+            // VoxSherpa-TTS / sherpa-onnx AAR contributes prebuilt `.so`
+            // libraries — without this their frames land in Play as raw
+            // addresses. "FULL" = unwind tables + line numbers (per #1674);
+            // AGP's mergeReleaseNativeDebugMetadata extracts them into the
+            // APK/AAB. Exercised by the release assemble in CI's Build APK.
+            ndk {
+                debugSymbolLevel = "FULL"
+            }
             // #952 — pick the keystore by task-graph intent:
             //   * `:app:bundleRelease` / `:app:publishReleaseBundle`
             //     (the Play AAB path) → release keystore when wired


### PR DESCRIPTION
Adds `ndk { debugSymbolLevel = "FULL" }` to `buildTypes.release` so the shipped release APK/AAB carries unwind tables + line numbers for its native libraries.

## Why
Candela ships **no native code of its own**, but the VoxSherpa-TTS / sherpa-onnx AAR contributes prebuilt `.so` libraries. Without bundled debug symbols, any native crash arrives in the **Play Console un-symbolicated** — raw addresses instead of function + line. `"FULL"` gives full unwind + line info (per the issue); AGP's `mergeReleaseNativeDebugMetadata` extracts them into the artifact.

## Proof
CI's **Build APK** assembles the **release** variant, so a green run exercises this exact path — proof the NDK symbol-extraction step is happy.

_One-block change in `app/build.gradle.kts`; no code, no runtime behavior change._

Closes #1674

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved native crash reporting for release builds by enabling full debug symbols, allowing more detailed crash trace analysis in the Play Console.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->