### PR TITLE
fix: consume the shared URL so Share → Candela adds it (#1679)

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/AddByUrlSheet.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/AddByUrlSheet.kt
@@ -75,7 +75,11 @@ fun AddByUrlSheet(
     val sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val spacing = LocalSpacing.current
     val context = LocalContext.current
-    var input by remember { mutableStateOf("") }
+    // #1679 — seed from the Open state's prefill so a shared / clipboard URL
+    // lands in the field ready to confirm. `remember` initialises once per
+    // open (the sheet returns early while Hidden above, disposing this state),
+    // so the user's edits survive recomposition but a fresh open re-seeds.
+    var input by remember { mutableStateOf((state as? AddByUrlSheetState.Open)?.prefill.orEmpty()) }
 
     val error: String? = (state as? AddByUrlSheetState.Open)?.error
     val isSubmitting = state === AddByUrlSheetState.Submitting

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryScreen.kt
@@ -254,6 +254,24 @@ fun LibraryScreen(
         out
     }
 
+    // Issue #1679 — the share-intent (ACTION_SEND / EXTRA_TEXT) and the
+    // clipboard magic-link deliver a URL as the one-shot [sharedUrl] nav arg.
+    // Open the Add-by-URL sheet pre-filled with it. Before #1679 this param
+    // was plumbed all the way here and then dropped (never consumed), so a
+    // shared URL opened the app but was never added. `rememberSaveable` guards
+    // once-only: returning to Library via the back stack re-enters this
+    // composition with the same arg and must NOT re-open the sheet.
+    var consumedShareUrl by androidx.compose.runtime.saveable.rememberSaveable {
+        androidx.compose.runtime.mutableStateOf<String?>(null)
+    }
+    androidx.compose.runtime.LaunchedEffect(sharedUrl) {
+        val url = sharedUrl?.trim().orEmpty()
+        if (url.isNotBlank() && url != consumedShareUrl) {
+            consumedShareUrl = url
+            viewModel.onSharedUrl(url)
+        }
+    }
+
     androidx.compose.runtime.LaunchedEffect(viewModel) {
         viewModel.events.collect { event ->
             when (event) {

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/library/LibraryViewModel.kt
@@ -182,8 +182,12 @@ sealed interface AddByUrlSheetState {
     /** Sheet hidden. */
     data object Hidden : AddByUrlSheetState
 
-    /** Sheet shown, accepting input. [error] non-null after a failed submission. */
-    data class Open(val error: String? = null) : AddByUrlSheetState
+    /**
+     * Sheet shown, accepting input. [error] non-null after a failed submission.
+     * [prefill] (#1679) seeds the input field when the sheet is opened from a
+     * share-intent / clipboard magic-link so the user just confirms.
+     */
+    data class Open(val error: String? = null, val prefill: String? = null) : AddByUrlSheetState
 
     /** Submission in flight (network call to the source). */
     data object Submitting : AddByUrlSheetState
@@ -601,6 +605,18 @@ class LibraryViewModel @Inject constructor(
         _addByUrlState.value = AddByUrlSheetState.Open()
     }
 
+    /**
+     * Issue #1679 — a URL arrived via the share-intent (`ACTION_SEND` /
+     * `EXTRA_TEXT`) or the clipboard magic-link, plumbed here as the
+     * `sharedUrl` nav arg. Open the Add-by-URL sheet **pre-filled** so the user
+     * confirms — never a silent auto-add (matches the #472 "Magic-add sheet
+     * pre-populated" contract). No-op for blank / non-http(s) input. Before
+     * #1679 the plumbed URL was dropped at the UI: the sheet never opened.
+     */
+    fun onSharedUrl(sharedUrl: String?) {
+        sharePrefillState(sharedUrl)?.let { _addByUrlState.value = it }
+    }
+
     fun dismissAddByUrl() {
         _addByUrlState.value = AddByUrlSheetState.Hidden
     }
@@ -834,4 +850,17 @@ internal fun isLikelyAddByUrl(raw: String): Boolean {
     if (lower.startsWith("http://") && url.length > "http://".length) return true
     if (lower.startsWith("https://") && url.length > "https://".length) return true
     return false
+}
+
+/**
+ * Issue #1679 — pure decision (no Android/Compose types, so it runs as a plain
+ * JUnit test): the [AddByUrlSheetState] to show for an inbound shared URL, or
+ * null when the string isn't an add-able http(s) URL (blank / scheme-only /
+ * other scheme). A non-null result is always [AddByUrlSheetState.Open]
+ * pre-filled with the trimmed URL — the caller confirms; we never silent-add.
+ */
+internal fun sharePrefillState(sharedUrl: String?): AddByUrlSheetState.Open? {
+    val trimmed = sharedUrl?.trim().orEmpty()
+    if (trimmed.isEmpty() || !isLikelyAddByUrl(trimmed)) return null
+    return AddByUrlSheetState.Open(prefill = trimmed)
 }

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/library/SharePrefillStateTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/library/SharePrefillStateTest.kt
@@ -1,0 +1,60 @@
+package `in`.jphe.storyvox.feature.library
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Issue #1679 — Chrome "Share → Candela" (and the clipboard magic-link) opened
+ * the app but never added the URL: the `sharedUrl` nav arg was plumbed all the
+ * way to `LibraryScreen` and then dropped (no consumer). [sharePrefillState] is
+ * the pure decision that now bridges the arg into the Add-by-URL sheet.
+ *
+ * Exercised directly (no VM coroutine harness) — same pattern as
+ * [AddByUrlSchemeTest] over [isLikelyAddByUrl], which this composes on top of.
+ */
+class SharePrefillStateTest {
+
+    @Test
+    fun `null or blank yields no sheet`() {
+        assertNull(sharePrefillState(null))
+        assertNull(sharePrefillState(""))
+        assertNull(sharePrefillState("   "))
+        assertNull(sharePrefillState("\n\t "))
+    }
+
+    @Test
+    fun `non-http(s) or scheme-only text yields no sheet`() {
+        assertNull(sharePrefillState("just some shared text"))
+        assertNull(sharePrefillState("ftp://example.com/file"))
+        assertNull(sharePrefillState("file:///etc/passwd"))
+        assertNull(sharePrefillState("http://")) // scheme only, no authority
+        assertNull(sharePrefillState("https://")) // scheme only, no authority
+    }
+
+    @Test
+    fun `http and https URLs open the sheet pre-filled, trimmed`() {
+        assertEquals(
+            AddByUrlSheetState.Open(prefill = "https://example.com/story/1"),
+            sharePrefillState("  https://example.com/story/1  "),
+        )
+        assertEquals(
+            AddByUrlSheetState.Open(prefill = "http://www.royalroad.com/fiction/12345"),
+            sharePrefillState("http://www.royalroad.com/fiction/12345"),
+        )
+    }
+
+    @Test
+    fun `scheme is case-insensitive but the prefill preserves original casing`() {
+        assertEquals(
+            AddByUrlSheetState.Open(prefill = "HTTPS://Example.com/X"),
+            sharePrefillState("HTTPS://Example.com/X"),
+        )
+    }
+
+    @Test
+    fun `prefill never carries an error (it is a fresh open, not a retry)`() {
+        val open = sharePrefillState("https://example.com/a")
+        assertEquals(null, open?.error)
+    }
+}


### PR DESCRIPTION
## Root cause (proven, static)
Chrome **"Share → Candela"** (`ACTION_SEND` / `EXTRA_TEXT`) opened the app but **never added the URL**. The URL is plumbed correctly the whole way — manifest `ACTION_SEND`+`DEFAULT`+`text/plain` → `MainActivity` navigates `DeepLinkResolver.resolve()` → `libraryWithShare()` route → `library?sharedUrl={…}` nav arg → `LibraryScreen(sharedUrl=…)` — **and then dropped**: `sharedUrl` was a **dead parameter**, never consumed into the Add-by-URL (Magic-add) flow, and the ViewModel never read it either. The **clipboard magic-link** path reuses the same `libraryWithShare` route, so it was broken by the identical gap.

(Refuted along the way: `looksLikeUrl` is *not* too strict — it handles multi-line "Title\nURL"; the nav arg *is* `Uri.encode`d. Both correct.)

## Fix (matches the documented #472 "Magic-add sheet **pre-populated**" contract — no silent add)
- **`LibraryScreen`** — a consume-once `LaunchedEffect(sharedUrl)` calls `viewModel.onSharedUrl(url)`; a `rememberSaveable` guard prevents re-opening when back-nav re-enters the composition with the same arg (survives process death).
- **`LibraryViewModel.onSharedUrl` + pure `sharePrefillState()`** — opens the sheet **pre-filled** with the URL; no-op for blank / non-http(s) input.
- **`AddByUrlSheetState.Open` gains `prefill`** (default `null`, back-compat); **`AddByUrlSheet`** seeds its text field from it.
- **`SharePrefillStateTest`** — JVM unit test for the pure decision (null/blank/non-URL → no sheet; http(s) → pre-filled, trimmed, case-insensitive scheme).

## ✅ CI proves (compile + unit)
`Build APK` (release assemble) + `Test Compile` + the new JVM test.

## 📱 Device-verify — **for JP** (CI cannot prove runtime UI behavior; do NOT merge until checked)
- [ ] **Cold-start** "Share → Candela" from Chrome → app opens on Library and the Add-by-URL sheet appears **pre-filled** with the shared URL.
- [ ] Tapping **Add** actually adds the fiction (readability catch-all resolves any http(s) URL).
- [ ] **Once-only:** dismiss the sheet, navigate away and back to Library → the sheet does **not** re-open.
- [ ] **Clipboard magic-link** (copy a URL, open app) still opens the sheet pre-filled (same code path — should be fixed too).
- [ ] A **non-URL** share (plain text) does not pop the sheet.

Closes #1679
Refs #472

🤖 Generated with [Claude Code](https://claude.com/claude-code)