### PR TITLE
test: add Compose-UI test toolchain to :feature (#1661)

### DIFF
--- a/feature/build.gradle.kts
+++ b/feature/build.gradle.kts
@@ -56,6 +56,11 @@ android {
             // Robolectric just to mock android.util.Log would be heavier
             // than the surface here justifies.
             isReturnDefaultValues = true
+            // #1661 — the Compose-UI test toolchain (createComposeRule under
+            // Robolectric) needs the merged resources + manifest on the
+            // unit-test classpath to inflate its host activity. Mirrors
+            // core-playback's Robolectric testOptions.
+            isIncludeAndroidResources = true
         }
     }
 }
@@ -139,4 +144,19 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.kotlinx.serialization.json)
+
+    // #1661 — Compose-UI test toolchain for :feature (deferred from Voice
+    // Notes Phase 4). Robolectric hosts createComposeRule() as a JVM unit
+    // test — no emulator: the Compose BOM pins ui-test-junit4 (createComposeRule
+    // + onNode*/assert* matchers), ui-test-manifest supplies the empty
+    // ComponentActivity the rule drives, and robolectric + the
+    // isIncludeAndroidResources testOption above give the SDK-36 sandbox its
+    // resources. NOTE (project memory): CI *compiles* these (Test Compile job)
+    // but the SDK-36 Robolectric sandbox needs local JDK 21 to *execute*
+    // (JDK 17 fails at classMethod) — so green CI proves the toolchain is
+    // wired, and running the Compose tests is a local-JDK21 concern.
+    testImplementation(platform(libs.androidx.compose.bom))
+    testImplementation(libs.androidx.compose.ui.test.junit4)
+    testImplementation(libs.robolectric)
+    debugImplementation(libs.androidx.compose.ui.test.manifest)
 }

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/ComposeUiToolchainSmokeTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/ComposeUiToolchainSmokeTest.kt
@@ -1,0 +1,49 @@
+package `in`.jphe.storyvox.feature
+
+import androidx.compose.material3.Text
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * Issue #1661 — proves the Compose-UI test toolchain for `:feature` is wired
+ * (deferred from Voice Notes Phase 4). [createComposeRule] runs under
+ * Robolectric as a plain JVM unit test (no emulator), so any real `:feature`
+ * screen — e.g. a Notes surface — can be driven with `setContent { … }` +
+ * `onNode*` / `assert*` from here on.
+ *
+ * - [GraphicsMode.Mode.NATIVE] is required for Compose to actually rasterise
+ *   under Robolectric (the default LEGACY canvas can't).
+ * - `@Config(sdk = [36])` pins the sandbox to the project's compileSdk.
+ * - `testOptions { unitTests { isIncludeAndroidResources = true } }` (see
+ *   `feature/build.gradle.kts`) gives the sandbox the merged resources +
+ *   manifest the rule's host activity inflates.
+ *
+ * NOTE (project memory): CI **compiles** this (the Test Compile job) but the
+ * SDK-36 Robolectric sandbox needs **JDK 21 to execute** (JDK 17 fails at
+ * `classMethod` with "Android SDK 36 requires Java 21"). CI runs JDK 17 and
+ * only compiles tests — so a green build proves the toolchain is wired;
+ * *running* the Compose tests is a local-JDK21 step, not a merge gate.
+ */
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(sdk = [36])
+class ComposeUiToolchainSmokeTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun composeRule_setsContent_andFindsNode() {
+        composeRule.setContent {
+            Text("compose-ui-toolchain-ok")
+        }
+        composeRule.onNodeWithText("compose-ui-toolchain-ok").assertIsDisplayed()
+    }
+}


### PR DESCRIPTION
Deferred from Voice Notes Phase 4. Establishes the **Compose-under-Robolectric** unit-test rig for `:feature` — the first module to drive Compose with `createComposeRule()` as a plain JVM test (no emulator).

## Changes
- **`feature/build.gradle.kts`**
  - `testImplementation`: Compose **BOM** + **`ui-test-junit4`** (`createComposeRule` + `onNode*`/`assert*`) + **`robolectric`**.
  - `debugImplementation`: **`ui-test-manifest`** (the empty `ComponentActivity` the rule drives).
  - `testOptions.unitTests.isIncludeAndroidResources = true` — the SDK-36 sandbox needs merged resources/manifest. Mirrors `core-playback`'s existing Robolectric `testOptions`.
- **`ComposeUiToolchainSmokeTest`** — `RobolectricTestRunner` + `GraphicsMode.NATIVE` + `@Config(sdk = [36])`; `createComposeRule` → `setContent` → `onNodeWithText` → `assertIsDisplayed`. Proves the rig compiles/wires. (A full Notes-screen test would drag in a Hilt VM; that can build on this rig now that it exists.)

## Merge bar — merge-on-green
CI's **Test Compile** compiles the Robolectric+Compose rig → green = **toolchain correctly wired at compile level**.

⚠️ Per project memory: the SDK-36 Robolectric sandbox needs **JDK 21 to *execute*** (JDK 17 fails at `classMethod` with "Android SDK 36 requires Java 21"). CI runs JDK 17 and only *compiles* tests — so **running** the Compose tests is a local-JDK21 step, **not** a CI/merge blocker.

Closes #1661
Refs #1657

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Android resources in local Compose UI tests.
  * Added the required Compose UI testing and Robolectric tooling.

* **Tests**
  * Added a Compose UI smoke test that verifies content can be rendered and located successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->