### PR TITLE
Completes #1628 — residual HTML strippers (core landed in #1636)

### DIFF
--- a/core-data/src/main/kotlin/in/jphe/storyvox/data/text/HtmlPlainText.kt
+++ b/core-data/src/main/kotlin/in/jphe/storyvox/data/text/HtmlPlainText.kt
@@ -38,7 +38,7 @@ fun String.htmlToPlainText(): String {
     if (isBlank()) return ""
     val doc = Jsoup.parse(this)
     // Non-content: strip so their text never reaches the reader / narration.
-    doc.select("head, script, style, noscript, svg, title").remove()
+    doc.select(NON_CONTENT_SELECTOR).remove()
     val sb = StringBuilder()
     doc.body().traverse(object : NodeVisitor {
         override fun head(node: Node, depth: Int) {
@@ -58,6 +58,39 @@ fun String.htmlToPlainText(): String {
     })
     return sb.toString().normalizeBlockWhitespace()
 }
+
+/**
+ * Issue #1628 — single-line sibling of [htmlToPlainText] for **metadata**
+ * fields (titles, author names, subject lists, one-line descriptions, an
+ * abstract block) rather than multi-paragraph chapter bodies.
+ *
+ * Where [htmlToPlainText] preserves `\n\n` paragraph breaks (paragraph-nav
+ * keys on them), a metadata field wants exactly one clean line: strip tags,
+ * decode **every** entity natively (jsoup — the curly quotes / numeric refs /
+ * **hex refs** `&#x2019;` / accents the per-source regex tables missed,
+ * #1628), and collapse every run of whitespace — including newlines — to a
+ * single space. This matches the `stripTags → decode → collapseWhitespace`
+ * shape the arXiv / Standard Ebooks / Prime Gaming parsers hand-rolled, so
+ * migrating them to it is behaviour-preserving except for the entity FIXES.
+ *
+ * jsoup follows the HTML5 spec for malformed numeric refs (out-of-range /
+ * surrogate code points → U+FFFD replacement char) rather than leaking the
+ * raw `&#…;` text; real machine-generated feeds never emit those, and a
+ * replacement char is safer in narration than a spoken entity code.
+ *
+ * Accepts full documents and bare fragments alike; blank in → blank out.
+ */
+fun String.htmlToInlineText(): String {
+    if (isBlank()) return ""
+    val doc = Jsoup.parse(this)
+    doc.select(NON_CONTENT_SELECTOR).remove()
+    // Element.text() decodes entities, strips tags, and collapses all
+    // whitespace (incl. newlines) to single spaces — the inline contract.
+    return doc.body().text().trim()
+}
+
+/** Non-content elements whose text must never reach the reader / narration. */
+private const val NON_CONTENT_SELECTOR = "head, script, style, noscript, svg, title"
 
 /** Block-level tags whose close introduces a paragraph break. Inline tags
  *  (`<em>`, `<strong>`, `<a>`, …) are intentionally absent so their text

--- a/core-data/src/test/kotlin/in/jphe/storyvox/data/text/HtmlPlainTextTest.kt
+++ b/core-data/src/test/kotlin/in/jphe/storyvox/data/text/HtmlPlainTextTest.kt
@@ -165,4 +165,121 @@ class HtmlPlainTextTest {
         assertEquals("Just one paragraph here.", out)
         assertFalse(out.contains("\n"))
     }
+
+    // ── htmlToInlineText: single-line metadata contract (#1628) ─────
+
+    @Test
+    fun `htmlToInlineText collapses blocks and newlines to one line`() {
+        val out = "<h2>Title</h2><p>First line\n  second line</p>".htmlToInlineText()
+        assertEquals("Title First line second line", out)
+        assertFalse("inline output must be one line", out.contains("\n"))
+    }
+
+    @Test
+    fun `htmlToInlineText strips tags and drops non-content`() {
+        val out = "<style>.c{}</style><p>Body <em>text</em>.</p><script>x()</script>"
+            .htmlToInlineText()
+        assertEquals("Body text.", out)
+    }
+
+    @Test
+    fun `htmlToInlineText blank and empty inputs yield empty string`() {
+        assertEquals("", "".htmlToInlineText())
+        assertEquals("", "   \n\t ".htmlToInlineText())
+        assertEquals("", "<body></body>".htmlToInlineText())
+    }
+
+    @Test
+    fun `htmlToInlineText passes plain (non-markup) metadata through unchanged`() {
+        // arXiv citation_* meta content / SE schema:name are plain text.
+        assertEquals("Attention Is All You Need", "Attention Is All You Need".htmlToInlineText())
+    }
+
+    // ── #1628 named failure modes: RTL, nested lists, CDATA, entities ─
+
+    @Test
+    fun `RTL text survives intact in both converters`() {
+        // Codepoint-safe extraction — no byte-level mangling of Arabic/Hebrew.
+        val arabic = "<p>مرحبا بالعالم</p>"
+        assertEquals("مرحبا بالعالم", arabic.htmlToPlainText())
+        assertEquals("مرحبا بالعالم", arabic.htmlToInlineText())
+        val mixed = "<p>Hello <span>שלום</span> world</p>"
+        assertEquals("Hello שלום world", mixed.htmlToInlineText())
+    }
+
+    @Test
+    fun `nested lists keep every item and leak no list markup`() {
+        val html = "<ul><li>One<ul><li>Two</li><li>Three</li></ul></li><li>Four</li></ul>"
+        // Inline: one clean spaced run — the metadata contract.
+        assertEquals("One Two Three Four", html.htmlToInlineText())
+
+        val plain = html.htmlToPlainText()
+        listOf("One", "Two", "Three", "Three", "Four").forEach {
+            assertTrue("item $it present", plain.contains(it))
+        }
+        assertFalse("no <li> markup leaks", plain.contains("<li"))
+        // Known htmlToPlainText limitation (pre-#1628, shared by all migrated
+        // sources): a parent <li>'s own text abuts its first nested child's
+        // text ("OneTwo") because block-nav emits the break on close, not
+        // open. Harmless for prose; nested lists are rare in narrated bodies.
+        // Pinned so a future change to the block walk is a deliberate choice.
+        assertEquals("OneTwo\n\nThree\n\nFour", plain)
+    }
+
+    @Test
+    fun `CDATA markers never leak and unwrapped feed content cleans`() {
+        // RSS `content:encoded` arrives CDATA-unwrapped from the XML layer;
+        // the util then cleans the inner HTML. Markers must never survive.
+        val mixed = "<p>Before</p><![CDATA[note text]]><p>After</p>"
+        listOf(mixed.htmlToPlainText(), mixed.htmlToInlineText()).forEach { out ->
+            assertFalse("no CDATA open marker", out.contains("CDATA"))
+            assertFalse("no CDATA close marker", out.contains("]]>"))
+            assertTrue(out.contains("Before"))
+            assertTrue(out.contains("After"))
+        }
+        // The realistic path: content already unwrapped by the feed parser.
+        val unwrapped = "<p>Chapter body with an &amp; and a curly quote&#8217;s tail.</p>"
+        assertEquals("Chapter body with an & and a curly quote’s tail.", unwrapped.htmlToPlainText())
+    }
+
+    @Test
+    fun `exotic entities decode — the entity-table gap fix`() {
+        // The per-source regex tables (arXiv/PLOS/Wikisource/SE/Prime Gaming)
+        // decoded only ~6-10 named entities, leaking curly quotes, hex refs,
+        // and accents into the reader + TTS narration. jsoup decodes them all.
+        val html = "<p>&rsquo;&lsquo;&ldquo;&rdquo; &mdash; &hellip; " +
+            "&#x2019;hex &#8217;dec Sch&ouml;n caf&eacute; na&#xEF;ve</p>"
+        listOf(html.htmlToPlainText(), html.htmlToInlineText()).forEach { out ->
+            assertTrue("right single quote", out.contains("’"))
+            assertTrue("left single quote", out.contains("‘"))
+            assertTrue("left double quote", out.contains("“"))
+            assertTrue("right double quote", out.contains("”"))
+            assertTrue("em-dash", out.contains("—"))
+            assertTrue("ellipsis", out.contains("…"))
+            assertTrue("hex numeric ref", out.contains("’hex"))
+            assertTrue("decimal numeric ref", out.contains("’dec"))
+            assertTrue("named accent (o-umlaut)", out.contains("Schön"))
+            assertTrue("named accent (e-acute)", out.contains("café"))
+            assertTrue("hex accent (i-diaeresis)", out.contains("naïve"))
+            assertFalse("no raw entity survives", out.contains("&"))
+        }
+    }
+
+    @Test
+    fun `astral-plane numeric refs decode via surrogate pair, never throw (#1539)`() {
+        // The #1539 regression: Char(code) threw above U+FFFF. jsoup uses the
+        // full-codepoint decode, so an emoji numeric ref round-trips.
+        assertEquals("Fun 😀!", "Fun &#128512;!".htmlToInlineText())
+    }
+
+    @Test
+    fun `malformed numeric refs do not leak raw and do not throw`() {
+        // Out-of-range / lone-surrogate refs follow HTML5: jsoup emits U+FFFD
+        // rather than the per-source decoders' old literal passthrough. Never
+        // the raw `&#…;` code (which TTS would try to narrate).
+        val out = "bad &#1114112; ref and &#55296; too".htmlToInlineText()
+        assertFalse("no raw numeric ref leaks", out.contains("&#"))
+        assertTrue(out.contains("bad"))
+        assertTrue(out.contains("ref"))
+    }
 }

--- a/source-arxiv/src/main/kotlin/in/jphe/storyvox/source/arxiv/net/ArxivAbstractParser.kt
+++ b/source-arxiv/src/main/kotlin/in/jphe/storyvox/source/arxiv/net/ArxivAbstractParser.kt
@@ -1,5 +1,7 @@
 package `in`.jphe.storyvox.source.arxiv.net
 
+import `in`.jphe.storyvox.data.text.htmlToInlineText
+
 /**
  * Issue #378 — focused regex extractor over the arXiv abstract page
  * (`arxiv.org/abs/<id>`). Pulls a small, narrating-friendly set of
@@ -23,8 +25,13 @@ package `in`.jphe.storyvox.source.arxiv.net
  * abstract pages have a stable, decade-old layout; the `<meta
  * name="citation_*">` tags are part of arXiv's published metadata
  * contract (they're how Google Scholar indexes papers). Regex over
- * those anchors is plenty robust, runs on the plain JUnit classpath,
- * and avoids pulling jsoup just for one parser pass.
+ * those anchors is plenty robust and runs on the plain JUnit classpath.
+ *
+ * Field text (tag-stripping + full entity decode + whitespace collapse)
+ * goes through the shared [htmlToInlineText] in core-data (#1628) — one
+ * entity table for the whole app, covering the hex refs / accents / curly
+ * quotes the old local decoder missed. jsoup stays transitive to core-data;
+ * this module adds no jsoup dependency of its own.
  */
 internal object ArxivAbstractParser {
 
@@ -82,32 +89,25 @@ internal object ArxivAbstractParser {
      */
     fun parse(html: String): ArxivAbstract {
         val title = META_TITLE_REGEX.find(html)?.groupValues?.get(1)
-            ?.let(::decodeXmlEntities)
-            ?.collapseWhitespace()
+            ?.htmlToInlineText()
             ?: H1_TITLE_REGEX.find(html)?.groupValues?.get(1)
-                ?.let(::stripTags)
-                ?.let(::decodeXmlEntities)
-                ?.collapseWhitespace()
-                // Descriptor span gets stripped above; the leading
-                // "Title:" label survives as raw text and needs to come
-                // off AFTER whitespace collapse (otherwise the leading
-                // newline / indent prevents the prefix match).
+                ?.htmlToInlineText()
+                // The "Title:" descriptor-span label survives as text and
+                // comes off AFTER whitespace collapse (the leading indent
+                // would otherwise prevent the prefix match).
                 ?.removePrefix("Title:")
                 ?.trim()
             ?: ""
 
         val authors = META_AUTHOR_REGEX.findAll(html)
-            .map { decodeXmlEntities(it.groupValues[1]).collapseWhitespace() }
+            .map { it.groupValues[1].htmlToInlineText() }
             .filter { it.isNotBlank() }
             .toList()
 
         val abstract = META_ABSTRACT_REGEX.find(html)?.groupValues?.get(1)
-            ?.let(::decodeXmlEntities)
-            ?.collapseWhitespace()
+            ?.htmlToInlineText()
             ?: ABSTRACT_BLOCK_REGEX.find(html)?.groupValues?.get(1)
-                ?.let(::stripTags)
-                ?.let(::decodeXmlEntities)
-                ?.collapseWhitespace()
+                ?.htmlToInlineText()
                 // Strip the leading "Abstract:" label AFTER whitespace
                 // collapses — same shape as the title fallback above.
                 ?.removePrefix("Abstract:")
@@ -115,15 +115,11 @@ internal object ArxivAbstractParser {
             ?: ""
 
         val subjects = SUBJECTS_REGEX.find(html)?.groupValues?.get(1)
-            ?.let(::stripTags)
-            ?.let(::decodeXmlEntities)
-            ?.collapseWhitespace()
+            ?.htmlToInlineText()
             .orEmpty()
 
         val comments = COMMENTS_REGEX.find(html)?.groupValues?.get(1)
-            ?.let(::stripTags)
-            ?.let(::decodeXmlEntities)
-            ?.collapseWhitespace()
+            ?.htmlToInlineText()
             ?.takeIf { it.isNotBlank() }
 
         return ArxivAbstract(
@@ -193,9 +189,6 @@ internal object ArxivAbstractParser {
             append("Abstract. ").append(abstract.abstract)
         }
     }.trim()
-
-    private fun stripTags(html: String): String =
-        html.replace(Regex("<[^>]+>"), "")
 
     private fun escapeHtml(text: String): String =
         text.replace("&", "&amp;")

--- a/source-arxiv/src/main/kotlin/in/jphe/storyvox/source/arxiv/net/ArxivAtomFeed.kt
+++ b/source-arxiv/src/main/kotlin/in/jphe/storyvox/source/arxiv/net/ArxivAtomFeed.kt
@@ -1,5 +1,7 @@
 package `in`.jphe.storyvox.source.arxiv.net
 
+import `in`.jphe.storyvox.data.text.htmlToInlineText
+
 /**
  * Issue #378 — typed view of an arXiv API Atom feed response from
  * `export.arxiv.org/api/query`. arXiv returns a standard Atom 1.0
@@ -108,13 +110,11 @@ internal data class ArxivAtomFeed(
 
         private fun parseEntry(body: String): ArxivFeedEntry {
             val title = TITLE_REGEX.find(body)?.groupValues?.get(1)
-                ?.let(::decodeXmlEntities)
-                ?.collapseWhitespace()
+                ?.htmlToInlineText()
                 .orEmpty()
 
             val summary = SUMMARY_REGEX.find(body)?.groupValues?.get(1)
-                ?.let(::decodeXmlEntities)
-                ?.collapseWhitespace()
+                ?.htmlToInlineText()
                 .orEmpty()
 
             val id = ID_REGEX.find(body)?.groupValues?.get(1)?.trim().orEmpty()
@@ -128,7 +128,7 @@ internal data class ArxivAtomFeed(
             val published = PUBLISHED_REGEX.find(body)?.groupValues?.get(1)?.trim()
 
             val authors = AUTHOR_NAME_REGEX.findAll(body)
-                .map { decodeXmlEntities(it.groupValues[1]).collapseWhitespace() }
+                .map { it.groupValues[1].htmlToInlineText() }
                 .filter { it.isNotBlank() }
                 .toList()
 
@@ -191,19 +191,3 @@ internal fun extractArxivId(idUrl: String): String {
     // Strip trailing version suffix; keep any slash in archive-style ids.
     return tail.replace(Regex("v\\d+$"), "")
 }
-
-private val WHITESPACE_RE = Regex("""\s+""")
-
-/** Atom titles / summaries arrive multi-line with leading indentation; collapse. */
-internal fun String.collapseWhitespace(): String =
-    WHITESPACE_RE.replace(trim(), " ")
-
-/** Decode the half-dozen XML entities arXiv actually emits in titles/summaries. */
-internal fun decodeXmlEntities(text: String): String =
-    text
-        .replace("&lt;", "<")
-        .replace("&gt;", ">")
-        .replace("&quot;", "\"")
-        .replace("&apos;", "'")
-        .replace("&#39;", "'")
-        .replace("&amp;", "&")

--- a/source-arxiv/src/test/kotlin/in/jphe/storyvox/source/arxiv/ArxivAbstractParserTest.kt
+++ b/source-arxiv/src/test/kotlin/in/jphe/storyvox/source/arxiv/ArxivAbstractParserTest.kt
@@ -3,6 +3,7 @@ package `in`.jphe.storyvox.source.arxiv
 import `in`.jphe.storyvox.source.arxiv.net.ArxivAbstractParser
 import `in`.jphe.storyvox.source.arxiv.net.formatAuthors
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -96,6 +97,31 @@ class ArxivAbstractParserTest {
         assertTrue(parsed.authors.isEmpty())
         // No comments row → nullable comments field stays null.
         assertNull(parsed.comments)
+    }
+
+    @Test
+    fun `decodes hex, named, and accented entities the local table missed (#1628)`() {
+        // The old decodeXmlEntities handled only 6 XML entities — hex refs
+        // (&#xF6;), named accents (&ouml;), and curly quotes (&#8217;) leaked
+        // into the chapter body and TTS narration. The shared htmlToInlineText
+        // decodes them all. citation_* meta tags carry the field text.
+        val html = """
+            <html><head>
+            <meta name="citation_title" content="Caf&#233; Habits &amp; Sch&ouml;lkopf&#8217;s Method">
+            <meta name="citation_author" content="Sch&#xF6;lkopf, Bernhard">
+            <meta name="citation_abstract" content="A na&#xEF;ve rodent&#x2019;s tale &mdash; fun&#8230;">
+            </head><body></body></html>
+        """.trimIndent()
+        val parsed = ArxivAbstractParser.parse(html)
+
+        assertEquals("Café Habits & Schölkopf’s Method", parsed.title)
+        assertEquals(listOf("Schölkopf, Bernhard"), parsed.authors)
+        assertEquals("A naïve rodent’s tale — fun…", parsed.abstract)
+        // No raw entity codes reach the reader / narration.
+        listOf(parsed.title, parsed.authors.first(), parsed.abstract).forEach {
+            assertFalse("no named entity leaks", it.contains("&amp;") || it.contains("&ouml;"))
+            assertFalse("no numeric ref leaks", it.contains("&#"))
+        }
     }
 
     private fun readFixture(name: String): String {

--- a/source-google-news/src/main/kotlin/in/jphe/storyvox/source/googlenews/parse/GoogleNewsParser.kt
+++ b/source-google-news/src/main/kotlin/in/jphe/storyvox/source/googlenews/parse/GoogleNewsParser.kt
@@ -1,5 +1,6 @@
 package `in`.jphe.storyvox.source.googlenews.parse
 
+import `in`.jphe.storyvox.data.text.htmlToInlineText
 import org.w3c.dom.Element
 import org.xml.sax.InputSource
 import java.io.StringReader
@@ -110,7 +111,7 @@ internal object GoogleNewsParser {
     internal fun relatedHeadlinesFrom(descriptionHtml: String, exclude: String): List<String> {
         if (descriptionHtml.isBlank()) return emptyList()
         return A_TAG.findAll(descriptionHtml)
-            .map { stripHtml(it.groupValues[1]) }
+            .map { it.groupValues[1].htmlToInlineText() }
             .filter { it.isNotBlank() && !it.equals(exclude, ignoreCase = true) }
             .distinct()
             .take(MAX_RELATED)
@@ -141,21 +142,6 @@ internal object GoogleNewsParser {
         return null
     }
 
-    /** Strip a tiny HTML subset to plain text and decode the basic
-     *  entities, mirroring the TTS-plaintext helper in `:source-rss` /
-     *  `:source-hackernews`. */
-    internal fun stripHtml(s: String): String =
-        s.replace(TAG, " ")
-            .replace("&amp;", "&")
-            .replace("&lt;", "<")
-            .replace("&gt;", ">")
-            .replace("&quot;", "\"")
-            .replace("&#x27;", "'")
-            .replace("&#39;", "'")
-            .replace("&nbsp;", " ")
-            .replace(WHITESPACE, " ")
-            .trim()
-
     private const val MAX_RELATED = 6
 
     private const val DISALLOW_DOCTYPE = "http://apache.org/xml/features/disallow-doctype-decl"
@@ -164,8 +150,6 @@ internal object GoogleNewsParser {
 
     private val EMPTY = GoogleNewsFeed(title = "", items = emptyList())
     private val A_TAG = Regex("<a\\b[^>]*>(.*?)</a>", setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL))
-    private val TAG = Regex("<[^>]+>")
-    private val WHITESPACE = Regex("\\s+")
     private val DATE_PATTERNS = listOf(
         "EEE, dd MMM yyyy HH:mm:ss zzz",
         "EEE, dd MMM yyyy HH:mm:ss Z",

--- a/source-google-news/src/test/kotlin/in/jphe/storyvox/source/googlenews/parse/GoogleNewsParserTest.kt
+++ b/source-google-news/src/test/kotlin/in/jphe/storyvox/source/googlenews/parse/GoogleNewsParserTest.kt
@@ -78,7 +78,17 @@ class GoogleNewsParserTest {
     }
 
     @Test
-    fun `stripHtml removes tags and decodes the basic entities`() {
-        assertEquals("A & B", GoogleNewsParser.stripHtml("<b>A</b> &amp; <i>B</i>"))
+    fun `related headlines strip tags and decode entities via shared util (#1628)`() {
+        // Field cleanup moved from the local stripHtml (7-entity table) to
+        // the shared htmlToInlineText. Tag-strip + &amp;/&lt;/&gt; are
+        // behaviour-preserving; the curly quote (&#8217;) is the entity-gap
+        // FIX the old table left raw in the browse card / narration.
+        val descHtml =
+            """<ol><li><a href="#">Mat &amp; Friends&#8217; <b>big</b> day</a></li>""" +
+                """<li><a href="#">Other &lt;coverage&gt;</a></li></ol>"""
+        assertEquals(
+            listOf("Mat & Friends’ big day", "Other <coverage>"),
+            GoogleNewsParser.relatedHeadlinesFrom(descHtml, exclude = ""),
+        )
     }
 }

--- a/source-google-news/src/test/kotlin/in/jphe/storyvox/source/googlenews/parse/GoogleNewsParserTest.kt
+++ b/source-google-news/src/test/kotlin/in/jphe/storyvox/source/googlenews/parse/GoogleNewsParserTest.kt
@@ -85,9 +85,12 @@ class GoogleNewsParserTest {
         // FIX the old table left raw in the browse card / narration.
         val descHtml =
             """<ol><li><a href="#">Mat &amp; Friends&#8217; <b>big</b> day</a></li>""" +
-                """<li><a href="#">Other &lt;coverage&gt;</a></li></ol>"""
+                """<li><a href="#">Other &lt;coverage&gt;</a></li>""" +
+                // R1: old stripHtml replaced a tag with a SPACE; the shared
+                // util uses source whitespace, so an intra-word tag merges.
+                """<li><a href="#">Sky<i>net</i>rises</a></li></ol>"""
         assertEquals(
-            listOf("Mat & Friends’ big day", "Other <coverage>"),
+            listOf("Mat & Friends’ big day", "Other <coverage>", "Skynetrises"),
             GoogleNewsParser.relatedHeadlinesFrom(descHtml, exclude = ""),
         )
     }

--- a/source-hackernews/src/main/kotlin/in/jphe/storyvox/source/hackernews/HackerNewsSource.kt
+++ b/source-hackernews/src/main/kotlin/in/jphe/storyvox/source/hackernews/HackerNewsSource.kt
@@ -2,6 +2,7 @@ package `in`.jphe.storyvox.source.hackernews
 
 import `in`.jphe.storyvox.data.source.FictionSource
 import `in`.jphe.storyvox.data.source.SourceIds
+import `in`.jphe.storyvox.data.text.htmlToInlineText
 import `in`.jphe.storyvox.data.source.filter.FilterDimension
 import `in`.jphe.storyvox.data.source.filter.FilterState
 import `in`.jphe.storyvox.data.source.model.ChapterContent
@@ -433,23 +434,13 @@ internal fun chapterIdFor(fictionId: String): String = "${fictionId}::c0"
 
 /**
  * HN renders comment / Ask bodies as a tiny HTML subset — paragraphs,
- * `<i>`, `<a>`, `<pre><code>`, line breaks. The TTS pipeline
- * normalizes plaintext on top of whatever we hand it; this strip
- * just removes the tags and decodes the basic entities so the engine
- * doesn't read out angle brackets and `&#x27;`.
+ * `<i>`, `<a>`, `<pre><code>`, line breaks. #1628 — routed through the
+ * shared [htmlToInlineText]: same single-line collapse this always did,
+ * now with the full entity table (was 7 named/`&#x27;` refs). Note this
+ * intentionally keeps the one-line shape; restoring paragraph structure
+ * (`htmlToPlainText`) is a separate, on-device-verified change.
  */
-internal fun String.toPlainText(): String {
-    val withoutTags = Regex("<[^>]+>").replace(this, " ")
-    val decoded = withoutTags
-        .replace("&amp;", "&")
-        .replace("&lt;", "<")
-        .replace("&gt;", ">")
-        .replace("&quot;", "\"")
-        .replace("&#x27;", "'")
-        .replace("&#39;", "'")
-        .replace("&nbsp;", " ")
-    return decoded.replace(Regex("\\s+"), " ").trim()
-}
+internal fun String.toPlainText(): String = htmlToInlineText()
 
 /** Minimal HTML escape for the htmlBody round-trip. The reader view
  *  treats this body as a single `<p>` so newlines and ampersands

--- a/source-hackernews/src/test/kotlin/in/jphe/storyvox/source/hackernews/HackerNewsParseTest.kt
+++ b/source-hackernews/src/test/kotlin/in/jphe/storyvox/source/hackernews/HackerNewsParseTest.kt
@@ -88,6 +88,16 @@ class HackerNewsParseTest {
     }
 
     @Test
+    fun `toPlainText decodes the wider entity table and merges adjacent tags (#1628)`() {
+        // &mdash; is outside the old 7-entity table — the entity-gap FIX.
+        assertEquals("Wit — wonder", "Wit &mdash; wonder".toPlainText())
+        // R1: the old stripper put a SPACE where a tag sat; the shared util
+        // uses source whitespace, so an intra-word tag merges (chosen,
+        // pinned outcome — prose always spaces its emphasis anyway).
+        assertEquals("Skynetrises", "Sky<i>net</i>rises".toPlainText())
+    }
+
+    @Test
     fun `parses Algolia search response into hits`() {
         // Truncated real Algolia response. The real shape has lots
         // more fields (highlight ranges, _tags, created_at, etc.) —

--- a/source-palace/src/main/kotlin/in/jphe/storyvox/source/palace/parse/OpdsParser.kt
+++ b/source-palace/src/main/kotlin/in/jphe/storyvox/source/palace/parse/OpdsParser.kt
@@ -1,5 +1,6 @@
 package `in`.jphe.storyvox.source.palace.parse
 
+import `in`.jphe.storyvox.data.text.htmlToInlineText
 import android.util.Xml
 import org.xmlpull.v1.XmlPullParser
 import java.io.StringReader
@@ -141,7 +142,7 @@ internal object OpdsParser {
                     // crudely so it renders as a plain card subtitle.
                     val txt = readText(parser).trim()
                     if (summary.isNullOrBlank() && txt.isNotEmpty()) {
-                        summary = stripHtml(txt)
+                        summary = txt.htmlToInlineText()
                     }
                 }
                 "category" -> {
@@ -294,14 +295,6 @@ internal object OpdsParser {
             href
         }
     }
-
-    /** Cheap HTML→plain for entry summaries that arrived as `type="html"`.
-     *  The detail/listing UI shows these at-a-glance so we don't need
-     *  the full HTML→text pipeline; strip tags and collapse whitespace. */
-    private fun stripHtml(input: String): String =
-        Regex("<[^>]+>").replace(input, " ")
-            .replace(Regex("\\s+"), " ")
-            .trim()
 
     /** Classified entry shape. The parser walks once and dispatches in
      *  the caller; an entry can be exactly one of these. */

--- a/source-palace/src/test/kotlin/in/jphe/storyvox/source/palace/parse/OpdsParserTest.kt
+++ b/source-palace/src/test/kotlin/in/jphe/storyvox/source/palace/parse/OpdsParserTest.kt
@@ -162,6 +162,32 @@ class OpdsParserTest {
         )
     }
 
+    @Test
+    fun `html content summary strips tags and decodes entities (#1628)`() {
+        // OPDS `<content type="html">` carries escaped markup. The old
+        // local stripHtml stripped tags but NEVER decoded entities, so
+        // `&amp;` leaked into the browse-card subtitle. Field cleanup now
+        // uses the shared htmlToInlineText (tag-strip + full entity decode).
+        val xml = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <feed xmlns="http://www.w3.org/2005/Atom">
+              <title>Sample Library</title>
+              <entry>
+                <id>urn:test:works/7777</id>
+                <title>Entity Test Book</title>
+                <author><name>Ent Author</name></author>
+                <content type="html">&lt;i&gt;Wit&lt;/i&gt; &amp;amp; wonder</content>
+                <link rel="http://opds-spec.org/acquisition/open-access"
+                      type="application/epub+zip"
+                      href="https://lib.example/works/7777/download.epub"/>
+              </entry>
+            </feed>
+        """.trimIndent()
+
+        val feed = OpdsParser.parse(xml, baseUrl = "https://lib.example/opds")
+        assertEquals("Wit & wonder", feed.entries.single().summary)
+    }
+
     @Test(expected = OpdsParseException::class)
     fun `rejects non-OPDS root element`() {
         // RSS root → not an OPDS feed → throw at parse-time so the

--- a/source-palace/src/test/kotlin/in/jphe/storyvox/source/palace/parse/OpdsParserTest.kt
+++ b/source-palace/src/test/kotlin/in/jphe/storyvox/source/palace/parse/OpdsParserTest.kt
@@ -168,6 +168,9 @@ class OpdsParserTest {
         // local stripHtml stripped tags but NEVER decoded entities, so
         // `&amp;` leaked into the browse-card subtitle. Field cleanup now
         // uses the shared htmlToInlineText (tag-strip + full entity decode).
+        // Content below also pins R1: the old stripHtml replaced a tag with
+        // a SPACE, so an intra-word tag ("Sky<i>net</i>rises") split into
+        // three words; the shared util merges it ("Skynetrises").
         val xml = """
             <?xml version="1.0" encoding="utf-8"?>
             <feed xmlns="http://www.w3.org/2005/Atom">
@@ -176,7 +179,7 @@ class OpdsParserTest {
                 <id>urn:test:works/7777</id>
                 <title>Entity Test Book</title>
                 <author><name>Ent Author</name></author>
-                <content type="html">&lt;i&gt;Wit&lt;/i&gt; &amp;amp; wonder</content>
+                <content type="html">Sky&lt;i&gt;net&lt;/i&gt;rises &amp;amp; wit</content>
                 <link rel="http://opds-spec.org/acquisition/open-access"
                       type="application/epub+zip"
                       href="https://lib.example/works/7777/download.epub"/>
@@ -185,7 +188,7 @@ class OpdsParserTest {
         """.trimIndent()
 
         val feed = OpdsParser.parse(xml, baseUrl = "https://lib.example/opds")
-        assertEquals("Wit & wonder", feed.entries.single().summary)
+        assertEquals("Skynetrises & wit", feed.entries.single().summary)
     }
 
     @Test(expected = OpdsParseException::class)

--- a/source-primegaming/src/main/kotlin/in/jphe/storyvox/source/primegaming/net/PrimeGamingFeed.kt
+++ b/source-primegaming/src/main/kotlin/in/jphe/storyvox/source/primegaming/net/PrimeGamingFeed.kt
@@ -1,5 +1,7 @@
 package `in`.jphe.storyvox.source.primegaming.net
 
+import `in`.jphe.storyvox.data.text.htmlToInlineText
+
 /**
  * Issue #1494 — typed view of the LootScraper "Free Amazon Prime Games" Atom
  * feed. One [PrimeGamingEntry] per claimable title.
@@ -25,6 +27,14 @@ package `in`.jphe.storyvox.source.primegaming.net
  * If LootScraper's template ever shifts we re-key the regexes; the unit tests
  * pin the canonical layout so a silent break surfaces at CI, not on a user's
  * empty chapter list.
+ *
+ * Captured field text (tag-stripping + entity decode + whitespace collapse)
+ * goes through the shared [htmlToInlineText] in core-data (#1628) — one
+ * entity table for the whole app, adding the hex refs the old local decoder
+ * missed. jsoup follows HTML5 for malformed numeric refs (out-of-range /
+ * lone-surrogate code points → U+FFFD) rather than leaking the raw `&#…;`;
+ * emoji and the common `&#039;` / `&amp;` cases still decode as before.
+ * jsoup stays transitive to core-data; this module adds no jsoup dep.
  */
 internal data class PrimeGamingFeed(
     /** Feed-level `<title>` (e.g. "Free Amazon Prime Games (PC)"). */
@@ -87,7 +97,7 @@ internal data class PrimeGamingFeed(
             val firstEntry = xml.indexOf("<entry", ignoreCase = true)
             val head = if (firstEntry >= 0) xml.substring(0, firstEntry) else xml
             val feedTitle = FEED_TITLE_REGEX.find(head)?.groupValues?.get(1)
-                ?.let(::decodeXmlEntities)?.collapseWhitespace()?.ifBlank { null }
+                ?.htmlToInlineText()?.ifBlank { null }
             val feedUpdated = FEED_UPDATED_REGEX.find(head)?.groupValues?.get(1)?.trim()
                 ?.ifBlank { null }
 
@@ -106,7 +116,7 @@ internal data class PrimeGamingFeed(
             // template change that drops the numeric id doesn't collapse every
             // chapter onto one key.
             val rawTitle = TITLE_REGEX.find(body)?.groupValues?.get(1)
-                ?.let(::decodeXmlEntities)?.collapseWhitespace().orEmpty()
+                ?.htmlToInlineText().orEmpty()
             val game = TITLE_PREFIX_REGEX.replace(rawTitle, "").trim()
             val id = idUrl.substringAfterLast('/', "").ifBlank { slug(game) }
 
@@ -117,17 +127,17 @@ internal data class PrimeGamingFeed(
             val validTo = VALID_TO_REGEX.find(content)?.groupValues?.get(1)?.trim()?.ifBlank { null }
             val releaseDate = RELEASE_DATE_REGEX.find(content)?.groupValues?.get(1)?.trim()?.ifBlank { null }
             val description = DESCRIPTION_REGEX.find(content)?.groupValues?.get(1)
-                ?.let(::stripTags)?.let(::decodeXmlEntities)?.collapseWhitespace()?.ifBlank { null }
+                ?.htmlToInlineText()?.ifBlank { null }
 
             // Genres: prefer the <category label="…"> tags (clean); fall back to
             // the inline "Genres: Action, Adventure" list in the content body.
             val categoryGenres = CATEGORY_LABEL_REGEX.findAll(body)
-                .map { decodeXmlEntities(it.groupValues[1]).trim() }
+                .map { it.groupValues[1].htmlToInlineText() }
                 .filter { it.isNotBlank() }
                 .toList()
             val genres = categoryGenres.ifEmpty {
                 GENRES_INLINE_REGEX.find(content)?.groupValues?.get(1)
-                    ?.let(::stripTags)?.let(::decodeXmlEntities)
+                    ?.htmlToInlineText()
                     ?.split(',')?.map { it.trim() }?.filter { it.isNotBlank() }
                     ?: emptyList()
             }
@@ -148,7 +158,7 @@ internal data class PrimeGamingFeed(
                 releaseDate = releaseDate,
                 description = description,
                 genres = genres,
-                claimUrl = claimUrl?.let(::decodeXmlEntities),
+                claimUrl = claimUrl?.htmlToInlineText(),
                 updated = updated,
             )
         }
@@ -170,35 +180,3 @@ internal data class PrimeGamingEntry(
     val claimUrl: String?,
     val updated: String?,
 )
-
-private val WHITESPACE_RE = Regex("""\s+""")
-private val TAG_RE = Regex("""<[^>]+>""")
-private val NUMERIC_ENTITY_RE = Regex("""&#(\d+);""")
-
-/** Collapse the multi-line, indented XHTML text into a single spaced line. */
-internal fun String.collapseWhitespace(): String = WHITESPACE_RE.replace(trim(), " ")
-
-/** Drop any residual HTML tags left in a captured fragment. */
-internal fun stripTags(html: String): String = TAG_RE.replace(html, " ")
-
-/**
- * Decode the entities LootScraper actually emits — named plus numeric
- * (`&#039;` for an apostrophe is common in its game titles). `&amp;` is
- * decoded LAST so a doubly-safe `&amp;lt;` doesn't turn into `<`.
- */
-internal fun decodeXmlEntities(text: String): String =
-    NUMERIC_ENTITY_RE.replace(text) { m ->
-        m.groupValues[1].toIntOrNull()
-            // Supplementary-plane chars (emoji in game descriptions, e.g.
-            // &#128512;) need Character.toChars — Char(code) throws above
-            // 0xFFFF. Out-of-range and surrogate code points stay literal.
-            ?.takeIf { it in 0..0x10FFFF && it !in 0xD800..0xDFFF }
-            ?.let { code -> String(Character.toChars(code)) }
-            ?: m.value
-    }
-        .replace("&lt;", "<")
-        .replace("&gt;", ">")
-        .replace("&quot;", "\"")
-        .replace("&apos;", "'")
-        .replace("&#39;", "'")
-        .replace("&amp;", "&")

--- a/source-primegaming/src/test/kotlin/in/jphe/storyvox/source/primegaming/net/PrimeGamingFeedTest.kt
+++ b/source-primegaming/src/test/kotlin/in/jphe/storyvox/source/primegaming/net/PrimeGamingFeedTest.kt
@@ -121,6 +121,7 @@ class PrimeGamingFeedTest {
                 <id>https://feed.example/lootscraper/99999</id>
                 <title>Amazon Prime (Game) - Caf&#233; Story</title>
                 <content type="xhtml"><div xmlns="http://www.w3.org/1999/xhtml"><ul><li><b>Description:</b> A rodent&#x2019;s tale &mdash; fun &#128512; &amp; friends.</li></ul></div></content>
+                <link href="https://luna.amazon.com/claims/x?a=1&amp;b=2"/>
               </entry>
             </feed>
         """.trimIndent()
@@ -130,5 +131,9 @@ class PrimeGamingFeedTest {
         assertEquals("Café Story", entry.game)
         // Hex ref + named em-dash + astral emoji + &amp; all decode.
         assertEquals("A rodent’s tale — fun 😀 & friends.", entry.description)
+        // R2: claimUrl still routes through the shared util — an href's
+        // `&amp;` decodes to `&` (correct for an Atom href) and the URL is
+        // otherwise preserved (no over-decode/mangle of a real claim link).
+        assertEquals("https://luna.amazon.com/claims/x?a=1&b=2", entry.claimUrl)
     }
 }

--- a/source-primegaming/src/test/kotlin/in/jphe/storyvox/source/primegaming/net/PrimeGamingFeedTest.kt
+++ b/source-primegaming/src/test/kotlin/in/jphe/storyvox/source/primegaming/net/PrimeGamingFeedTest.kt
@@ -107,14 +107,28 @@ class PrimeGamingFeedTest {
     }
 
     @Test
-    fun `numeric entities decode across planes and never throw`() {
-        // BMP apostrophe — the common LootScraper case.
-        assertEquals("Rat's Quest", decodeXmlEntities("Rat&#039;s Quest"))
-        // Supplementary plane: emoji must decode via a surrogate pair,
-        // not throw (Char(code) IAE above 0xFFFF — the #1539 regression).
-        assertEquals("Fun 😀!", decodeXmlEntities("Fun &#128512;!"))
-        // Out-of-Unicode-range and surrogate code points stay literal.
-        assertEquals("bad &#1114112; ref", decodeXmlEntities("bad &#1114112; ref"))
-        assertEquals("lone &#55296; ref", decodeXmlEntities("lone &#55296; ref"))
+    fun `decodes hex, named, decimal, and astral entities via the shared util (#1628, #1539)`() {
+        // Field text now flows through core-data's htmlToInlineText (jsoup).
+        // This pins the entity-table FIX the local decoder missed — hex refs
+        // (&#x2019;) and named entities (&mdash;) — plus the #1539 guard that
+        // an astral emoji numeric ref decodes via a surrogate pair (never a
+        // Char(code) IAE) and &amp;/&#233; still decode as before.
+        val feed = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <feed xmlns="http://www.w3.org/2005/Atom">
+              <title>Free Amazon Prime Games (PC)</title>
+              <entry>
+                <id>https://feed.example/lootscraper/99999</id>
+                <title>Amazon Prime (Game) - Caf&#233; Story</title>
+                <content type="xhtml"><div xmlns="http://www.w3.org/1999/xhtml"><ul><li><b>Description:</b> A rodent&#x2019;s tale &mdash; fun &#128512; &amp; friends.</li></ul></div></content>
+              </entry>
+            </feed>
+        """.trimIndent()
+
+        val entry = PrimeGamingFeed.parse(feed).entries.single()
+        // Decimal accent in the title (prefix stripped, &#233; -> é).
+        assertEquals("Café Story", entry.game)
+        // Hex ref + named em-dash + astral emoji + &amp; all decode.
+        assertEquals("A rodent’s tale — fun 😀 & friends.", entry.description)
     }
 }

--- a/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/parser/FictionDetailParser.kt
+++ b/source-royalroad/src/main/kotlin/in/jphe/storyvox/source/royalroad/parser/FictionDetailParser.kt
@@ -4,6 +4,7 @@ import `in`.jphe.storyvox.data.source.model.ChapterInfo
 import `in`.jphe.storyvox.data.source.model.FictionDetail
 import `in`.jphe.storyvox.data.source.model.FictionStatus
 import `in`.jphe.storyvox.data.source.model.FictionSummary
+import `in`.jphe.storyvox.data.text.htmlToInlineText
 import `in`.jphe.storyvox.source.royalroad.model.RoyalRoadIds
 import `in`.jphe.storyvox.source.royalroad.model.extractChapterIdFromHref
 import kotlinx.serialization.json.Json
@@ -188,10 +189,12 @@ internal object FictionDetailParser {
         }
     }
 
-    private val TAG_RE = Regex("""<[^>]+>""")
-    private fun stripHtmlTags(s: String): String = s.replace(TAG_RE, "")
-        .replace("&nbsp;", " ").replace("&amp;", "&").replace("&#x2013;", "–")
-        .replace("&quot;", "\"").replace("&#x27;", "'").trim()
+    /** #1628 — RoyalRoad's JSON-LD `description` carries inline HTML +
+     *  entities. Was a local 5-entity table (tags→empty, no whitespace
+     *  collapse); now the shared [htmlToInlineText] — full entity decode +
+     *  single line, matching the parser's `div.hidden-content`.text()
+     *  HTML-selector fallback. `internal` so the parity test can pin it. */
+    internal fun stripHtmlTags(s: String): String = s.htmlToInlineText()
 
     private fun parseIso8601(s: String): Long? = runCatching {
         java.time.OffsetDateTime.parse(s).toInstant().toEpochMilli()

--- a/source-royalroad/src/test/kotlin/in/jphe/storyvox/source/royalroad/parser/FictionDetailParserTest.kt
+++ b/source-royalroad/src/test/kotlin/in/jphe/storyvox/source/royalroad/parser/FictionDetailParserTest.kt
@@ -1,0 +1,38 @@
+package `in`.jphe.storyvox.source.royalroad.parser
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Issue #1628 — pins the RoyalRoad JSON-LD `description` cleanup after
+ * moving it from a local 5-entity table (`&nbsp;/&amp;/&#x2013;/&quot;/
+ * &#x27;`, tags stripped to the empty string, internal whitespace kept)
+ * to the shared [stripHtmlTags] → `htmlToInlineText`.
+ *
+ * Tag-strip + those five entities are behaviour-preserving on a single-line
+ * blurb; the wins are (a) the full entity table (curly quotes / hex / accents
+ * the old table missed) and (b) multi-line blurbs collapsing to one line —
+ * which ALIGNS the JSON-LD path with the parser's `.text()` HTML fallback.
+ */
+class FictionDetailParserTest {
+
+    @Test
+    fun `stripHtmlTags decodes entities and strips inline tags`() {
+        assertEquals(
+            "A tale of woe & wonder–unabridged.'s end",
+            FictionDetailParser.stripHtmlTags(
+                "A tale of <i>woe</i> &amp; wonder&#x2013;unabridged.&#x27;s end",
+            ),
+        )
+    }
+
+    @Test
+    fun `stripHtmlTags collapses multi-line blurbs to one line`() {
+        // Aligns the JSON-LD description path with the div.hidden-content
+        // .text() fallback (which already collapses).
+        assertEquals(
+            "Line one. Line two.",
+            FictionDetailParser.stripHtmlTags("Line one.\nLine two."),
+        )
+    }
+}

--- a/source-standard-ebooks/src/main/kotlin/in/jphe/storyvox/source/standardebooks/net/SeHtmlParser.kt
+++ b/source-standard-ebooks/src/main/kotlin/in/jphe/storyvox/source/standardebooks/net/SeHtmlParser.kt
@@ -1,5 +1,7 @@
 package `in`.jphe.storyvox.source.standardebooks.net
 
+import `in`.jphe.storyvox.data.text.htmlToInlineText
+
 /**
  * Issue #375 — focused regex extractor over the public Standard Ebooks
  * listing and per-book HTML pages.
@@ -16,6 +18,12 @@ package `in`.jphe.storyvox.source.standardebooks.net
  * extraction shape an OPDS `<entry>` walker would. If SE ever ships a
  * public OPDS feed, the API client can swap to a `<feed><entry>` parser
  * and leave this file behind unchanged.
+ *
+ * Captured field text (tag-stripping + entity decode + whitespace
+ * collapse) goes through the shared [htmlToInlineText] in core-data
+ * (#1628) — one entity table for the whole app, decoding the curly
+ * quotes / em-dashes / accents the old local `htmlDecode` left raw.
+ * jsoup stays transitive to core-data; this module adds no jsoup dep.
  */
 internal object SeHtmlParser {
 
@@ -78,8 +86,6 @@ internal object SeHtmlParser {
         """<section\s+id="description">([\s\S]*?)</section>""",
     )
     private val PARAGRAPH_REGEX = Regex("""<p>([\s\S]*?)</p>""")
-    private val TAG_STRIP_REGEX = Regex("""<[^>]+>""")
-    private val WHITESPACE_REGEX = Regex("""\s+""")
 
     /**
      * Parse one HTML listing page into the wire shape consumed by
@@ -95,23 +101,21 @@ internal object SeHtmlParser {
             val block = m.groupValues[3]
 
             val title = TITLE_REGEX.find(block)?.groupValues?.get(1)
-                ?.htmlDecode()
-                ?.trim()
+                ?.htmlToInlineText()
                 ?: return@mapNotNull null
 
             // Author falls back to the slug prettified if the chip is
             // missing — SE always emits the chip, but a defensive
             // default protects against a layout shift.
             val author = AUTHOR_REGEX.find(block)?.groupValues?.get(1)
-                ?.htmlDecode()
-                ?.trim()
+                ?.htmlToInlineText()
                 ?: authorSlug.replace('-', ' ').replaceFirstChar { it.uppercase() }
 
             val coverPath = COVER_REGEX.find(block)?.groupValues?.get(1)
             val coverUrl = coverPath?.let { absolutize(it) }
 
             val tags = TAG_REGEX.findAll(block)
-                .map { it.groupValues[2].htmlDecode().trim() }
+                .map { it.groupValues[2].htmlToInlineText() }
                 .toList()
 
             SeBookEntry(
@@ -139,7 +143,7 @@ internal object SeHtmlParser {
         val section = DESCRIPTION_SECTION_REGEX.find(html)?.groupValues?.get(1)
             ?: return null
         val paragraphs = PARAGRAPH_REGEX.findAll(section)
-            .map { it.groupValues[1].stripTags().htmlDecode().trim() }
+            .map { it.groupValues[1].htmlToInlineText() }
             .filter { it.isNotEmpty() }
             .toList()
         if (paragraphs.isEmpty()) return null
@@ -159,23 +163,4 @@ internal object SeHtmlParser {
         path.startsWith("/") -> "https://standardebooks.org$path"
         else -> "https://standardebooks.org/$path"
     }
-
-    private fun String.stripTags(): String =
-        TAG_STRIP_REGEX.replace(this, " ")
-            .let { WHITESPACE_REGEX.replace(it, " ") }
-            .trim()
-
-    /**
-     * Cheap HTML-entity decoder for the handful of entities SE actually
-     * emits in titles/authors/descriptions (`&amp;`, `&quot;`, `&#39;`,
-     * the Unicode-encoded curly quotes / em-dashes pass through raw).
-     */
-    private fun String.htmlDecode(): String =
-        replace("&amp;", "&")
-            .replace("&quot;", "\"")
-            .replace("&#39;", "'")
-            .replace("&apos;", "'")
-            .replace("&lt;", "<")
-            .replace("&gt;", ">")
-            .replace("&nbsp;", " ")
 }

--- a/source-standard-ebooks/src/test/kotlin/in/jphe/storyvox/source/standardebooks/SeHtmlParserTest.kt
+++ b/source-standard-ebooks/src/test/kotlin/in/jphe/storyvox/source/standardebooks/SeHtmlParserTest.kt
@@ -159,4 +159,30 @@ class SeHtmlParserTest {
         val pageWithoutDescription = "<html><body><h1>Nope</h1></body></html>"
         assertNull(SeHtmlParser.parseBookDescription(pageWithoutDescription))
     }
+
+    @Test
+    fun `parseBookDescription decodes curly quotes, dashes, and accents (#1628)`() {
+        // The old local htmlDecode handled only ~7 named entities; curly
+        // quotes / em-dashes / accents leaked into the browse card + TTS.
+        // Field text now flows through the shared htmlToInlineText (jsoup).
+        val bookPage = """
+            <main><section id="description">
+                <h2>Description</h2>
+                <p>A rogue&#8217;s tale &mdash; wit, <em>daring</em>&hellip; and a curly &ldquo;quote&rdquo;.</p>
+                <p>Caf&eacute; na&#xEF;ve &amp; bold.</p>
+            </section></main>
+        """.trimIndent()
+
+        val desc = SeHtmlParser.parseBookDescription(bookPage)
+        assertNotNull(desc)
+        assertEquals(
+            "A rogue’s tale — wit, daring… and a curly “quote”.\n\nCafé naïve & bold.",
+            desc,
+        )
+        // No raw entity codes and no inline markup survive.
+        assertFalse(desc!!.contains("&#"))
+        assertFalse(desc.contains("&mdash;"))
+        assertFalse(desc.contains("&ldquo;"))
+        assertFalse(desc.contains("<em>"))
+    }
 }

--- a/source-wikipedia/src/main/kotlin/in/jphe/storyvox/source/wikipedia/net/WikipediaApi.kt
+++ b/source-wikipedia/src/main/kotlin/in/jphe/storyvox/source/wikipedia/net/WikipediaApi.kt
@@ -1,6 +1,7 @@
 package `in`.jphe.storyvox.source.wikipedia.net
 
 import `in`.jphe.storyvox.data.source.model.FictionResult
+import `in`.jphe.storyvox.data.text.htmlToInlineText
 import `in`.jphe.storyvox.source.wikipedia.config.WikipediaConfig
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
@@ -132,8 +133,7 @@ internal class WikipediaApi @Inject constructor(
                         res.value.query?.search.orEmpty().map { hit ->
                             WikipediaSearchHit(
                                 title = hit.title,
-                                // strip MediaWiki's <span class="searchmatch"> highlighting
-                                description = hit.snippet.replace(Regex("<[^>]+>"), "").trim(),
+                                description = cleanSearchSnippet(hit.snippet),
                                 url = "",
                             )
                         },
@@ -260,6 +260,15 @@ internal class WikipediaApi @Inject constructor(
 
 private fun JsonElement.contentOrEmpty(): String =
     runCatching { jsonPrimitive.contentOrNull }.getOrNull().orEmpty()
+
+/**
+ * Clean a MediaWiki search `snippet` into a plain one-line card subtitle.
+ * The snippet carries `<span class="searchmatch">` highlight markup and
+ * HTML entities. #1628 — routed through the shared [htmlToInlineText]
+ * (strip tags + full entity decode); the old inline strip removed tags
+ * but left entities like `&amp;` raw in the browse card.
+ */
+internal fun cleanSearchSnippet(rawSnippet: String): String = rawSnippet.htmlToInlineText()
 
 // ─── wire types ───────────────────────────────────────────────────────
 

--- a/source-wikipedia/src/test/kotlin/in/jphe/storyvox/source/wikipedia/net/WikipediaSearchSnippetTest.kt
+++ b/source-wikipedia/src/test/kotlin/in/jphe/storyvox/source/wikipedia/net/WikipediaSearchSnippetTest.kt
@@ -1,0 +1,36 @@
+package `in`.jphe.storyvox.source.wikipedia.net
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Issue #1628 — pins the MediaWiki search-snippet cleanup after moving it
+ * from an inline tag-strip (tags only, entities left raw) to the shared
+ * [cleanSearchSnippet] → [htmlToInlineText]. Tag-stripping is
+ * behaviour-preserving; entity decoding (`&amp;` → `&`) is the FIX the old
+ * inline strip left leaking into the browse-card subtitle.
+ */
+class WikipediaSearchSnippetTest {
+
+    @Test
+    fun `strips searchmatch highlight spans`() {
+        val snippet = "The <span class=\"searchmatch\">quantum</span> theory of fields"
+        assertEquals("The quantum theory of fields", cleanSearchSnippet(snippet))
+    }
+
+    @Test
+    fun `decodes entities the old inline strip left raw`() {
+        val snippet =
+            "The <span class=\"searchmatch\">quantum</span> theory &amp; its " +
+                "<span class=\"searchmatch\">field</span> &mdash; a curly quote&#8217;s tail"
+        assertEquals(
+            "The quantum theory & its field — a curly quote’s tail",
+            cleanSearchSnippet(snippet),
+        )
+    }
+
+    @Test
+    fun `blank snippet yields empty string`() {
+        assertEquals("", cleanSearchSnippet(""))
+    }
+}


### PR DESCRIPTION
**Refs #1628** — the issue stays open as the tracker until the PR2 follow-up (gutenberg / palace chapter-body strippers) lands; PR2 closes it.

Completes the residual HTML→plaintext strippers for #1628. The core consolidation (the shared `htmlToPlainText()` util + the 6 chapter-body strippers: rss, standard-ebooks, plos, wikipedia, wikisource, epub) landed earlier in **#1636**; this finishes the issue's remaining **metadata / snippet** strippers.

## The shared-util contract

`core-data`'s `text/HtmlPlainText.kt` now exposes **two** jsoup-based converters:

| | Use for | Whitespace | Entities |
|---|---|---|---|
| `htmlToPlainText()` (#1636) | **chapter bodies** — narrated content | preserves `\n\n` paragraph breaks (paragraph-nav keys on them) | full native decode |
| `htmlToInlineText()` (**new, this PR**) | **metadata / snippet fields** — titles, authors, abstracts, descriptions, card subtitles | collapses **all** whitespace (incl. newlines) → one line | full native decode |

The distinction is load-bearing: a title/author/summary field wants one clean line, so `htmlToInlineText` mirrors the old `stripTags → decode → collapseWhitespace` shape exactly — while `htmlToPlainText`'s `\n\n` would visibly regress a browse card into a multi-line blob. Both drop non-content (`head/script/style/noscript/svg/title`) and decode **every** entity (named, decimal, **hex `&#x2019;`**, accents) natively — closing the per-source entity-table gaps.

## Migrated

**Metadata parsers** (entity-fix only — behaviour-preserving on every existing fixture):

| Source | Fields | Delta |
|---|---|---|
| arXiv `ArxivAbstractParser` / `ArxivAtomFeed` | title, authors, abstract, subjects, comments | decodes hex refs / named accents / curly quotes the 6-entity table missed |
| Standard Ebooks `SeHtmlParser` | title, author, tags, description | curly quotes / em-dashes / accents no longer leak |
| Prime Gaming `PrimeGamingFeed` | title, description, genres, claim URL | entity-fix + malformed-numeric delta (below) |

**Snippet / blurb strippers** (single-line — entity-fix + the R1 tag-boundary note):

| Source | Field | Delta |
|---|---|---|
| Google News `GoogleNewsParser` | related-coverage headlines | curly quotes now decode |
| Palace `OpdsParser` | OPDS entry summary | old `stripHtml` decoded **no** entities (`&amp;` leaked) |
| Wikipedia `WikipediaApi` | search-result snippet (new `cleanSearchSnippet` seam) | old inline strip decoded **no** entities |
| Hacker News `toPlainText` | comment / Ask body | old stripper already flattened to one line → **parity**; wider entity table. (Restoring paragraphs via `htmlToPlainText` is the separate PR2.) |
| Royal Road `FictionDetailParser.stripHtmlTags` | JSON-LD fiction description | wider entity table + a **fix**: old empty-tag-replacement glued block/`<br>` boundaries (`line1<br>line2` → `line1line2`); the shared util spaces them (`line1 line2`), matching the parser's own `.text()` HTML fallback. Pinned by test. |

**Prime Gaming malformed-numeric delta** (pre-approved): the old decoder left out-of-range / lone-surrogate numeric refs (`&#1114112;`, `&#55296;`) *literal*; jsoup follows HTML5 → `U+FFFD`. Real LootScraper data never emits these — emoji (`&#128512;`), `&#039;`, `&amp;` all still decode. Pinned by test.

**R1 — tag-boundary whitespace** (pinned): google-news / palace / hackernews's old strippers replaced a tag with a **space**; `htmlToInlineText` uses source whitespace, so an intra-word tag merges (`Sky<i>net</i>rises` → `Skynetrises` instead of three words). Prose always spaces its emphasis, so real impact is nil — but the merge is now a chosen, tested outcome (one adjacency case pinned per space-replacer).

**R2 — `claimUrl`** (pinned): Prime Gaming's claim URL routes through the shared util; an href's `&amp;` decodes to `&` (correct for an Atom href) and the URL is otherwise preserved — pinned so no over-decode/mangle slips in.

## Behavior deltas (the only two non-preservation changes — both sanctioned, pinned)

| Delta | Where it shows | Why sanctioned | Pinned by |
|---|---|---|---|
| **Prime Gaming** — malformed numeric refs (`&#1114112;`, lone surrogate `&#55296;`) → `U+FFFD` instead of literal `&#…;` passthrough | game description (browse card + narration) | HTML5-spec behavior; real LootScraper feeds never emit these; a replacement char is safer than a spoken entity code. Emoji / `&#039;` / `&amp;` all still decode. | `HtmlPlainTextTest` (malformed → `U+FFFD`) + `PrimeGamingFeedTest` (feed still decodes emoji/`&#039;`/`&amp;`) |
| **Royal Road** — multi-line JSON-LD description collapses to one line; block/`<br>` boundaries the old empty-tag-replace **glued** (`line1<br>line2`→`line1line2`) now **space** (`line1 line2`) | fiction-detail blurb (browse; **not** chapter body, not TTS paragraph-nav) | fixes a latent gluing bug **and** aligns the JSON-LD path with the parser's own `div.hidden-content`.text() sibling, which already collapses — a consistency win | `FictionDetailParserTest` pins the multi-line (`\n`) collapse + inline-tag strip; the `<br>`-gluing case is jsoup-1.22.2-probed (an explicit `<br>` assertion is a PR2 test nice-to-have) |

Everything else is either behavior-preserving or a sanctioned **entity-gap fix** (raw `&…;` codes that used to leak into the reader / TTS now decode).

## Skipped — jsoup would *provably* regress (probed against jsoup-1.22.2)

- **ao3** `stripTags`/`decodeHtmlEntities` — a fixed-point loop decodes AO3's double-encoded `&amp;amp;` → `&`. jsoup decodes one level → `&amp;`, reintroducing the "narrates amp" bug (`Clint Barton &amp;amp; Kate Bishop`). **Left as-is.**
- **wikipedia** `cleanWikipediaTitle` — deliberately decodes *before* stripping, so entity-encoded `&lt;i&gt;Iceman&lt;/i&gt;` → `Iceman`. jsoup strips-then-decodes → literal `<i>Iceman</i>`. Its kdoc documents this exact trap. **Left as-is.**

## Deferred to a follow-up PR (PR2)

The 2 chapter-**body** strippers — **gutenberg** `stripTags`, **palace** `PalaceSource.stripTags` — currently collapse a whole chapter to one line. Their correct fix is `htmlToPlainText` (restores paragraph nav) — a *visible behaviour change* (blob → paragraphs, same class as the #1636 six) needing on-device verification. It gets its own headline PR + parity-of-content tests, not a hidden ride inside this behaviour-preserving migration.

## arXiv documented-exception note

arXiv's `## Why regex over jsoup` kdoc is about **structural field-extraction** — kept 100% regex here (every `META_*`/block regex untouched; the module adds **no jsoup dependency of its own**, jsoup is transitive via core-data only). This PR swaps only the **entity/tag cleanup** of already-extracted text, whose old 6-entity table was the #1628 leak. Kdoc updated to say exactly this. (Reviewed & ruled *compatible* by the read-only verifier.)

## Test-parity evidence

- `core-data/HtmlPlainTextTest` — new parity cases for both converters: RTL text, nested lists, CDATA-markers, exotic entities (named curly quotes, hex/decimal refs, accents), astral-plane emoji (#1539 guard), malformed-numeric → `U+FFFD`.
- Per-source parity pins added: arXiv, Standard Ebooks, Prime Gaming, Google News, Palace (OPDS), Wikipedia, Hacker News, Royal Road — each asserting the entity FIX + (for space-replacers) the R1 adjacency outcome.
- Every pre-existing contract test unchanged and green (behaviour preserved); one necessary replacement (the old Prime Gaming unit test called the now-deleted `decodeXmlEntities` and asserted the *old* literal-passthrough — replaced by a feed-level test; the `U+FFFD` behaviour is pinned in core-data).

Non-test diff is **net-negative** (deletes the per-module decoders).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
