### PR TITLE
feat: scroll chapter list to the resume chapter on open (#1676)

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
@@ -618,6 +618,23 @@ fun FictionDetailScreen(
                 val wideFiltered by remember(state.chapters, wideSearchQuery) {
                     derivedStateOf { filterChaptersByQuery(state.chapters, wideSearchQuery) }
                 }
+                // Issue #1676 — on first open, bring the resume chapter
+                // (first-unfinished-or-first) into view so the list opens where
+                // the listener left off. Once-only (rememberSaveable) so it
+                // never fights manual scrolling or re-fires on chapter-list
+                // updates (download / cache state). Reuses the jump feature's
+                // [wideHeaderOffset]. Live auto-follow of the playing chapter is
+                // the deferred #1676 half.
+                var wideDidResumeScroll by androidx.compose.runtime.saveable.rememberSaveable {
+                    mutableStateOf(false)
+                }
+                androidx.compose.runtime.LaunchedEffect(wideFiltered.isNotEmpty()) {
+                    if (!wideDidResumeScroll && wideFiltered.isNotEmpty()) {
+                        targetScrollIndex(wideFiltered, pickChapterToPlay(state.chapters)?.id)
+                            ?.let { wideListState.scrollToItem(it + wideHeaderOffset) }
+                        wideDidResumeScroll = true
+                    }
+                }
                 LazyColumn(
                     state = wideListState,
                     modifier = Modifier.weight(chapterWeight).fillMaxSize(),
@@ -731,6 +748,18 @@ fun FictionDetailScreen(
                 1 + // Synopsis
                 1 + // Notebook
                 (if (narrowShowSearch) 1 else 0)
+            // Issue #1676 — bring the resume chapter into view on first open,
+            // once-only (see the wide-layout note above). Reuses [narrowHeaderCount].
+            var narrowDidResumeScroll by androidx.compose.runtime.saveable.rememberSaveable {
+                mutableStateOf(false)
+            }
+            androidx.compose.runtime.LaunchedEffect(narrowFiltered.isNotEmpty()) {
+                if (!narrowDidResumeScroll && narrowFiltered.isNotEmpty()) {
+                    targetScrollIndex(narrowFiltered, pickChapterToPlay(state.chapters)?.id)
+                        ?.let { narrowListState.scrollToItem(it + narrowHeaderCount) }
+                    narrowDidResumeScroll = true
+                }
+            }
             LazyColumn(
                 state = narrowListState,
                 modifier = Modifier.fillMaxSize(),
@@ -1860,6 +1889,20 @@ private fun ChapterSearchBar(
 internal fun pickChapterToPlay(chapters: List<UiChapter>): UiChapter? {
     if (chapters.isEmpty()) return null
     return chapters.firstOrNull { !it.isFinished } ?: chapters.first()
+}
+
+/**
+ * Issue #1676 — the chapter-list index to scroll to on open, or null for
+ * "don't scroll". [resumeId] is `pickChapterToPlay(chapters)?.id` (the
+ * first-unfinished-or-first resume anchor). Returns that chapter's index in
+ * [chapters] (the rendered list), or null when the id is absent or the list is
+ * empty — defensive, so we never scroll to a bogus row. Live auto-follow of the
+ * currently-*playing* chapter is the deferred #1676 follow-up (needs new
+ * playback-state wiring the screen doesn't have today).
+ */
+internal fun targetScrollIndex(chapters: List<UiChapter>, resumeId: String?): Int? {
+    if (resumeId == null) return null
+    return chapters.indexOfFirst { it.id == resumeId }.takeIf { it >= 0 }
 }
 
 /** Issue #604 — derive the Play button label. Reads "Resume" when the

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/fiction/TargetScrollIndexTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/fiction/TargetScrollIndexTest.kt
@@ -1,0 +1,76 @@
+package `in`.jphe.storyvox.feature.fiction
+
+import `in`.jphe.storyvox.feature.api.UiChapter
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Issue #1676 — the chapter list should open scrolled to the resume chapter so
+ * a listener returning to a book lands where they left off. [targetScrollIndex]
+ * is the pure decision the once-only `LaunchedEffect` in `FictionDetailScreen`
+ * calls (the Compose scroll itself is device-verified; this is the CI-provable
+ * core). `resumeId` is `pickChapterToPlay(chapters)?.id`, so the composed
+ * behavior is pinned here too.
+ */
+class TargetScrollIndexTest {
+
+    private fun ch(id: String, number: Int, finished: Boolean) = UiChapter(
+        id = id,
+        number = number,
+        title = "Chapter $number",
+        publishedRelative = "1d",
+        durationLabel = "12 min",
+        isDownloaded = false,
+        isFinished = finished,
+    )
+
+    // ── targetScrollIndex (pure) ──────────────────────────────────────────
+
+    @Test
+    fun `null resumeId means no scroll`() {
+        assertNull(targetScrollIndex(listOf(ch("a", 1, false)), resumeId = null))
+    }
+
+    @Test
+    fun `empty chapter list means no scroll`() {
+        assertNull(targetScrollIndex(emptyList(), resumeId = "a"))
+    }
+
+    @Test
+    fun `resume id absent from the list means no scroll (defensive)`() {
+        assertNull(targetScrollIndex(listOf(ch("a", 1, false), ch("b", 2, false)), resumeId = "zzz"))
+    }
+
+    @Test
+    fun `present resume id returns its index`() {
+        val chapters = listOf(ch("a", 1, true), ch("b", 2, true), ch("c", 3, false))
+        assertEquals(2, targetScrollIndex(chapters, resumeId = "c"))
+    }
+
+    // ── composed with pickChapterToPlay (the real resume anchor) ──────────
+
+    @Test
+    fun `fresh fiction resumes at the first chapter (index 0)`() {
+        val chapters = listOf(ch("a", 1, false), ch("b", 2, false))
+        assertEquals(0, targetScrollIndex(chapters, pickChapterToPlay(chapters)?.id))
+    }
+
+    @Test
+    fun `partway through resumes at the first unfinished chapter`() {
+        val chapters = listOf(ch("a", 1, true), ch("b", 2, true), ch("c", 3, false))
+        assertEquals(2, targetScrollIndex(chapters, pickChapterToPlay(chapters)?.id))
+    }
+
+    @Test
+    fun `fully finished fiction falls back to the first chapter`() {
+        val chapters = listOf(ch("a", 1, true), ch("b", 2, true))
+        assertEquals(0, targetScrollIndex(chapters, pickChapterToPlay(chapters)?.id))
+    }
+
+    @Test
+    fun `empty fiction never scrolls`() {
+        val chapters = emptyList<UiChapter>()
+        assertNull(targetScrollIndex(chapters, pickChapterToPlay(chapters)?.id))
+    }
+}


### PR DESCRIPTION
Opening a fiction with progress left the chapter list scrolled to the top — the listener had to hunt for where they were. Now, **on first open, the list scrolls to the resume chapter** (first-unfinished-or-first, via the existing `pickChapterToPlay`) in both the wide (tablet) and narrow (phone) layouts.

## Change
- **Pure `targetScrollIndex(chapters, resumeId)`** — the chapter's index in the rendered list, or `null` (empty list / id absent → no scroll). `resumeId = pickChapterToPlay(chapters)?.id`.
- **Per-layout once-only `LaunchedEffect`** → `scrollToItem(target + headerOffset)`, reusing the jump feature's `wideHeaderOffset` / `narrowHeaderCount`. A `rememberSaveable` guard fires it **once** on first chapter-load, so it **never fights manual scrolling**, doesn't re-fire on chapter-list updates (download / cache-state changes), and survives config change.
- **No new playback-state wiring.**

## Scope — Progresses #1676 (NOT Closes)
This is the **"last-played on open"** half. **Live auto-follow of the currently-playing chapter** is deferred: `FictionDetail` doesn't observe the playing-chapter id today (`ChapterCard(currentId = null)` is hardcoded), so that needs new playback-state wiring + a manual-scroll-interaction decision. Tracked on the issue — **#1676 stays open**.

## CI proves (compile + unit)
`TargetScrollIndexTest` — 8 JVM cases: pure (null/empty/absent/present) + composed with `pickChapterToPlay` (fresh→0, partway→first-unfinished, all-finished→0, empty→no-scroll).

## 📱 Device-verify — for JP (Compose scroll is runtime; do NOT merge until checked)
- [ ] Open a book **with progress** (some chapters finished) → chapter list opens **scrolled to the resume chapter**, on both phone and tablet layouts.
- [ ] Open a **fresh** book → list at chapter 1 (no jarring jump).
- [ ] After the initial scroll, **manually scroll away** → the list is **not** yanked back (once-only guard); rotate → still not yanked back.
- [ ] A book whose chapters are still loading → scrolls once they arrive, not before.

Progresses #1676

🤖 Generated with [Claude Code](https://claude.com/claude-code)