### PR TITLE
feat: live-follow the playing chapter in the chapter list (#1676)

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
@@ -4,7 +4,14 @@ import android.content.Context
 import android.content.Intent
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.DragInteraction
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -28,6 +35,8 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
@@ -43,6 +52,7 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.rememberModalBottomSheetState
@@ -65,6 +75,7 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.liveRegion
@@ -623,8 +634,8 @@ fun FictionDetailScreen(
                 // the listener left off. Once-only (rememberSaveable) so it
                 // never fights manual scrolling or re-fires on chapter-list
                 // updates (download / cache state). Reuses the jump feature's
-                // [wideHeaderOffset]. Live auto-follow of the playing chapter is
-                // the deferred #1676 half.
+                // [wideHeaderOffset]. Live auto-follow of the *playing* chapter
+                // is a separate concern — see [rememberChapterAutoFollow] below.
                 var wideDidResumeScroll by androidx.compose.runtime.saveable.rememberSaveable {
                     mutableStateOf(false)
                 }
@@ -635,9 +646,20 @@ fun FictionDetailScreen(
                         wideDidResumeScroll = true
                     }
                 }
+                // Issue #1676 — live auto-follow of the playing chapter (+ the
+                // "playing" re-engage chip). Operates on [wideFiltered] so a
+                // filtered-out playing chapter simply stops following (index
+                // absent → no scroll / no chip).
+                val wideFollow = rememberChapterAutoFollow(
+                    listState = wideListState,
+                    chapters = wideFiltered,
+                    playingChapterId = state.playingChapterId,
+                    headerOffset = wideHeaderOffset,
+                )
+                Box(modifier = Modifier.weight(chapterWeight).fillMaxSize()) {
                 LazyColumn(
                     state = wideListState,
-                    modifier = Modifier.weight(chapterWeight).fillMaxSize(),
+                    modifier = Modifier.fillMaxSize(),
                     contentPadding = PaddingValues(top = spacing.md, bottom = spacing.md),
                 ) {
                     // Issue #638 — action row pinned at the top of the
@@ -688,7 +710,7 @@ fun FictionDetailScreen(
                     }
                     items(wideFiltered, key = { it.id }) { ch ->
                         ChapterCard(
-                            state = ch.toCardState(currentId = null),
+                            state = ch.toCardState(currentId = state.playingChapterId),
                             onClick = { viewModel.listen(ch.id) },
                             modifier = Modifier
                                 .fillMaxWidth()
@@ -723,6 +745,14 @@ fun FictionDetailScreen(
                             )
                         }
                     }
+                }
+                FollowPlayingChip(
+                    direction = wideFollow.chipDirection,
+                    onClick = wideFollow.onReEngage,
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        .padding(bottom = spacing.lg),
+                )
                 }
             }
         } else {
@@ -760,6 +790,15 @@ fun FictionDetailScreen(
                     narrowDidResumeScroll = true
                 }
             }
+            // Issue #1676 — live auto-follow of the playing chapter (+ chip),
+            // same contract as the wide layout. Operates on [narrowFiltered].
+            val narrowFollow = rememberChapterAutoFollow(
+                listState = narrowListState,
+                chapters = narrowFiltered,
+                playingChapterId = state.playingChapterId,
+                headerOffset = narrowHeaderCount,
+            )
+            Box(modifier = Modifier.fillMaxSize()) {
             LazyColumn(
                 state = narrowListState,
                 modifier = Modifier.fillMaxSize(),
@@ -874,7 +913,7 @@ fun FictionDetailScreen(
                 }
                 items(narrowFiltered, key = { it.id }) { ch ->
                     ChapterCard(
-                        state = ch.toCardState(currentId = null),
+                        state = ch.toCardState(currentId = state.playingChapterId),
                         onClick = { viewModel.listen(ch.id) },
                         modifier = Modifier
                             .fillMaxWidth()
@@ -907,6 +946,14 @@ fun FictionDetailScreen(
                         )
                     }
                 }
+            }
+            FollowPlayingChip(
+                direction = narrowFollow.chipDirection,
+                onClick = narrowFollow.onReEngage,
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = spacing.lg),
+            )
             }
         }
     }
@@ -1896,13 +1943,235 @@ internal fun pickChapterToPlay(chapters: List<UiChapter>): UiChapter? {
  * "don't scroll". [resumeId] is `pickChapterToPlay(chapters)?.id` (the
  * first-unfinished-or-first resume anchor). Returns that chapter's index in
  * [chapters] (the rendered list), or null when the id is absent or the list is
- * empty — defensive, so we never scroll to a bogus row. Live auto-follow of the
- * currently-*playing* chapter is the deferred #1676 follow-up (needs new
- * playback-state wiring the screen doesn't have today).
+ * empty — defensive, so we never scroll to a bogus row. This is the
+ * *resume-on-open* anchor; live auto-follow of the currently-*playing* chapter
+ * is the sibling [followScrollIndex] decision.
  */
 internal fun targetScrollIndex(chapters: List<UiChapter>, resumeId: String?): Int? {
     if (resumeId == null) return null
     return chapters.indexOfFirst { it.id == resumeId }.takeIf { it >= 0 }
+}
+
+/**
+ * Issue #1676 (live auto-follow half) — the LazyColumn *item* index to
+ * animate-scroll to so the currently-*playing* chapter follows into view as
+ * playback advances, or null for "leave the list where it is". This is the pure
+ * core of the auto-follow effect (the Compose `animateScrollToItem` is
+ * device-verified; this decision is CI-provable).
+ *
+ * Returns null when:
+ *  - [suspended] — the user manually scrolled and hasn't re-engaged (the chip
+ *    owns re-engagement; auto-follow must not fight a manual scroll);
+ *  - nothing from this fiction is playing ([playingChapterId] null, or absent
+ *    from the rendered [chapters] — defensive);
+ *  - the playing row is already *comfortably* visible: inside the visible item
+ *    range with at least [edgeMargin] rows of breathing room from either edge,
+ *    so we don't re-scroll on every position tick while it's plainly in view.
+ *
+ * Otherwise returns the playing chapter's list-item index ([chapters] index +
+ * [headerOffset], mirroring [targetScrollIndex]'s header math). [firstVisibleItemIndex]
+ * / [lastVisibleItemIndex] come from the list's `layoutInfo`.
+ */
+internal fun followScrollIndex(
+    chapters: List<UiChapter>,
+    playingChapterId: String?,
+    headerOffset: Int,
+    firstVisibleItemIndex: Int,
+    lastVisibleItemIndex: Int,
+    suspended: Boolean,
+    edgeMargin: Int = 1,
+): Int? {
+    if (suspended || playingChapterId == null) return null
+    val chapterIndex = chapters.indexOfFirst { it.id == playingChapterId }
+    if (chapterIndex < 0) return null
+    val target = chapterIndex + headerOffset
+    val comfortablyVisible =
+        target in (firstVisibleItemIndex + edgeMargin)..(lastVisibleItemIndex - edgeMargin)
+    return if (comfortablyVisible) null else target
+}
+
+/** Issue #1676 — which way the "playing" re-engage chip should point, or null
+ *  when it shouldn't show at all. */
+internal enum class FollowChipDirection { Up, Down }
+
+/**
+ * Issue #1676 — the direction the "↓ playing" re-engage chip should point, or
+ * null to hide it. The chip is purely a re-engagement affordance, so it shows
+ * ONLY while auto-follow is [suspended] AND the playing chapter is entirely
+ * off-screen (outside `[firstVisibleItemIndex, lastVisibleItemIndex]`): pointing
+ * [FollowChipDirection.Up] when the playing row is above the viewport,
+ * [FollowChipDirection.Down] when below. Hidden (null) when following (not
+ * suspended), when nothing from this fiction is playing, or when the playing
+ * row is even partially visible — tapping to scroll to a row you can already
+ * see would be pointless.
+ */
+internal fun followChipDirection(
+    chapters: List<UiChapter>,
+    playingChapterId: String?,
+    headerOffset: Int,
+    firstVisibleItemIndex: Int,
+    lastVisibleItemIndex: Int,
+    suspended: Boolean,
+): FollowChipDirection? {
+    if (!suspended || playingChapterId == null) return null
+    val chapterIndex = chapters.indexOfFirst { it.id == playingChapterId }
+    if (chapterIndex < 0) return null
+    val target = chapterIndex + headerOffset
+    return when {
+        target < firstVisibleItemIndex -> FollowChipDirection.Up
+        target > lastVisibleItemIndex -> FollowChipDirection.Down
+        else -> null
+    }
+}
+
+/** Issue #1676 — handle returned by [rememberChapterAutoFollow] carrying the
+ *  re-engage chip's direction (null = hidden) and the tap-to-re-engage action. */
+private data class ChapterAutoFollow(
+    val chipDirection: FollowChipDirection?,
+    val onReEngage: () -> Unit,
+)
+
+/**
+ * Issue #1676 (live auto-follow half) — wires live playing-chapter auto-follow
+ * onto a chapter [listState], shared verbatim by the wide + narrow layouts:
+ *
+ *  - **Follow:** as playback advances (`playingChapterId` changes) the list
+ *    animate-scrolls to keep the playing chapter comfortably in view
+ *    ([followScrollIndex]).
+ *  - **Suspend on manual scroll:** a genuine user drag suspends the follow so
+ *    it never fights the wheel. We watch the list's [DragInteraction]s — a
+ *    programmatic `animateScrollToItem` (this follow, the resume-on-open scroll,
+ *    the jump-to-#) never emits one, so the follow can't suspend *itself* (no
+ *    guard flag needed). This is ReaderView's "manual scroll owns the wheel"
+ *    idea, but *sticky*: unlike ReaderView's wall-clock grace window that
+ *    auto-resumes, re-engagement here is explicit (the chip), so the list never
+ *    yanks itself back under the reader.
+ *  - **Re-engage:** [ChapterAutoFollow.onReEngage] clears the suspend; the
+ *    follow effect (keyed on the flag) then scrolls to the playing chapter.
+ *
+ * `suspended` is [androidx.compose.runtime.saveable.rememberSaveable] so a
+ * rotate mid-suspend doesn't silently re-arm the follow.
+ */
+@Composable
+private fun rememberChapterAutoFollow(
+    listState: LazyListState,
+    chapters: List<UiChapter>,
+    playingChapterId: String?,
+    headerOffset: Int,
+): ChapterAutoFollow {
+    var suspended by androidx.compose.runtime.saveable.rememberSaveable { mutableStateOf(false) }
+
+    LaunchedEffect(listState) {
+        listState.interactionSource.interactions.collect { interaction ->
+            if (interaction is DragInteraction.Start) suspended = true
+        }
+    }
+
+    // Follow on advance / re-engage / first hydration. Keyed on the playing id
+    // (chapter advance), the suspend flag (re-engage flips it false), and the
+    // list going non-empty (a currently-playing book opened whose chapters
+    // hydrate after first composition). NOT keyed on the visible range — that's
+    // read imperatively at fire time so a scroll that leaves the row comfortably
+    // visible doesn't re-fire.
+    LaunchedEffect(playingChapterId, suspended, chapters.isNotEmpty()) {
+        val lastVisible = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index
+            ?: listState.firstVisibleItemIndex
+        followScrollIndex(
+            chapters = chapters,
+            playingChapterId = playingChapterId,
+            headerOffset = headerOffset,
+            firstVisibleItemIndex = listState.firstVisibleItemIndex,
+            lastVisibleItemIndex = lastVisible,
+            suspended = suspended,
+        )?.let { listState.animateScrollToItem(it) }
+    }
+
+    // Chip visibility/direction tracks scroll (visible range), the suspend flag,
+    // and the playing id — all read live so the chip appears/hides as the user
+    // scrolls the playing row on/off screen.
+    val chipDirection by remember(chapters, playingChapterId, headerOffset) {
+        derivedStateOf {
+            val lastVisible = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index
+                ?: listState.firstVisibleItemIndex
+            followChipDirection(
+                chapters = chapters,
+                playingChapterId = playingChapterId,
+                headerOffset = headerOffset,
+                firstVisibleItemIndex = listState.firstVisibleItemIndex,
+                lastVisibleItemIndex = lastVisible,
+                suspended = suspended,
+            )
+        }
+    }
+
+    return ChapterAutoFollow(
+        chipDirection = chipDirection,
+        onReEngage = { suspended = false },
+    )
+}
+
+/**
+ * Issue #1676 — the brass "playing" re-engage chip. A small Library-Nocturne
+ * brass pill floating bottom-center over the chapter list while auto-follow is
+ * suspended and the playing chapter is off-screen; it points ↓/↑ toward the
+ * playing row and, on tap, re-engages the follow (which scrolls to it). Renders
+ * nothing when [direction] is null; fades + slides for the transition. Apply
+ * `Modifier.align(Alignment.BottomCenter)` at the (Box) call site.
+ */
+@Composable
+private fun FollowPlayingChip(
+    direction: FollowChipDirection?,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val spacing = LocalSpacing.current
+    // Hold the last shown direction so the arrow doesn't flip mid-fade-out.
+    var lastDirection by remember { mutableStateOf(FollowChipDirection.Down) }
+    if (direction != null) lastDirection = direction
+    val description = stringResource(R.string.fiction_follow_playing_chip_desc)
+    AnimatedVisibility(
+        visible = direction != null,
+        enter = fadeIn() + slideInVertically { it / 2 },
+        exit = fadeOut() + slideOutVertically { it / 2 },
+        modifier = modifier,
+    ) {
+        Surface(
+            shape = RoundedCornerShape(percent = 50),
+            color = MaterialTheme.colorScheme.primary,
+            contentColor = MaterialTheme.colorScheme.onPrimary,
+            shadowElevation = 6.dp,
+            modifier = Modifier.clickable(
+                role = Role.Button,
+                onClickLabel = description,
+                onClick = onClick,
+            ),
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(spacing.xxs),
+                modifier = Modifier.padding(
+                    start = spacing.sm,
+                    end = spacing.md,
+                    top = spacing.xs,
+                    bottom = spacing.xs,
+                ),
+            ) {
+                Icon(
+                    imageVector = if (lastDirection == FollowChipDirection.Up) {
+                        Icons.Filled.KeyboardArrowUp
+                    } else {
+                        Icons.Filled.KeyboardArrowDown
+                    },
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp),
+                )
+                Text(
+                    text = stringResource(R.string.fiction_follow_playing_chip),
+                    style = MaterialTheme.typography.labelLarge,
+                )
+            }
+        }
+    }
 }
 
 /** Issue #604 — derive the Play button label. Reads "Resume" when the

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailViewModel.kt
@@ -46,6 +46,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -98,6 +99,15 @@ data class FictionDetailUiState(
      *  affordance instead of a bare empty list while a slow feed (e.g. a fresh
      *  RSS subscription) hydrates its chapters. */
     val chaptersRefreshing: Boolean = false,
+    /** Issue #1676 (live auto-follow half) — the id of the chapter currently
+     *  playing, but ONLY when the playing fiction is *this* detail screen's
+     *  fiction; null otherwise (nothing playing, or another book is playing).
+     *  Sourced from [PlaybackControllerUi.state] — the same flow the mini-player
+     *  reads. Drives two things in the chapter list: the playing-row highlight
+     *  (`ChapterCard.isCurrent`) and the live auto-follow scroll (the list keeps
+     *  the playing chapter in view as playback advances). Gating on the fiction
+     *  match keeps the list inert while a different book plays. */
+    val playingChapterId: String? = null,
 )
 
 /**
@@ -410,6 +420,29 @@ class FictionDetailViewModel @Inject constructor(
             // / connectivity folds above.
             .combine(repo.detailRefreshing(fictionId)) { state, refreshing ->
                 state.copy(chaptersRefreshing = refreshing)
+            }
+            // Issue #1676 — fold in the live playing-chapter id from the shared
+            // playback flow (same source the mini-player reads). Only surface it
+            // when the *playing* fiction is this screen's fiction, so the list
+            // follows its own playback and stays inert while another book plays.
+            // Appended as a binary combine (the `base` combine is at its 5-arg
+            // ceiling) — same shape as the companion / connectivity / refresh
+            // folds above.
+            //
+            // `onStart { emit(null) }` is load-bearing: `playback.state` is a
+            // shareIn(WhileSubscribed) over a combine that only ticks while
+            // playing, so on an idle app it may not emit until the first
+            // playback — and a `combine` withholds ALL output until every source
+            // has emitted once. Without the seed the whole detail screen would
+            // sit on the skeleton until something played. distinctUntilChanged
+            // coalesces the seed with an identical first real value.
+            .combine(
+                playback.state
+                    .map { pb -> pb.chapterId?.takeIf { pb.fictionId == fictionId } }
+                    .distinctUntilChanged()
+                    .onStart { emit(null) },
+            ) { state, playingChapterId ->
+                state.copy(playingChapterId = playingChapterId)
             }
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), FictionDetailUiState())
     }

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -444,6 +444,11 @@
     <string name="fiction_chapter_search_label">Search chapters</string>
     <string name="fiction_chapter_jump_label">Go to #</string>
     <string name="fiction_chapter_search_no_results">No chapters match your search.</string>
+    <!-- Issue #1676 — live auto-follow "playing" re-engage chip. Shown floating
+         over the chapter list after the listener manually scrolls away from the
+         playing chapter; tapping it re-engages auto-follow and scrolls back. -->
+    <string name="fiction_follow_playing_chip">Playing</string>
+    <string name="fiction_follow_playing_chip_desc">Scroll to the chapter that\'s playing</string>
     <!-- Issue #1489 — shown in the chapter-list slot while a slow feed (e.g. a
          fresh RSS subscription) is still fetching its chapters. -->
     <string name="fiction_fetching_chapters">Fetching chapters…</string>

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/fiction/ChapterAutoFollowTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/fiction/ChapterAutoFollowTest.kt
@@ -1,0 +1,238 @@
+package `in`.jphe.storyvox.feature.fiction
+
+import `in`.jphe.storyvox.feature.api.UiChapter
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Issue #1676 (live auto-follow half) — the chapter list should live-follow the
+ * *playing* chapter as playback advances, suspend when the user scrolls away,
+ * and offer a re-engage chip. [followScrollIndex] (should-we-scroll-and-where)
+ * and [followChipDirection] (should-the-chip-show-and-which-way) are the pure
+ * decisions the Compose effects call — the animate-scroll itself is
+ * device-verified; these are the CI-provable core (mirrors [TargetScrollIndexTest]).
+ */
+class ChapterAutoFollowTest {
+
+    private fun ch(id: String, number: Int) = UiChapter(
+        id = id,
+        number = number,
+        title = "Chapter $number",
+        publishedRelative = "1d",
+        durationLabel = "12 min",
+        isDownloaded = false,
+        isFinished = false,
+    )
+
+    /** A list of [n] chapters with ids "c0"…"c(n-1)". */
+    private fun chapters(n: Int) = (0 until n).map { ch("c$it", it + 1) }
+
+    // ── followScrollIndex: the follow decision ────────────────────────────
+
+    @Test
+    fun `follows forward when the playing chapter advances below the viewport`() {
+        // Playing "c5" (index 5) → list-item 6 with headerOffset 1. Visible rows
+        // are items 1..4 (chapters above it), so it's off-screen below → scroll.
+        val target = followScrollIndex(
+            chapters = chapters(10),
+            playingChapterId = "c5",
+            headerOffset = 1,
+            firstVisibleItemIndex = 1,
+            lastVisibleItemIndex = 4,
+            suspended = false,
+        )
+        assertEquals(6, target)
+    }
+
+    @Test
+    fun `follows backward when the playing chapter is above the viewport`() {
+        // Playing "c5" → item 6; viewport is items 8..11 (scrolled past it) → scroll up.
+        val target = followScrollIndex(
+            chapters = chapters(20),
+            playingChapterId = "c5",
+            headerOffset = 1,
+            firstVisibleItemIndex = 8,
+            lastVisibleItemIndex = 11,
+            suspended = false,
+        )
+        assertEquals(6, target)
+    }
+
+    @Test
+    fun `no-op when the playing chapter is already comfortably visible`() {
+        // Item 6 sits well inside the visible range [1..11] (margin 1) → don't jitter.
+        assertNull(
+            followScrollIndex(
+                chapters = chapters(20),
+                playingChapterId = "c5",
+                headerOffset = 1,
+                firstVisibleItemIndex = 1,
+                lastVisibleItemIndex = 11,
+                suspended = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `re-centres when the playing chapter is hugging the top edge`() {
+        // Item 6 == firstVisibleItemIndex: technically visible but glued to the
+        // edge; the edge margin re-centres it so it isn't clipped at the top.
+        val target = followScrollIndex(
+            chapters = chapters(20),
+            playingChapterId = "c5",
+            headerOffset = 1,
+            firstVisibleItemIndex = 6,
+            lastVisibleItemIndex = 15,
+            suspended = false,
+        )
+        assertEquals(6, target)
+    }
+
+    @Test
+    fun `suspended follow never scrolls even when the playing chapter is off-screen`() {
+        assertNull(
+            followScrollIndex(
+                chapters = chapters(10),
+                playingChapterId = "c5",
+                headerOffset = 1,
+                firstVisibleItemIndex = 1,
+                lastVisibleItemIndex = 4,
+                suspended = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `no playing chapter means no follow`() {
+        assertNull(
+            followScrollIndex(
+                chapters = chapters(10),
+                playingChapterId = null,
+                headerOffset = 1,
+                firstVisibleItemIndex = 1,
+                lastVisibleItemIndex = 4,
+                suspended = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `playing id absent from the list means no follow (defensive, e g filtered out)`() {
+        assertNull(
+            followScrollIndex(
+                chapters = chapters(10),
+                playingChapterId = "not-in-list",
+                headerOffset = 1,
+                firstVisibleItemIndex = 1,
+                lastVisibleItemIndex = 4,
+                suspended = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `header offset is added to the chapter index (narrow-layout preamble)`() {
+        // Narrow layout: 6 header items above the chapter rows. Playing the first
+        // chapter ("c0", index 0) → list-item 6, off-screen below the header → scroll.
+        val target = followScrollIndex(
+            chapters = chapters(10),
+            playingChapterId = "c0",
+            headerOffset = 6,
+            firstVisibleItemIndex = 0,
+            lastVisibleItemIndex = 3,
+            suspended = false,
+        )
+        assertEquals(6, target)
+    }
+
+    // ── followChipDirection: the re-engage chip decision ──────────────────
+
+    @Test
+    fun `chip points down when suspended and the playing chapter is below the viewport`() {
+        assertEquals(
+            FollowChipDirection.Down,
+            followChipDirection(
+                chapters = chapters(10),
+                playingChapterId = "c5",
+                headerOffset = 1,
+                firstVisibleItemIndex = 1,
+                lastVisibleItemIndex = 4,
+                suspended = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `chip points up when suspended and the playing chapter is above the viewport`() {
+        assertEquals(
+            FollowChipDirection.Up,
+            followChipDirection(
+                chapters = chapters(20),
+                playingChapterId = "c5",
+                headerOffset = 1,
+                firstVisibleItemIndex = 8,
+                lastVisibleItemIndex = 11,
+                suspended = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `no chip while suspended if the playing chapter is on-screen`() {
+        // Tapping to scroll to a row you can already see would be pointless.
+        assertNull(
+            followChipDirection(
+                chapters = chapters(20),
+                playingChapterId = "c5",
+                headerOffset = 1,
+                firstVisibleItemIndex = 1,
+                lastVisibleItemIndex = 11,
+                suspended = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `no chip while auto-follow is active (not suspended)`() {
+        // When following, the list keeps the row in view itself — no chip needed.
+        assertNull(
+            followChipDirection(
+                chapters = chapters(10),
+                playingChapterId = "c5",
+                headerOffset = 1,
+                firstVisibleItemIndex = 1,
+                lastVisibleItemIndex = 4,
+                suspended = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `no chip when nothing from this fiction is playing`() {
+        assertNull(
+            followChipDirection(
+                chapters = chapters(10),
+                playingChapterId = null,
+                headerOffset = 1,
+                firstVisibleItemIndex = 1,
+                lastVisibleItemIndex = 4,
+                suspended = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `no chip when the playing id is absent from the rendered list`() {
+        assertNull(
+            followChipDirection(
+                chapters = chapters(10),
+                playingChapterId = "not-in-list",
+                headerOffset = 1,
+                firstVisibleItemIndex = 1,
+                lastVisibleItemIndex = 4,
+                suspended = true,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
**Completes #1676.** PR #1695 shipped the *resume-on-open* half (scroll to where the listener left off); this is the deferred **live auto-follow** half — the chapter list now follows the *currently-playing* chapter as playback advances.

## Behavior
- **Playing row lights up.** `ChapterCard(currentId = …)` was hardcoded `null`; it's now fed the live playing-chapter id, so the row you're hearing is highlighted (the existing `isCurrent` primaryContainer affordance) in **both** the wide (tablet) and narrow (phone) layouts.
- **Auto-follow on advance.** As playback moves to the next chapter, the chapter `LazyColumn` animate-scrolls to keep the playing chapter comfortably in view. No-op when it's already comfortably visible (no jitter on every position tick).
- **Suspend on manual scroll.** The moment the listener drags the list, auto-follow suspends so it never fights the wheel. **Sticky** — it does *not* auto-resume on a timer (that's the one deliberate divergence from ReaderView's `lastManualScrollAt` grace window; here re-engagement is explicit via the chip, so the list never yanks itself back under the reader).
- **"Playing" re-engage chip.** While suspended **and** the playing chapter is off-screen, a small brass Library-Nocturne pill floats bottom-center over the list, pointing ↓/↑ toward the playing row. Tap it to re-engage auto-follow (which scrolls back to the playing chapter). It hides when follow is active or the playing row is on-screen.

## Wiring
- `FictionDetailUiState` gains a nullable `playingChapterId`, folded in from `PlaybackControllerUi.state` — the same flow the mini-player reads — but **only when the playing fiction is this detail screen's fiction**, so the list follows its own playback and stays inert while another book plays.

## ⚠️ Load-bearing: the `WhileSubscribed` stall guard
`playback.state` is a `shareIn(WhileSubscribed)` over a `combine` that includes a *tick-while-playing* source, so **on an idle app it may not emit until the first playback**. A bare `combine(…, playback.state)` withholds *all* output until every source has emitted once — which would have stranded the **entire detail screen on the skeleton** until something played. Guarded by seeding the playing-id flow with `onStart { emit(null) }` (+ `distinctUntilChanged` to coalesce the seed with an identical first real value). Flagging this explicitly for review — it's easy to trip over.

## Structure
- Two pure, CI-provable decision fns (siblings of #1695's `targetScrollIndex`):
  - `followScrollIndex(...)` → the list-item index to scroll to, or `null` (suspended / nothing playing / already comfortably visible).
  - `followChipDirection(...)` → `Up` / `Down` / `null` for the chip.
- Both layouts share a `rememberChapterAutoFollow` helper that owns the sticky-suspend state (drag detection via `DragInteraction` — a programmatic scroll never emits one, so the follow can't suspend *itself*, no guard flag needed) and the follow effect.
- No interface member added → **no hand-rolled-fake breakage**: `playingChapterId` is a defaulted `FictionDetailUiState` field and `PlaybackControllerUi.state` already existed.

## CI proves (compile + unit)
`ChapterAutoFollowTest` — 15 JVM cases: follow forward/backward on advance, no-op when comfortably visible, re-centre when hugging an edge, suspended never scrolls, null/absent playing id, header-offset math; chip direction down/up + all hide cases (visible / not-suspended / nothing-playing / absent-id).

## 📱 Device-verify — for team-lead (Compose scroll is runtime; do NOT merge until checked)
- [ ] Play a chapter, let it advance → the list scrolls to keep the playing chapter in view, and the playing row is highlighted (phone + tablet).
- [ ] Manually scroll away → follow suspends (list is not yanked back) and the brass "Playing" chip appears pointing toward the playing row (↓ if below, ↑ if above).
- [ ] Tap the chip → auto-follow re-engages and scrolls to the playing chapter; the chip disappears.
- [ ] Scroll so the playing row is back on-screen → chip hides even while suspended.
- [ ] A *different* book playing while viewing this fiction's detail → no highlight, no follow, no chip (inert).

Completes #1676

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chapter lists now highlight the currently playing chapter.
  * Lists automatically follow playback as chapters advance, while pausing during manual scrolling.
  * A follow-playing chip lets you quickly return to the playing chapter when it is off-screen.
  * The chip indicates whether the playing chapter is above or below the current view.

* **Accessibility**
  * Added descriptive labels for the follow-playing control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->