### PR TITLE
build(deps): bump kotlin 2.4.0→2.4.10 and ksp 2.3.10→2.3.11 (#1712)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
 # Build tools
 agp = "9.3.1"
-kotlin = "2.4.0"
-ksp = "2.3.10"
+kotlin = "2.4.10"
+ksp = "2.3.11"
 # Triple-T gradle-play-publisher — `./gradlew publishReleaseBundle` uploads
 # the signed AAB to Play Console without the browser. Requires a Google
 # Cloud service-account JSON with Play Console "Release manager"


### PR DESCRIPTION
Retest of #1712 on top of AGP 9.3.1 (#1722) and the library batch (#1720). The original Dependabot run failed at compile (~3 min); if it fails again here the failure is a genuine Kotlin/KSP incompatibility to investigate, not a stale base. Cherry-picked (version-catalog conflict on the AGP line resolved: AGP stays 9.3.1). Supersedes #1712.

🤖 Generated with [Claude Code](https://claude.com/claude-code)