### PR TITLE
fix(fiction): Resume targets the most recently played chapter (#1685)

### DIFF
--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailScreen.kt
@@ -641,7 +641,7 @@ fun FictionDetailScreen(
                 }
                 androidx.compose.runtime.LaunchedEffect(wideFiltered.isNotEmpty()) {
                     if (!wideDidResumeScroll && wideFiltered.isNotEmpty()) {
-                        targetScrollIndex(wideFiltered, pickChapterToPlay(state.chapters)?.id)
+                        targetScrollIndex(wideFiltered, pickChapterToPlay(state.chapters, state.resumeChapterId)?.id)
                             ?.let { wideListState.scrollToItem(it + wideHeaderOffset) }
                         wideDidResumeScroll = true
                     }
@@ -680,12 +680,12 @@ fun FictionDetailScreen(
                                 }
                             },
                             onFollowOnSource = viewModel::toggleFollowOnSource,
-                            onPlay = pickChapterToPlay(state.chapters)?.let { picked ->
+                            onPlay = pickChapterToPlay(state.chapters, state.resumeChapterId)?.let { picked ->
                                 { viewModel.listen(picked.id) }
                             },
                             playLabel = playButtonLabel(
                                 state.chapters,
-                                pickChapterToPlay(state.chapters),
+                                pickChapterToPlay(state.chapters, state.resumeChapterId),
                             ),
                         )
                     }
@@ -785,7 +785,7 @@ fun FictionDetailScreen(
             }
             androidx.compose.runtime.LaunchedEffect(narrowFiltered.isNotEmpty()) {
                 if (!narrowDidResumeScroll && narrowFiltered.isNotEmpty()) {
-                    targetScrollIndex(narrowFiltered, pickChapterToPlay(state.chapters)?.id)
+                    targetScrollIndex(narrowFiltered, pickChapterToPlay(state.chapters, state.resumeChapterId)?.id)
                         ?.let { narrowListState.scrollToItem(it + narrowHeaderCount) }
                     narrowDidResumeScroll = true
                 }
@@ -853,12 +853,12 @@ fun FictionDetailScreen(
                         onFollowOnSource = viewModel::toggleFollowOnSource,
                         // Issue #604 — Play CTA. First non-finished
                         // chapter (resume) or fall back to chapter 1.
-                        onPlay = pickChapterToPlay(state.chapters)?.let { picked ->
+                        onPlay = pickChapterToPlay(state.chapters, state.resumeChapterId)?.let { picked ->
                             { viewModel.listen(picked.id) }
                         },
                         playLabel = playButtonLabel(
                             state.chapters,
-                            pickChapterToPlay(state.chapters),
+                            pickChapterToPlay(state.chapters, state.resumeChapterId),
                         ),
                     )
                 }
@@ -1927,14 +1927,34 @@ private fun ChapterSearchBar(
     }
 }
 
-/** Issue #604 — pick the chapter the Play button should open.
- *  Strategy: first non-finished chapter, fall back to first chapter.
- *  Returns null when there are no chapters to play (loading state,
- *  empty fiction). Exposed `internal` so FictionDetailScreenTest can
- *  pin the contract without rendering the whole composable.
+/** Issue #604 / #1685 — pick the chapter the Play button should open.
+ *
+ *  Strategy, in order:
+ *  1. **Most recent position wins** (#1685). When [resumeChapterId] — the
+ *     chapter of this fiction's most-recently-updated saved position — is
+ *     present in [chapters], return it, *finished or not*. A listener who
+ *     went back to re-listen to chapter 10 of a 50-chapter book must resume
+ *     in chapter 10, and chapter 10 is already marked played, so the finished
+ *     flag cannot be used to skip it. The saved offset inside that chapter
+ *     is restored by the playback layer, not here.
+ *  2. First non-finished chapter (the original #604 progress frontier) when
+ *     there is no saved position, or it points at a chapter no longer in the
+ *     list (e.g. a source pruned it).
+ *  3. First chapter (replay a fully-finished book from the top).
+ *
+ *  Returns null when there are no chapters to play (loading state, empty
+ *  fiction). Exposed `internal` so the pure contract is pinned by
+ *  FictionDetailPlayButtonTest / PickChapterToPlayResumeTest without
+ *  rendering the composable.
  */
-internal fun pickChapterToPlay(chapters: List<UiChapter>): UiChapter? {
+internal fun pickChapterToPlay(
+    chapters: List<UiChapter>,
+    resumeChapterId: String? = null,
+): UiChapter? {
     if (chapters.isEmpty()) return null
+    if (resumeChapterId != null) {
+        chapters.firstOrNull { it.id == resumeChapterId }?.let { return it }
+    }
     return chapters.firstOrNull { !it.isFinished } ?: chapters.first()
 }
 

--- a/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailViewModel.kt
+++ b/feature/src/main/kotlin/in/jphe/storyvox/feature/fiction/FictionDetailViewModel.kt
@@ -14,6 +14,7 @@ import `in`.jphe.storyvox.data.db.entity.FictionMemoryEntry
 import `in`.jphe.storyvox.data.network.ConnectivityObserver
 import `in`.jphe.storyvox.data.repository.AnnotationRepository
 import `in`.jphe.storyvox.data.repository.FictionMemoryRepository
+import `in`.jphe.storyvox.data.repository.PlaybackPositionRepository
 import `in`.jphe.storyvox.data.repository.pronunciation.PronunciationDictRepository
 import `in`.jphe.storyvox.data.source.companion.CompanionMatch
 import `in`.jphe.storyvox.data.source.companion.CompanionResolver
@@ -99,6 +100,14 @@ data class FictionDetailUiState(
      *  affordance instead of a bare empty list while a slow feed (e.g. a fresh
      *  RSS subscription) hydrates its chapters. */
     val chaptersRefreshing: Boolean = false,
+    /** Issue #1685 — the chapter holding this fiction's **most recently
+     *  updated** playback position (from [PlaybackPositionRepository.observePosition],
+     *  `ORDER BY updatedAt DESC LIMIT 1`), or null when the user has never
+     *  played it. Feeds [pickChapterToPlay] so the Play/Resume button and the
+     *  open-scroll anchor (#1676) follow where the listener *actually* was —
+     *  not the first unfinished chapter, which is a progress frontier and
+     *  never moves back when someone re-listens to an earlier chapter. */
+    val resumeChapterId: String? = null,
     /** Issue #1676 (live auto-follow half) — the id of the chapter currently
      *  playing, but ONLY when the playing fiction is *this* detail screen's
      *  fiction; null otherwise (nothing playing, or another book is playing).
@@ -211,6 +220,10 @@ class FictionDetailViewModel @Inject constructor(
     private val exportAnnotations: ExportAnnotationsUseCase,
     /** Issue #1208 — cross-source audio↔text companion matcher (LibriVox↔Gutenberg). */
     private val companionResolver: CompanionResolver,
+    /** Issue #1685 — most-recent playback position for this fiction. Folded
+     *  into [uiState] as [FictionDetailUiState.resumeChapterId] so the
+     *  Play/Resume button resumes the chapter the user was last *in*. */
+    private val positionRepo: PlaybackPositionRepository,
     /** Issue #1314 — live network reachability. Folded into [uiState] so the
      *  screen can flag "showing cached data" while offline. */
     private val connectivity: ConnectivityObserver,
@@ -420,6 +433,12 @@ class FictionDetailViewModel @Inject constructor(
             // / connectivity folds above.
             .combine(repo.detailRefreshing(fictionId)) { state, refreshing ->
                 state.copy(chaptersRefreshing = refreshing)
+            }
+            // Issue #1685 — fold in the most-recently-updated saved position so
+            // Play/Resume (and the #1676 open-scroll anchor) target the chapter
+            // the listener was last in, not the first-unfinished frontier.
+            .combine(positionRepo.observePosition(fictionId)) { state, pos ->
+                state.copy(resumeChapterId = pos?.chapterId)
             }
             // Issue #1676 — fold in the live playing-chapter id from the shared
             // playback flow (same source the mini-player reads). Only surface it

--- a/feature/src/test/kotlin/in/jphe/storyvox/feature/fiction/PickChapterToPlayResumeTest.kt
+++ b/feature/src/test/kotlin/in/jphe/storyvox/feature/fiction/PickChapterToPlayResumeTest.kt
@@ -1,0 +1,133 @@
+package `in`.jphe.storyvox.feature.fiction
+
+import `in`.jphe.storyvox.feature.api.UiChapter
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Issue #1685 — "Resume goes to the last chapter ever listened to instead of
+ * the one listened to most recently."
+ *
+ * Pre-fix [pickChapterToPlay] returned the first non-finished chapter — a
+ * *progress frontier*. A listener who finished chapters 1–50, then went back to
+ * re-listen to chapter 10, was bounced to chapter 51 because chapter 10 was
+ * already marked played and nothing about the frontier ever moves backwards.
+ *
+ * Post-fix the picker takes the fiction's most-recently-updated saved
+ * position's chapter (`resumeChapterId`, `ORDER BY updatedAt DESC LIMIT 1` in
+ * the DAO) and returns it when present in the list, finished or not. The
+ * frontier rule remains the fallback when there is no saved position — so the
+ * #604 contract in [FictionDetailPlayButtonTest] still holds verbatim.
+ */
+class PickChapterToPlayResumeTest {
+
+    private fun ch(id: String, number: Int, finished: Boolean) = UiChapter(
+        id = id,
+        number = number,
+        title = "Chapter $number",
+        publishedRelative = "1d",
+        durationLabel = "12 min",
+        isDownloaded = false,
+        isFinished = finished,
+    )
+
+    /** The exact #1685 scenario: everything through c5 finished, most recent
+     *  position is back in c2. Resume must land in c2, not c6. */
+    @Test
+    fun `re-listening to an earlier finished chapter resumes there, not at the frontier`() {
+        val chapters = listOf(
+            ch("c1", 1, finished = true),
+            ch("c2", 2, finished = true),
+            ch("c3", 3, finished = true),
+            ch("c4", 4, finished = true),
+            ch("c5", 5, finished = true),
+            ch("c6", 6, finished = false),
+        )
+        assertEquals("c2", pickChapterToPlay(chapters, resumeChapterId = "c2")?.id)
+        // And the frontier rule is what the OLD code would have done:
+        assertEquals("c6", pickChapterToPlay(chapters, resumeChapterId = null)?.id)
+    }
+
+    @Test
+    fun `most recent position on an unfinished chapter resumes there`() {
+        val chapters = listOf(
+            ch("c1", 1, finished = true),
+            ch("c2", 2, finished = false),
+            ch("c3", 3, finished = false),
+        )
+        // User skipped ahead to c3 and stopped mid-way; c2 is the frontier.
+        assertEquals("c3", pickChapterToPlay(chapters, resumeChapterId = "c3")?.id)
+    }
+
+    @Test
+    fun `no saved position falls back to the first unfinished chapter`() {
+        val chapters = listOf(
+            ch("c1", 1, finished = true),
+            ch("c2", 2, finished = false),
+        )
+        assertEquals("c2", pickChapterToPlay(chapters, resumeChapterId = null)?.id)
+    }
+
+    @Test
+    fun `saved position for a chapter no longer in the list falls back to the frontier`() {
+        // Source pruned the chapter, or the id scheme changed — never return a
+        // chapter that isn't rendered; degrade to the #604 rule.
+        val chapters = listOf(
+            ch("c1", 1, finished = true),
+            ch("c2", 2, finished = false),
+        )
+        assertEquals("c2", pickChapterToPlay(chapters, resumeChapterId = "gone")?.id)
+    }
+
+    @Test
+    fun `fully finished book with a most recent position resumes that chapter (not chapter 1)`() {
+        // Re-listening to a finished book: the listener was in c2 last time,
+        // so Resume goes back into c2 rather than restarting at c1.
+        val chapters = listOf(
+            ch("c1", 1, finished = true),
+            ch("c2", 2, finished = true),
+            ch("c3", 3, finished = true),
+        )
+        assertEquals("c2", pickChapterToPlay(chapters, resumeChapterId = "c2")?.id)
+    }
+
+    @Test
+    fun `empty chapter list is null regardless of a saved position`() {
+        assertNull(pickChapterToPlay(emptyList(), resumeChapterId = "c1"))
+    }
+
+    // ── composed contracts ────────────────────────────────────────────────
+
+    @Test
+    fun `open-scroll anchor follows the most recent chapter too (#1676 composed)`() {
+        val chapters = listOf(
+            ch("c1", 1, finished = true),
+            ch("c2", 2, finished = true),
+            ch("c3", 3, finished = false),
+        )
+        val picked = pickChapterToPlay(chapters, resumeChapterId = "c1")
+        assertEquals(0, targetScrollIndex(chapters, picked?.id))
+    }
+
+    @Test
+    fun `label reads Play when the most recent chapter is the first one`() {
+        val chapters = listOf(
+            ch("c1", 1, finished = false),
+            ch("c2", 2, finished = false),
+        )
+        val picked = pickChapterToPlay(chapters, resumeChapterId = "c1")
+        assertEquals("Play", playButtonLabel(chapters, picked))
+    }
+
+    @Test
+    fun `label reads Resume when the most recent chapter is not the first`() {
+        val chapters = listOf(
+            ch("c1", 1, finished = true),
+            ch("c2", 2, finished = true),
+            ch("c3", 3, finished = false),
+        )
+        val picked = pickChapterToPlay(chapters, resumeChapterId = "c2")
+        assertEquals("Resume", playButtonLabel(chapters, picked))
+    }
+}


### PR DESCRIPTION
Fixes #1685 — *"Resume goes to the last chapter ever listened to instead of the one you listened to most recently."*

## Root cause
The Play/Resume button on Fiction Detail (and the #1676 open-scroll anchor, which reuses the same picker) resolved its target with `pickChapterToPlay` = **first non-finished chapter**. That is a *progress frontier*, not a recency anchor. A listener who finished chapters 1–50 and then went back to re-listen to chapter 10 was sent to **chapter 51**, because chapter 10 was already marked played and nothing about the frontier moves backwards.

## Fix
The Library "Continue listening" tile already had the right signal — the fiction's most-recently-updated `playback_position` row (`ORDER BY updatedAt DESC LIMIT 1`, `PlaybackDao.observe`). This folds that same flow into `FictionDetailUiState.resumeChapterId` (one more binary `.combine` on the state chain — the shape used for #1208 / #1314 / #1489) and teaches `pickChapterToPlay` to prefer it when present in the list, **finished or not**. The saved char-offset inside that chapter is restored by the playback layer as before.

**Fallback is unchanged** when there is no saved position, or it points at a chapter no longer in the list: first-unfinished, then first. So the #604 contract in `FictionDetailPlayButtonTest` holds verbatim via the default parameter.

## Tests
`PickChapterToPlayResumeTest` (new) pins the exact #1685 scenario, the pruned-chapter fallback, the fully-finished-book case, and the composed #1676 scroll-anchor + Play/Resume label behaviour. Pure-function tests, no device needed — the picker is `internal`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)