### PR TITLE
refactor: dedupe Tier-3 pool cap-on-failure across voice plugins (#1503)

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/StreamingPool.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/StreamingPool.kt
@@ -1,0 +1,60 @@
+package `in`.jphe.storyvox.playback.voice
+
+/**
+ * Issue #1503 — shared cap-on-failure Tier-3 pool builder, extracted from the
+ * near-verbatim `acquirePool` in `PiperEnginePlugin` / `KokoroEnginePlugin` /
+ * `KittenEnginePlugin` (#1488 ultrareview). The three implementations were
+ * identical in cap-on-failure semantics; only the per-instance
+ * "build + configure + load one engine" step and its Handle wrapper differed.
+ * Those now live in the [attempt] lambda; this owns the shared loop, the cap
+ * log, and the break.
+ */
+internal sealed interface PoolAttempt {
+    /** The i-th secondary loaded; [handle] wraps the loaded native engine. */
+    data class Loaded(val handle: StreamingSynth.Handle) : PoolAttempt
+
+    /**
+     * The i-th load failed with native [reason]. Per the destroy-on-failure
+     * contract the caller ([attempt]) has ALREADY destroyed the failed
+     * instance before returning this — [buildCapOnFailurePool] only logs + caps.
+     */
+    data class Failed(val reason: String) : PoolAttempt
+}
+
+/**
+ * Issue #1503 — build a Tier-3 secondary-instance pool, capping at the first
+ * failed load. Semantics preserved verbatim from the old inline `acquirePool`:
+ * try to build up to [size] instances in order; on the FIRST [PoolAttempt.Failed]
+ * (its instance already destroyed), log the cap (family + reason + the count
+ * we're capping at) and STOP, returning the instances built so far. All-success
+ * returns [size] handles; [size] <= 0 returns empty.
+ *
+ * The only side effect — the cap warning — goes through [warn] (default
+ * `android.util.Log.w`) so the cap-on-failure logic is JVM-unit-testable with a
+ * fake logger, without native engines or a Robolectric sandbox. That is
+ * coverage the inline `acquirePool` never had (`acquirePool` is "out of JVM
+ * scope" per the voice contract kit).
+ */
+internal fun buildCapOnFailurePool(
+    size: Int,
+    family: String,
+    logTag: String,
+    warn: (tag: String, msg: String) -> Unit = { tag, msg -> android.util.Log.w(tag, msg) },
+    attempt: (index: Int) -> PoolAttempt,
+): List<StreamingSynth.Handle> {
+    val handles = mutableListOf<StreamingSynth.Handle>()
+    for (i in 1..size) {
+        when (val result = attempt(i)) {
+            is PoolAttempt.Loaded -> handles += result.handle
+            is PoolAttempt.Failed -> {
+                warn(
+                    logTag,
+                    "Tier 3 secondary $i ($family) load failed: ${result.reason} — " +
+                        "capping at ${handles.size + 1} instances.",
+                )
+                break
+            }
+        }
+    }
+    return handles
+}

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/engines/KittenEnginePlugin.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/engines/KittenEnginePlugin.kt
@@ -7,7 +7,9 @@ import `in`.jphe.storyvox.playback.EngineSampleRateCache
 import `in`.jphe.storyvox.playback.voice.CatalogEntry
 import `in`.jphe.storyvox.playback.voice.EngineType
 import `in`.jphe.storyvox.playback.voice.ModelSpec
+import `in`.jphe.storyvox.playback.voice.PoolAttempt
 import `in`.jphe.storyvox.playback.voice.StreamingSynth
+import `in`.jphe.storyvox.playback.voice.buildCapOnFailurePool
 import `in`.jphe.storyvox.playback.voice.StreamingTuning
 import `in`.jphe.storyvox.playback.voice.VoiceCatalog
 import `in`.jphe.storyvox.playback.voice.VoiceEnginePlugin
@@ -93,8 +95,9 @@ class KittenEnginePlugin @Inject constructor(
         tuning: StreamingTuning,
     ): List<StreamingSynth.Handle> {
         val s = spec as? ModelSpec.OnnxTokensVoices ?: return emptyList()
-        val handles = mutableListOf<StreamingSynth.Handle>()
-        for (i in 1..size) {
+        // #1503 — the cap-on-failure loop is shared (buildCapOnFailurePool);
+        // only the Kitten-specific build/configure/load stays here in [attempt].
+        return buildCapOnFailurePool(size, "Kitten", LOG_TAG) { _ ->
             val secondary = KittenEngine()
             s.speakerId?.let { secondary.setActiveSpeakerId(it) }
             val r = secondary.loadModel(
@@ -105,18 +108,12 @@ class KittenEnginePlugin @Inject constructor(
                 threadsPerInstance,
             )
             if (r == "Success") {
-                handles += KittenHandle(secondary)
+                PoolAttempt.Loaded(KittenHandle(secondary))
             } else {
                 runCatching { secondary.destroy() }
-                android.util.Log.w(
-                    LOG_TAG,
-                    "Tier 3 secondary $i (Kitten) load failed: " +
-                        "$r — capping at ${handles.size + 1} instances.",
-                )
-                break
+                PoolAttempt.Failed(r)
             }
         }
-        return handles
     }
 
     private class KittenHandle(

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/engines/KokoroEnginePlugin.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/engines/KokoroEnginePlugin.kt
@@ -7,7 +7,9 @@ import `in`.jphe.storyvox.playback.EngineSampleRateCache
 import `in`.jphe.storyvox.playback.voice.CatalogEntry
 import `in`.jphe.storyvox.playback.voice.EngineType
 import `in`.jphe.storyvox.playback.voice.ModelSpec
+import `in`.jphe.storyvox.playback.voice.PoolAttempt
 import `in`.jphe.storyvox.playback.voice.StreamingSynth
+import `in`.jphe.storyvox.playback.voice.buildCapOnFailurePool
 import `in`.jphe.storyvox.playback.voice.StreamingTuning
 import `in`.jphe.storyvox.playback.voice.VoiceCatalog
 import `in`.jphe.storyvox.playback.voice.VoiceEnginePlugin
@@ -96,8 +98,9 @@ class KokoroEnginePlugin @Inject constructor(
         tuning: StreamingTuning,
     ): List<StreamingSynth.Handle> {
         val s = spec as? ModelSpec.OnnxTokensVoices ?: return emptyList()
-        val handles = mutableListOf<StreamingSynth.Handle>()
-        for (i in 1..size) {
+        // #1503 — the cap-on-failure loop is shared (buildCapOnFailurePool);
+        // only the Kokoro-specific build/configure/load stays here in [attempt].
+        return buildCapOnFailurePool(size, "Kokoro", LOG_TAG) { _ ->
             val secondary = KokoroEngine()
             s.speakerId?.let { secondary.setActiveSpeakerId(it) }
             secondary.setSilenceScale(tuning.kokoroSilenceScale)
@@ -109,18 +112,12 @@ class KokoroEnginePlugin @Inject constructor(
                 threadsPerInstance,
             )
             if (r == "Success") {
-                handles += KokoroHandle(secondary)
+                PoolAttempt.Loaded(KokoroHandle(secondary))
             } else {
                 runCatching { secondary.destroy() }
-                android.util.Log.w(
-                    LOG_TAG,
-                    "Tier 3 secondary $i (Kokoro) load failed: " +
-                        "$r — capping at ${handles.size + 1} instances.",
-                )
-                break
+                PoolAttempt.Failed(r)
             }
         }
-        return handles
     }
 
     private class KokoroHandle(

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/engines/PiperEnginePlugin.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/voice/engines/PiperEnginePlugin.kt
@@ -11,7 +11,9 @@ import `in`.jphe.storyvox.playback.EngineSampleRateCache
 import `in`.jphe.storyvox.playback.voice.CatalogEntry
 import `in`.jphe.storyvox.playback.voice.EngineType
 import `in`.jphe.storyvox.playback.voice.ModelSpec
+import `in`.jphe.storyvox.playback.voice.PoolAttempt
 import `in`.jphe.storyvox.playback.voice.StreamingSynth
+import `in`.jphe.storyvox.playback.voice.buildCapOnFailurePool
 import `in`.jphe.storyvox.playback.voice.StreamingTuning
 import `in`.jphe.storyvox.playback.voice.VoiceCatalog
 import `in`.jphe.storyvox.playback.voice.VoiceEnginePlugin
@@ -89,8 +91,9 @@ class PiperEnginePlugin @Inject constructor(
         tuning: StreamingTuning,
     ): List<StreamingSynth.Handle> {
         val s = spec as? ModelSpec.OnnxWithTokens ?: return emptyList()
-        val handles = mutableListOf<StreamingSynth.Handle>()
-        for (i in 1..size) {
+        // #1503 — the cap-on-failure loop is shared (buildCapOnFailurePool);
+        // only the Piper-specific build/configure/load stays here in [attempt].
+        return buildCapOnFailurePool(size, "Piper", LOG_TAG) { i ->
             android.util.Log.i(LOG_TAG, "Tier 3 attempting secondary Piper $i")
             val secondary = VoiceEngine()
             // Propagate noiseScale settings so all instances render with
@@ -106,19 +109,13 @@ class PiperEnginePlugin @Inject constructor(
                 threadsPerInstance,
             )
             if (r == "Success") {
-                handles += PiperHandle(secondary)
                 android.util.Log.i(LOG_TAG, "Tier 3 secondary Piper $i loaded ok")
+                PoolAttempt.Loaded(PiperHandle(secondary))
             } else {
                 runCatching { secondary.destroy() }
-                android.util.Log.w(
-                    LOG_TAG,
-                    "Tier 3 secondary $i (Piper) load failed: " +
-                        "$r — capping at ${handles.size + 1} instances.",
-                )
-                break
+                PoolAttempt.Failed(r)
             }
         }
-        return handles
     }
 
     private class PiperHandle(

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/voice/StreamingPoolTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/voice/StreamingPoolTest.kt
@@ -1,0 +1,68 @@
+package `in`.jphe.storyvox.playback.voice
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Issue #1503 — cap-on-failure semantics of the shared [buildCapOnFailurePool],
+ * extracted from the Piper/Kokoro/Kitten `acquirePool` triplicate. Runs as a
+ * plain JVM test: the per-instance native load is faked via the `attempt`
+ * lambda and the only Android side effect (the cap `Log.w`) is captured through
+ * the injectable `warn`, so this executes in CI (no native engines, no
+ * Robolectric sandbox / JDK-21 requirement). The inline `acquirePool` was "out
+ * of JVM scope" per the voice contract kit — this is coverage it never had.
+ */
+class StreamingPoolTest {
+
+    private val warnings = mutableListOf<String>()
+    private val warn: (String, String) -> Unit = { _, msg -> warnings += msg }
+
+    private fun fakeHandle(): StreamingSynth.Handle = object : StreamingSynth.Handle {
+        override val sampleRate: Int = 24_000
+        override fun generatePCM(text: String, speed: Float, pitch: Float): ByteArray? = null
+        override fun destroy() {}
+    }
+
+    @Test
+    fun `all loads succeed builds the full pool and never warns`() {
+        val pool = buildCapOnFailurePool(3, "Piper", "TAG", warn) {
+            PoolAttempt.Loaded(fakeHandle())
+        }
+        assertEquals(3, pool.size)
+        assertEquals(emptyList<String>(), warnings)
+    }
+
+    @Test
+    fun `first failure caps and stops, keeping the instances built so far`() {
+        var lastAttempt = 0
+        val pool = buildCapOnFailurePool(5, "Kokoro", "TAG", warn) { i ->
+            lastAttempt = i
+            if (i <= 2) PoolAttempt.Loaded(fakeHandle()) else PoolAttempt.Failed("native boom")
+        }
+        assertEquals(2, pool.size)        // two successes kept
+        assertEquals(3, lastAttempt)      // stopped at the first failure (attempt 3), no attempt 4/5
+        assertEquals(
+            listOf("Tier 3 secondary 3 (Kokoro) load failed: native boom — capping at 3 instances."),
+            warnings,
+        )
+    }
+
+    @Test
+    fun `immediate failure returns empty and caps at one`() {
+        val pool = buildCapOnFailurePool(4, "Kitten", "TAG", warn) {
+            PoolAttempt.Failed("no model")
+        }
+        assertEquals(0, pool.size)
+        assertEquals(
+            listOf("Tier 3 secondary 1 (Kitten) load failed: no model — capping at 1 instances."),
+            warnings,
+        )
+    }
+
+    @Test
+    fun `size zero or negative builds nothing`() {
+        assertEquals(0, buildCapOnFailurePool(0, "Piper", "TAG", warn) { PoolAttempt.Loaded(fakeHandle()) }.size)
+        assertEquals(0, buildCapOnFailurePool(-1, "Piper", "TAG", warn) { PoolAttempt.Loaded(fakeHandle()) }.size)
+        assertEquals(emptyList<String>(), warnings)
+    }
+}


### PR DESCRIPTION
`PiperEnginePlugin` / `KokoroEnginePlugin` / `KittenEnginePlugin` each carried a near-verbatim ~30-line `acquirePool`. Diffed line-by-line: the **cap-on-failure loop is byte-identical** — build up to `size` secondary instances; on the **first** failed load, `runCatching { destroy() }` the failed instance, `Log.w("Tier 3 secondary $i ($family) load failed: $r — capping at ${handles.size + 1} instances.")`, `break`; return the instances built so far. Only the per-instance **engine ctor + config calls + `loadModel` arity + Handle wrapper** differed (#1488 ultrareview).

## Extraction
- **`StreamingPool.kt`** — `buildCapOnFailurePool(size, family, logTag, warn?, attempt)` owns the shared loop + cap log + break; `PoolAttempt.Loaded/Failed` carries each instance's outcome.
- The three plugins now keep **only** their engine glue inside the `attempt` lambda. **Behavior preserved exactly**: the cap `Log.w` is byte-identical, and Piper's two extra `Log.i` info lines are kept inside its lambda (zero behavioral change).

## New coverage
The `warn` side effect is **injectable** (default `android.util.Log.w`), so the cap-on-failure logic is now **JVM-unit-testable** — **`StreamingPoolTest`** covers all-succeed / first-failure-caps-and-stops / immediate-failure / `size ≤ 0`. The inline `acquirePool` was **"out of JVM scope"** per the voice contract kit (native loads), so this is coverage it never had.

## Merge bar — merge-on-green
- `EnginePluginContractTests` (plain JVM, **executes** in CI) stays green — the plugins' pure surface is unchanged.
- `StreamingPoolTest` (plain JVM, **executes** in CI) proves the shared cap-on-failure core.
- The per-family native glue (ctor/config/`loadModel`) is **behavior-preserving** (byte-identical calls, verified by diff) and was never CI/JVM-testable (native engines). **No device-only runtime introduced or regressed.**

Closes #1503
Refs #1488

🤖 Generated with [Claude Code](https://claude.com/claude-code)