### PR TITLE
feat: shake-to-revive after the sleep timer stops (#1618)

### DIFF
--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackController.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/PlaybackController.kt
@@ -903,6 +903,14 @@ class DefaultPlaybackController @Inject constructor(
         player?.setPunctuationPauseMultiplier(multiplier)
     }
 
+    /**
+     * Issue #1618 — the sleep-timer "fired" event (the mode that just elapsed
+     * and paused), surfaced from [SleepTimer] for the playback service's
+     * shake-to-revive grace window. Concrete-only (deliberately NOT on the
+     * [PlaybackController] interface, so its fakes need no change).
+     */
+    val timerFired: SharedFlow<SleepTimerMode> get() = sleepTimer.timerFired
+
     override fun startSleepTimer(mode: SleepTimerMode) {
         sleepTimer.start(mode)
     }

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/SleepTimer.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/SleepTimer.kt
@@ -63,6 +63,19 @@ class SleepTimer @Inject constructor(
     private val chapterEndSignal = MutableSharedFlow<Unit>(replay = 1)
     val chapterEnd: SharedFlow<Unit> = chapterEndSignal.asSharedFlow()
 
+    /**
+     * Issue #1618 — emits the mode that just elapsed, the instant the timer
+     * pauses playback (see [fadeAndPause]). An EVENT, not state: `replay = 0`
+     * so a late subscriber never sees a stale fire and opens a spurious
+     * shake-to-revive grace window; `extraBufferCapacity = 1` so the emit
+     * isn't dropped if the (single, startup-registered) collector is briefly
+     * busy. [cancel] deliberately emits nothing — a user-dismissed timer must
+     * NOT start a grace window. Carries the fired mode so the service can
+     * re-arm "the same duration as last".
+     */
+    private val timerFiredSignal = MutableSharedFlow<SleepTimerMode>(replay = 0, extraBufferCapacity = 1)
+    val timerFired: SharedFlow<SleepTimerMode> = timerFiredSignal.asSharedFlow()
+
     /** Called when the last sentence of a chapter finishes. */
     fun signalChapterEnd() {
         chapterEndSignal.tryEmit(Unit)
@@ -84,26 +97,26 @@ class SleepTimer @Inject constructor(
             // so re-arming an already-running timer won't re-snapshot.
             dndController.activateForSleepTimer()
             when (mode) {
-                is SleepTimerMode.Duration -> runCountdown(mode.minutes * 60_000L)
+                is SleepTimerMode.Duration -> runCountdown(mode.minutes * 60_000L, mode)
                 SleepTimerMode.EndOfChapter -> {
                     chapterEndSignal.first()
-                    fadeAndPause()
+                    fadeAndPause(mode)
                 }
             }
         }
     }
 
-    private suspend fun runCountdown(totalMs: Long) {
+    private suspend fun runCountdown(totalMs: Long, mode: SleepTimerMode) {
         var remaining = totalMs
         while (remaining > FADE_TAIL_MS) {
             _remainingMs.value = remaining
             delay(TICK_MS)
             remaining -= TICK_MS
         }
-        fadeAndPause()
+        fadeAndPause(mode)
     }
 
-    private suspend fun fadeAndPause() {
+    private suspend fun fadeAndPause(mode: SleepTimerMode) {
         val steps = (FADE_TAIL_MS / FADE_STEP_MS).toInt()
         for (step in 0..steps) {
             val v = (steps - step).toFloat() / steps
@@ -114,6 +127,11 @@ class SleepTimer @Inject constructor(
         pauseAction.invoke()
         volumeRamp.set(1.0f)
         _remainingMs.value = null
+        // Issue #1618 — the timer genuinely fired and paused (this path is
+        // never reached by cancel()). Emit the fired mode so the playback
+        // service can open the shake-to-revive grace window and re-arm the
+        // same duration on a qualifying shake.
+        timerFiredSignal.tryEmit(mode)
         // Drop the consumed signal so a future EndOfChapter timer
         // doesn't see a stale value (issue #34).
         chapterEndSignal.resetReplayCache()

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/SleepTimerDecisions.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/SleepTimerDecisions.kt
@@ -69,3 +69,29 @@ fun shouldExtendOnShake(
     sleepTimerRemainingMs: Long?,
     fadeWindowMs: Long,
 ): Boolean = (sleepTimerRemainingMs ?: -1L) in 0L..fadeWindowMs
+
+/**
+ * #1618 — should the accelerometer keep listening in the post-stop
+ * shake-to-revive grace window? True iff the sleep timer fired within the last
+ * [graceWindowMs] (`0 <= msSinceFired <= graceWindowMs`). A null
+ * [msSinceFiredMs] — timer never fired, or already revived / window expired —
+ * maps to "not listening", so the sensor is released and doesn't drain battery
+ * overnight. Mirrors [shouldListenForShake] for the fade tail.
+ */
+fun shouldListenInGraceWindow(
+    msSinceFiredMs: Long?,
+    graceWindowMs: Long,
+): Boolean = (msSinceFiredMs ?: -1L) in 0L..graceWindowMs
+
+/**
+ * #1618 — when a shake fires after the timer stopped, should it revive
+ * playback (resume + re-arm the same duration)? Guards to the grace window so
+ * a shake landing after the window elapsed (sensor about to be released) is
+ * ignored. Same predicate as [shouldListenInGraceWindow]; kept as a separate
+ * name to mirror the fade-tail [shouldListenForShake] / [shouldExtendOnShake]
+ * pair and to read clearly at the call site.
+ */
+fun shouldReviveOnShake(
+    msSinceFiredMs: Long?,
+    graceWindowMs: Long,
+): Boolean = (msSinceFiredMs ?: -1L) in 0L..graceWindowMs

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/SleepTimerDecisions.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/SleepTimerDecisions.kt
@@ -95,3 +95,19 @@ fun shouldReviveOnShake(
     msSinceFiredMs: Long?,
     graceWindowMs: Long,
 ): Boolean = (msSinceFiredMs ?: -1L) in 0L..graceWindowMs
+
+/**
+ * #1618 — is the post-stop shake-to-revive grace window now stale and safe to
+ * clear? True iff the user has taken over manually since the timer fired:
+ * playback is active again, or a fresh timer is running. During a *legitimate*
+ * open window neither holds — the fired timer paused playback (`isPlaying`
+ * false) and left no timer running (`sleepTimerRunning` false) — so the window
+ * survives. But if the user manually resumed, or started a new timer, inside
+ * the 60s window, a later stray shake must NOT resurrect the old fired mode
+ * and clobber their action (Gemini review, PR #1696): clearing the window here
+ * both releases the accelerometer and disarms [shouldReviveOnShake].
+ */
+fun shouldClearGraceWindow(
+    isPlaying: Boolean,
+    sleepTimerRunning: Boolean,
+): Boolean = isPlaying || sleepTimerRunning

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/StoryvoxPlaybackService.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/StoryvoxPlaybackService.kt
@@ -116,6 +116,16 @@ class StoryvoxPlaybackService : MediaSessionService() {
      *  redundant register/unregister churn on every state emission. */
     private var shakeListening: Boolean = false
 
+    /** Issue #1618 — post-stop shake-to-revive grace window. [shakeGraceJob]
+     *  observes [DefaultPlaybackController.timerFired]; on a fire it stamps
+     *  [sleepTimerFiredAtMs] + [lastFiredSleepMode], keeps the detector armed
+     *  for [SHAKE_GRACE_WINDOW_MS], and a qualifying shake resumes + re-arms
+     *  that mode. `@Volatile` because the sensor callback reads these off the
+     *  main thread. */
+    private var shakeGraceJob: Job? = null
+    @Volatile private var sleepTimerFiredAtMs: Long? = null
+    @Volatile private var lastFiredSleepMode: SleepTimerMode? = null
+
     /** DND / Bedtime mode auto-sleep receiver, registered when the
      *  bedtime-auto-sleep setting is on and playback is active.
      *  Unregistered on destroy or when the setting is flipped off. */
@@ -190,55 +200,73 @@ class StoryvoxPlaybackService : MediaSessionService() {
             context = applicationContext,
             onShake = {
                 val remaining = controller.state.value.sleepTimerRemainingMs
-                // Issue #1595 — gate the re-arm to the fade tail via the
-                // pure [shouldExtendOnShake] decision so a jolt landing a
-                // beat after the timer paused is ignored.
-                if (shouldExtendOnShake(remaining, SHAKE_FADE_WINDOW_MS)) {
-                    // Issue #595 — read the user-tunable extend duration
-                    // from the config contract instead of the legacy
-                    // hardcoded constant. Off-main launch so the suspend
-                    // read doesn't block the accelerometer callback.
-                    // `currentShakeExtendMinutes` falls back to 15 (the
-                    // legacy value) when the store hasn't emitted yet.
-                    Log.i(TAG, "Shake-to-extend: shake detected in fade tail (remaining=${remaining}ms) — extending")
-                    scope.launch {
-                        val minutes = sleepExtendConfig.currentShakeExtendMinutes()
-                        controller.startSleepTimer(SleepTimerMode.Duration(minutes))
+                val sinceFired = sleepTimerFiredAtMs?.let { android.os.SystemClock.uptimeMillis() - it }
+                when {
+                    // Issue #1595 — fade-tail shake-to-extend (pure gate so a
+                    // jolt a beat after the pause is ignored). Off-main launch
+                    // so the suspend config read doesn't block the callback;
+                    // `currentShakeExtendMinutes` falls back to 15.
+                    shouldExtendOnShake(remaining, SHAKE_FADE_WINDOW_MS) -> {
+                        Log.i(TAG, "Shake-to-extend: shake in fade tail (remaining=${remaining}ms) — extending")
+                        scope.launch {
+                            val minutes = sleepExtendConfig.currentShakeExtendMinutes()
+                            controller.startSleepTimer(SleepTimerMode.Duration(minutes))
+                        }
                     }
-                } else {
-                    // #1595 instrumentation — a shake fired but outside the
-                    // fade tail. If an on-device repro shows this line but
-                    // no "extending", the detector is armed too early/late;
-                    // if it shows NO shake lines at all while the fade-tail
-                    // "accelerometer registered" line is present, the
-                    // gesture isn't crossing the detector threshold.
-                    Log.d(TAG, "Shake-to-extend: shake ignored — not in fade tail (remaining=${remaining}ms)")
+                    // Issue #1618 — post-stop shake-to-revive. A shake inside
+                    // the grace window resumes playback and re-arms the SAME
+                    // mode that just elapsed.
+                    shouldReviveOnShake(sinceFired, SHAKE_GRACE_WINDOW_MS) -> {
+                        val mode = lastFiredSleepMode
+                        sleepTimerFiredAtMs = null // consume the window
+                        Log.i(TAG, "Shake-to-revive: shake in grace window (sinceFired=${sinceFired}ms) — resuming + re-arming $mode")
+                        scope.launch {
+                            // #1609 — resume must run on the main thread; [scope] is Dispatchers.Main.
+                            controller.resume()
+                            mode?.let { controller.startSleepTimer(it) }
+                            refreshShakeListening() // grace consumed → release the sensor
+                        }
+                    }
+                    else -> Log.d(
+                        TAG,
+                        "Shake ignored — not in fade tail or grace window " +
+                            "(remaining=${remaining}ms, sinceFired=${sinceFired}ms)",
+                    )
                 }
             },
         )
+        // Issue #1595 + #1618 — ONE owner for the accelerometer, driven by
+        // [refreshShakeListening]: arm while an armed timer is in its fade tail
+        // OR a fired timer is inside its shake-to-revive grace window; release
+        // otherwise so long sessions don't drain battery.
         shakeJob = scope.launch {
             controller.state
                 .map { it.sleepTimerRemainingMs to it.shakeToExtendEnabled }
                 .distinctUntilChanged()
-                .collect { (remaining, enabled) ->
-                    // Issue #1595 — pure [shouldListenForShake] gate: listen
-                    // only while the user opted in AND an armed timer is in
-                    // its 10s fade tail.
-                    val inFadeWindow = shouldListenForShake(remaining, enabled, SHAKE_FADE_WINDOW_MS)
-                    if (inFadeWindow && !shakeListening) {
-                        val started = shakeDetector?.start() ?: false
-                        shakeListening = true
-                        Log.i(
-                            TAG,
-                            "Shake-to-extend: fade tail entered (remaining=${remaining}ms) — " +
-                                "accelerometer ${if (started) "registered" else "FAILED to register"}",
-                        )
-                    } else if (!inFadeWindow && shakeListening) {
-                        shakeDetector?.stop()
-                        shakeListening = false
-                        Log.d(TAG, "Shake-to-extend: fade tail exited — accelerometer released")
+                .collect { refreshShakeListening() }
+        }
+        // Issue #1618 — a fired sleep timer opens the grace window; keep the
+        // detector listening, then release after the window if no qualifying
+        // shake revived playback. [cancel] never emits here, so a user-
+        // dismissed timer opens no window.
+        shakeGraceJob = scope.launch {
+            controller.timerFired.collect { mode ->
+                lastFiredSleepMode = mode
+                sleepTimerFiredAtMs = android.os.SystemClock.uptimeMillis()
+                Log.i(TAG, "Shake-to-revive: sleep timer fired ($mode) — grace window open for ${SHAKE_GRACE_WINDOW_MS}ms")
+                refreshShakeListening()
+                scope.launch {
+                    kotlinx.coroutines.delay(SHAKE_GRACE_WINDOW_MS)
+                    val firedAt = sleepTimerFiredAtMs
+                    if (firedAt != null &&
+                        android.os.SystemClock.uptimeMillis() - firedAt >= SHAKE_GRACE_WINDOW_MS
+                    ) {
+                        sleepTimerFiredAtMs = null
+                        Log.d(TAG, "Shake-to-revive: grace window elapsed — accelerometer released")
+                        refreshShakeListening()
                     }
                 }
+            }
         }
 
         // Bedtime / DND auto-sleep: register a BroadcastReceiver for
@@ -466,6 +494,31 @@ class StoryvoxPlaybackService : MediaSessionService() {
         super.onTaskRemoved(rootIntent)
     }
 
+    /**
+     * Issue #1595 + #1618 — single owner of the accelerometer registration.
+     * Arms [shakeDetector] iff the user opted in AND either an armed timer is
+     * in its fade tail ([shouldListenForShake]) OR a fired timer is inside its
+     * shake-to-revive grace window ([shouldListenInGraceWindow]); releases it
+     * otherwise. Idempotent via [shakeListening], so the state collector and
+     * the grace collector can both call it without fighting over the sensor.
+     */
+    private fun refreshShakeListening() {
+        val s = controller.state.value
+        val enabled = s.shakeToExtendEnabled
+        val inFadeTail = shouldListenForShake(s.sleepTimerRemainingMs, enabled, SHAKE_FADE_WINDOW_MS)
+        val sinceFired = sleepTimerFiredAtMs?.let { android.os.SystemClock.uptimeMillis() - it }
+        val inGraceWindow = enabled && shouldListenInGraceWindow(sinceFired, SHAKE_GRACE_WINDOW_MS)
+        val shouldListen = inFadeTail || inGraceWindow
+        if (shouldListen && !shakeListening) {
+            shakeListening = shakeDetector?.start() ?: false
+            Log.i(TAG, "Shake detector armed (fadeTail=$inFadeTail, grace=$inGraceWindow) — registered=$shakeListening")
+        } else if (!shouldListen && shakeListening) {
+            shakeDetector?.stop()
+            shakeListening = false
+            Log.d(TAG, "Shake detector released (no fade tail, no grace window)")
+        }
+    }
+
     override fun onDestroy() {
         wearBridge.stop()
         // "Why are we waiting?" — stop the diagnostic monitor before
@@ -481,6 +534,9 @@ class StoryvoxPlaybackService : MediaSessionService() {
         }
         shakeDetector = null
         shakeJob = null
+        shakeGraceJob = null // #1618 — cancelled with [scope] on teardown
+        sleepTimerFiredAtMs = null
+        lastFiredSleepMode = null
         if (dndReceiverRegistered) {
             // runCatching: unregister can throw if the receiver never
             // fully registered (e.g. a SecurityException swallowed above).
@@ -524,6 +580,11 @@ class StoryvoxPlaybackService : MediaSessionService() {
          *  default for now; if the timer's fade duration ever moves
          *  to settings, plumb that through controller.state too. */
         private const val SHAKE_FADE_WINDOW_MS = 10_000L
+        /** Issue #1618 — how long after the sleep timer STOPS the accelerometer
+         *  keeps listening for a shake-to-revive gesture. A shake in this window
+         *  resumes + re-arms the same duration; after it elapses the sensor is
+         *  released so a stopped timer never drains battery overnight. */
+        private const val SHAKE_GRACE_WINDOW_MS = 60_000L
         /** Legacy default extension on shake-detect. Pre-#595 this
          *  was the hardcoded source of truth; v1 reads the
          *  user-tunable value via [SleepTimerExtendConfig] at

--- a/core-playback/src/main/kotlin/in/jphe/storyvox/playback/StoryvoxPlaybackService.kt
+++ b/core-playback/src/main/kotlin/in/jphe/storyvox/playback/StoryvoxPlaybackService.kt
@@ -241,7 +241,11 @@ class StoryvoxPlaybackService : MediaSessionService() {
         // otherwise so long sessions don't drain battery.
         shakeJob = scope.launch {
             controller.state
-                .map { it.sleepTimerRemainingMs to it.shakeToExtendEnabled }
+                // #1618 — `isPlaying` is in the key so a MANUAL resume (which
+                // moves neither remaining nor the toggle) still triggers
+                // [refreshShakeListening], letting it close a now-stale grace
+                // window the user superseded by resuming (Gemini review, #1696).
+                .map { Triple(it.sleepTimerRemainingMs, it.shakeToExtendEnabled, it.isPlaying) }
                 .distinctUntilChanged()
                 .collect { refreshShakeListening() }
         }
@@ -504,6 +508,16 @@ class StoryvoxPlaybackService : MediaSessionService() {
      */
     private fun refreshShakeListening() {
         val s = controller.state.value
+        // #1618 — a manual resume or a freshly-started timer supersedes the
+        // post-stop grace window; drop it so a stray shake can't revive the
+        // old fired mode over the user's action (Gemini review, #1696).
+        if (sleepTimerFiredAtMs != null &&
+            shouldClearGraceWindow(s.isPlaying, s.sleepTimerRemainingMs != null)
+        ) {
+            sleepTimerFiredAtMs = null
+            lastFiredSleepMode = null
+            Log.d(TAG, "Shake-to-revive: grace window cleared — user resumed/re-armed manually")
+        }
         val enabled = s.shakeToExtendEnabled
         val inFadeTail = shouldListenForShake(s.sleepTimerRemainingMs, enabled, SHAKE_FADE_WINDOW_MS)
         val sinceFired = sleepTimerFiredAtMs?.let { android.os.SystemClock.uptimeMillis() - it }

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/ShakeReviveGraceWindowTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/ShakeReviveGraceWindowTest.kt
@@ -1,0 +1,54 @@
+package `in`.jphe.storyvox.playback
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #1696 (Gemini review of #1618) — the post-stop shake-to-revive grace window
+ * must be dropped once the user takes over manually, or a stray shake inside
+ * the 60s window would call `resume()` + re-arm the OLD fired mode, clobbering
+ * a manual resume or a freshly-started timer.
+ *
+ * [shouldClearGraceWindow] is the pure gate `StoryvoxPlaybackService`
+ * .refreshShakeListening consults before computing [shouldReviveOnShake] /
+ * [shouldListenInGraceWindow]. These pin it, and pin that a *legitimate* open
+ * window (timer just fired: paused, no timer running) is preserved.
+ */
+class ShakeReviveGraceWindowTest {
+
+    @Test
+    fun `legitimate open window is preserved`() {
+        // Timer fired => playback paused (isPlaying=false), no timer running.
+        assertFalse(shouldClearGraceWindow(isPlaying = false, sleepTimerRunning = false))
+    }
+
+    @Test
+    fun `manual resume clears the window`() {
+        assertTrue(shouldClearGraceWindow(isPlaying = true, sleepTimerRunning = false))
+    }
+
+    @Test
+    fun `a newly started timer clears the window`() {
+        assertTrue(shouldClearGraceWindow(isPlaying = false, sleepTimerRunning = true))
+    }
+
+    @Test
+    fun `resume with a new timer clears the window`() {
+        assertTrue(shouldClearGraceWindow(isPlaying = true, sleepTimerRunning = true))
+    }
+
+    /**
+     * The bug scenario, expressed against the two gates together: after the
+     * window is cleared (msSinceFired reset to null), a shake must NOT revive.
+     */
+    @Test
+    fun `once cleared, a shake in the old window no longer revives`() {
+        val graceMs = 60_000L
+        // Before clear: 5s since fire, inside the window -> would revive.
+        assertTrue(shouldReviveOnShake(msSinceFiredMs = 5_000L, graceWindowMs = graceMs))
+        // Manual resume => window cleared => msSinceFired becomes null.
+        assertTrue(shouldClearGraceWindow(isPlaying = true, sleepTimerRunning = false))
+        assertFalse(shouldReviveOnShake(msSinceFiredMs = null, graceWindowMs = graceMs))
+    }
+}

--- a/core-playback/src/test/kotlin/in/jphe/storyvox/playback/SleepTimerAutoArmTest.kt
+++ b/core-playback/src/test/kotlin/in/jphe/storyvox/playback/SleepTimerAutoArmTest.kt
@@ -91,4 +91,29 @@ class SleepTimerAutoArmTest {
     @Test fun `extends at the fade-tail end boundary`() {
         assertTrue(shouldExtendOnShake(sleepTimerRemainingMs = 0L, fadeWindowMs = fade))
     }
+
+    // ── #1618 — post-stop shake-to-revive grace window ─────────────
+
+    private val grace = 60_000L
+
+    @Test fun `does not listen in grace window when the timer never fired`() {
+        assertFalse(shouldListenInGraceWindow(msSinceFiredMs = null, graceWindowMs = grace))
+    }
+
+    @Test fun `listens right after the timer fires and partway through`() {
+        assertTrue(shouldListenInGraceWindow(msSinceFiredMs = 0L, graceWindowMs = grace))
+        assertTrue(shouldListenInGraceWindow(msSinceFiredMs = 30_000L, graceWindowMs = grace))
+    }
+
+    @Test fun `listens at the grace-window end boundary but not past it`() {
+        assertTrue(shouldListenInGraceWindow(msSinceFiredMs = 60_000L, graceWindowMs = grace))
+        assertFalse(shouldListenInGraceWindow(msSinceFiredMs = 60_001L, graceWindowMs = grace))
+    }
+
+    @Test fun `revives on a shake inside the window, ignores one past it or with no fire`() {
+        assertTrue(shouldReviveOnShake(msSinceFiredMs = 0L, graceWindowMs = grace))
+        assertTrue(shouldReviveOnShake(msSinceFiredMs = 60_000L, graceWindowMs = grace))
+        assertFalse(shouldReviveOnShake(msSinceFiredMs = 60_001L, graceWindowMs = grace))
+        assertFalse(shouldReviveOnShake(msSinceFiredMs = null, graceWindowMs = grace))
+    }
 }


### PR DESCRIPTION
When the sleep timer fires and pauses, a quick shake within a short grace window should bring playback back — instead of forcing the user to unlock, find the app, and hit play. Builds on **#1595** (the `ShakeDetector` + 12 m/s² threshold, reused as-is) and **#1609** (main-marshalled pause/resume).

## Behavior (per the issue)
- Timer fires + pauses → the accelerometer keeps listening for a **60s grace window** (`SHAKE_GRACE_WINDOW_MS`, tunable const).
- A qualifying shake **in-window** → **resume** from the paused position + **re-arm a fresh timer at the same mode** that just elapsed.
- Window elapses with no shake → **release the accelerometer** (no overnight battery drain).
- A **user-cancelled** timer opens **no** window.

## Design
- **`SleepTimer.timerFired: SharedFlow<SleepTimerMode>`** — `replay = 0` (an event, not state) so a late subscriber can't open a spurious window; emitted at the single fire point (`fadeAndPause`), carrying the fired mode. `cancel()` emits nothing. One signal solves fire-vs-cancel **and** "same duration as last".
- **`DefaultPlaybackController.timerFired`** — a **concrete-only** val delegating to `SleepTimer`. The `PlaybackController` interface is deliberately **untouched**, so its fakes need no change.
- **`StoryvoxPlaybackService`** — one accelerometer owner (`refreshShakeListening()`) armed while in the fade tail **OR** the grace window; `shakeGraceJob` opens the window on `timerFired` and releases the sensor after it; `onShake` revives (`resume()` on the Main scope per #1609 + `startSleepTimer(firedMode)`).

## CI proves (compile + unit)
Pure decisions **`shouldListenInGraceWindow`** / **`shouldReviveOnShake`** in `SleepTimerDecisions`, with JVM cases in `SleepTimerAutoArmTest` (fire→listen, partway, end-boundary, past-boundary, no-fire).

## 📱 Device-verify — for JP (sensor + resume are runtime; do NOT merge until checked)
- [ ] Sleep timer stops → **shake within ~60s** → playback **resumes** and a **fresh timer re-arms** at the same duration.
- [ ] Timer stops → **wait >60s, then shake** → nothing resumes, and the accelerometer is **released** (no battery drain).
- [ ] **Cancel** the timer manually (don't let it fire) → a shake does **not** resume (no grace window opened).
- [ ] Shake-to-extend during the fade tail (#1595) still works (unregression).
- [ ] Shake-to-extend toggle OFF → neither extend nor revive listens.

Closes #1618
Refs #1595 #1609

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a 60-second grace period after the sleep timer pauses playback.
  - Users can shake the device during this window to resume playback.
  - The previously active sleep-timer mode is automatically restored when playback resumes.
  - Shake detection remains active during the grace period and stops automatically afterward.

- **Tests**
  - Added coverage for grace-period boundaries, timer states, and shake-to-revive behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->