### PR TITLE
build(deps): batch 8 library bumps (#1704 #1706 #1707 #1709 #1710 #1714 #1715)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,14 +20,14 @@ startup = "1.2.0"
 security-crypto = "1.1.0"
 
 # Compose
-compose-bom = "2026.06.01"
+compose-bom = "2026.08.00"
 compose-material-icons = "1.7.8"
 
 # mikepenz AboutLibraries — OSS license collection + Compose M3 UI (#1142).
 # 15.x is the AGP 9 / Compose 1.10 line; the `.plugin.android` plugin variant
 # (split out in v13) auto-generates the dependency + license metadata into the
 # consuming module's `R.raw.aboutlibraries` during the Android build, GMS-free.
-aboutlibraries = "15.0.3"
+aboutlibraries = "15.0.4"
 
 # Hilt + Hilt-Work
 hilt = "2.60.1"
@@ -44,8 +44,8 @@ media3 = "1.10.1"
 
 # Networking + parsing
 okhttp = "4.12.0"
-jsoup = "1.22.2"
-commonmark = "0.29.0"
+jsoup = "1.23.1"
+commonmark = "0.30.0"
 # Readability4J — Mozilla Readability port (#472 :source-readability).
 # Catch-all article extractor for the magic-link paste flow. ~50 KB,
 # pure JVM, JSoup-backed.
@@ -75,8 +75,8 @@ wear-compose = "1.6.2"
 wear-tooling = "1.0.0"
 wear-watchface = "1.3.0"
 wear-ongoing = "1.1.0"
-wear-tiles = "1.6.1"
-wear-protolayout = "1.4.1"
+wear-tiles = "1.6.2"
+wear-protolayout = "1.4.2"
 concurrent-futures = "1.3.0"
 play-services-wearable = "20.0.1"
 
@@ -103,9 +103,9 @@ robolectric = "4.16.1"
 # handle Android 14's new "Waiting for app processes to flush
 # profiles..." prefix line. 1.3.x throws IllegalStateException on
 # that output on the Tab A7 Lite (Android 14, June 2025 patch).
-benchmark = "1.5.0-alpha07"
+benchmark = "1.5.0-beta01"
 uiautomator = "2.4.0"
-baselineprofile-gradle = "1.5.0-alpha07"
+baselineprofile-gradle = "1.5.0-rc01"
 
 # Desugaring
 desugar = "2.1.5"


### PR DESCRIPTION
One branch, one CI build, instead of seven serialized Dependabot rebases —
each of which re-runs a full assembleRelease and, in aggregate, is the load
that OOMs the familiar runner (rebase-strategy is disabled for that reason).
Every bump here was individually CI-green on its own Dependabot PR; this
verifies them together against current main.

- androidx.baselineprofile 1.5.0-alpha07 → 1.5.0-rc01   (#1715)
- androidx.compose:compose-bom 2026.06.01 → 2026.08.00 (#1714)
- org.commonmark 0.29.0 → 0.30.0                        (#1710)
- org.jsoup 1.22.2 → 1.23.1                             (#1709)
- androidx.benchmark 1.5.0-alpha07 → 1.5.0-beta01       (#1707)
- wear-tiles 1.6.1 → 1.6.2, wear-protolayout 1.4.1 → 1.4.2 (#1706)
- aboutlibraries 15.0.3 → 15.0.4                        (#1704)

AGP (#1705), the Gradle wrapper (#1711) and Kotlin/KSP (#1712) are
deliberately NOT in this batch: AGP is a toolchain change verified on its
own next; the wrapper and Kotlin/KSP were red and are re-tested after AGP.

Supersedes #1704 #1706 #1707 #1709 #1710 #1714 #1715 (closed on merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated underlying libraries and build tooling to newer versions.
  * Upgraded performance benchmarking and baseline profile tooling to newer preview releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->