### PR TITLE
build(deps): bump agp from 9.2.0 to 9.3.1 (#1705)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # Build tools
-agp = "9.2.0"
+agp = "9.3.1"
 kotlin = "2.4.0"
 ksp = "2.3.10"
 # Triple-T gradle-play-publisher — `./gradlew publishReleaseBundle` uploads


### PR DESCRIPTION
Toolchain bump verified on its own, separately from the library batch (#1720), so a failure here is unambiguous. Was CI-green on the Dependabot PR; re-verified here against current main (now including #1720).

Supersedes #1705 (closed on merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)