### PR TITLE
fix(release): keep ML Kit component registrar constructors through R8 (#1727)

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -285,3 +285,16 @@
     public static int d(...);
     public static int i(...);
 }
+
+# ── #1727 — ML Kit component registrars ────────────────────────────────────
+# ML Kit's MlKitInitProvider discovers its ComponentRegistrar classes by name
+# (from the merged manifest <meta-data>) and instantiates them REFLECTIVELY via
+# the no-arg constructor. R8 keeps the class names (manifest-referenced) but
+# strips the unreferenced <init>() — so every release cold start logged
+#   W ComponentDiscovery: Could not instantiate com.google.mlkit.common.internal.CommonComponentRegistrar
+#   Caused by: java.lang.NoSuchMethodException: ...CommonComponentRegistrar.<init> []
+# (also TextRegistrar + VisionCommonRegistrar) and text recognition had no
+# components registered. The AARs' consumer rules did not cover this under R8
+# full mode. Keep the no-arg ctor of every registrar; nothing else is needed.
+-keep class * implements com.google.firebase.components.ComponentRegistrar { <init>(); }
+-keep class com.google.mlkit.**Registrar { <init>(); }


### PR DESCRIPTION
Fixes #1727. On every release-build cold start, ML Kit's MlKitInitProvider
failed to instantiate all three registrars it needs for text recognition
(CommonComponentRegistrar, VisionCommonRegistrar, TextRegistrar) with
NoSuchMethodException: <init> []. The classes survive R8 because the merged
manifest names them, but their no-arg constructors — only ever invoked
reflectively — were stripped, leaving the ML Kit component runtime empty
and on-device OCR (MlKitOcrTextRecognizer) without a text recognizer.

Device-independent (LG-H830 A15, SM-G950U A9) and pre-existing: v1.13.1
shows the identical warnings, so this is not from the v1.14.0 toolchain
bump. It hid because debug builds are not minified and release strips the
app's own Log.i/d breadcrumbs.

Two keep rules: the no-arg ctor of every ComponentRegistrar implementor,
plus a belt-and-braces pattern on com.google.mlkit.**Registrar.

Verification plan (on the built release APK): dexdump must show <init>()V
on CommonComponentRegistrar (absent in v1.14.0), and the cold-start logcat
must contain zero ComponentDiscovery registrar failures (78 lines in
v1.14.0 on the same phone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ML Kit initialization reliability by preserving required component registrations during release builds.
  * Helps prevent issues caused by code shrinking or obfuscation when using Firebase and ML Kit features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->