### PR TITLE
refactor(palace): use the shared htmlToPlainText for chapter bodies (#1628)

### DIFF
--- a/source-palace/src/main/kotlin/in/jphe/storyvox/source/palace/PalaceSource.kt
+++ b/source-palace/src/main/kotlin/in/jphe/storyvox/source/palace/PalaceSource.kt
@@ -1,5 +1,6 @@
 package `in`.jphe.storyvox.source.palace
 
+import `in`.jphe.storyvox.data.text.htmlToPlainText
 import `in`.jphe.storyvox.data.source.FictionSource
 import `in`.jphe.storyvox.data.source.RouteMatch
 import `in`.jphe.storyvox.data.source.SourceIds
@@ -379,7 +380,7 @@ internal class PalaceSource @Inject constructor(
             ChapterContent(
                 info = info,
                 htmlBody = ch.htmlBody,
-                plainBody = ch.htmlBody.stripTags(),
+                plainBody = ch.htmlBody.htmlToPlainText(),
             ),
         )
     }
@@ -662,23 +663,6 @@ internal fun chapterIndexFrom(chapterId: String): Int? =
     chapterId.substringAfterLast("::", missingDelimiterValue = "")
         .takeIf { it.isNotEmpty() }
         ?.toIntOrNull()
-
-/** Cheap HTML→plaintext for the chapter body the engine receives.
- *  The downstream pipeline normalizes further; this just gets the
- *  visible text out of the wrapper tags so the TTS engine doesn't
- *  read out angle-bracket noise. Same shape as the equivalent helper
- *  on `:source-gutenberg` (which already handles `<head>` / `<script>`
- *  / `<style>` stripping for SE / PG EPUBs — Palace EPUBs are the same
- *  EPUB 3 shape). */
-internal fun String.stripTags(): String {
-    val noHead = Regex("(?is)<head\\b[^>]*>.*?</head>").replace(this, " ")
-    val noScript = Regex("(?is)<script\\b[^>]*>.*?</script>").replace(noHead, " ")
-    val noStyle = Regex("(?is)<style\\b[^>]*>.*?</style>").replace(noScript, " ")
-    val noComments = Regex("(?s)<!--.*?-->").replace(noStyle, " ")
-    return Regex("<[^>]+>").replace(noComments, " ")
-        .replace(Regex("\\s+"), " ")
-        .trim()
-}
 
 /** Build a filesystem-safe filename from a fictionId. Uses
  *  [String.hashCode] formatted as 8-hex — collision-prone in theory but

--- a/source-palace/src/test/kotlin/in/jphe/storyvox/source/palace/PalacePlainBodyTest.kt
+++ b/source-palace/src/test/kotlin/in/jphe/storyvox/source/palace/PalacePlainBodyTest.kt
@@ -1,0 +1,65 @@
+package `in`.jphe.storyvox.source.palace
+
+import `in`.jphe.storyvox.data.text.htmlToPlainText
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #1628 — Palace chapter `plainBody` now comes from the shared
+ * `htmlToPlainText()` (core-data) instead of the module-local `stripTags`
+ * regex (the last chapter-body stripper, twin of the one #1718 removed from
+ * :source-gutenberg). Palace serves EPUB 3 spine documents, the same shape as
+ * PG/Standard Ebooks, so the same contracts apply.
+ *
+ * Pins what the old stripper guarded — `<head>`/`<script>`/`<style>`/comment
+ * removal with contents, case-insensitively — and the two things it got wrong
+ * (the reason for #1628): paragraph breaks survive as `\n\n` (paragraph-nav
+ * keys on them), and entities decode natively rather than leaking into TTS.
+ */
+class PalacePlainBodyTest {
+
+    @Test
+    fun `head script style and comments are stripped with their contents`() {
+        val html = """
+            <HTML><HEAD>
+              <TITLE>Ch. 1</TITLE>
+              <STYLE>body { color: black; }</STYLE>
+              <SCRIPT>alert('x');</SCRIPT>
+            </HEAD><BODY>
+              <!-- editor note -->
+              <h1>Chapter One</h1>
+              <p>The visible prose.</p>
+            </BODY></HTML>
+        """.trimIndent()
+
+        val plain = html.htmlToPlainText()
+
+        assertTrue(plain.contains("Chapter One"))
+        assertTrue(plain.contains("The visible prose."))
+        assertFalse("style leaked: $plain", plain.contains("color:"))
+        assertFalse("script leaked: $plain", plain.contains("alert"))
+        assertFalse("comment leaked: $plain", plain.contains("editor note"))
+        assertFalse("title leaked: $plain", plain.contains("Ch. 1"))
+    }
+
+    @Test
+    fun `paragraph breaks survive as blank lines`() {
+        assertEquals("One.\n\nTwo.", "<p>One.</p><p>Two.</p>".htmlToPlainText())
+    }
+
+    @Test
+    fun `entities decode natively`() {
+        assertEquals(
+            "It’s a “quote” & an em—dash.",
+            "<p>It&rsquo;s a &ldquo;quote&rdquo; &amp; an em&mdash;dash.</p>".htmlToPlainText(),
+        )
+    }
+
+    @Test
+    fun `empty and tag-only input return empty string`() {
+        assertEquals("", "".htmlToPlainText())
+        assertEquals("", "<head><title>only</title></head>".htmlToPlainText())
+    }
+}


### PR DESCRIPTION
Follow-up to #1718 / #1700 — migrates the **last** chapter-body stripper, Palace's module-local `String.stripTags()` regex (the exact twin of the one #1718 removed from `:source-gutenberg`), to core-data's shared `htmlToPlainText()`.

Palace serves EPUB 3 spine documents (same shape as PG / Standard Ebooks), so it's a drop-in with two wins for a Palace listener:
- **Paragraph breaks survive as `\n\n`** → paragraph navigation works (the regex flattened chapters to one line).
- **Entities decode natively** → `&rsquo;` / `&ldquo;` / `&mdash;` no longer reach the narrator as literal text.

`PalacePlainBodyTest` pins the #442-class `<head>`/`<script>`/`<style>`/comment removal the old stripper guarded, plus the two fixes above.

**Completes the #1628 consolidation.** The only remaining local HTML handler is Wikipedia's `cleanWikipediaTitle`, which deliberately stays — it decodes-then-strips (inverse order of the shared util) to render double-encoded italic tags in Popular-page titles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)