### PR TITLE
fix(scripts): phone-check fails only on a real crash signature (#1726)

### DIFF
--- a/scripts/phone-check.sh
+++ b/scripts/phone-check.sh
@@ -22,20 +22,34 @@ fi
 adb -s "$DEVICE" shell am start -n org.techempower.candela/in.jphe.storyvox.MainActivity > /dev/null 2>&1
 sleep 3
 
-# 3. Crash check
-PID=$(adb -s "$DEVICE" shell pidof org.techempower.candela 2>/dev/null || true)
+# 3. Crash check (#1726)
+# A crash is a real crash signature, not any log line containing "exception":
+# W-level library noise (e.g. ML Kit's ComponentDiscovery NoSuchMethodException
+# stacks, #1727) used to trip this and fail a healthy launch. Scope to the
+# launched PID for its whole lifetime (no -t window — the old 30-line window
+# made the result depend on what else the device logged that second).
+PID=$(adb -s "$DEVICE" shell pidof org.techempower.candela 2>/dev/null | tr -d '\r' || true)
 if [ -z "$PID" ]; then
     echo "FAIL: process not running after launch"
+    adb -s "$DEVICE" logcat -d 2>/dev/null \
+        | grep -E 'FATAL EXCEPTION|AndroidRuntime.*org\.techempower\.candela|Process org\.techempower\.candela .* has died' | head -8
     exit 1
 fi
 
-CRASHES=$(adb -s "$DEVICE" logcat -d -t 30 --pid="$PID" 2>/dev/null \
-    | grep -ciE 'fatal|crash|java\.lang\.\w+exception' || true)
-if [ "$CRASHES" -gt 0 ]; then
-    echo "FAIL: $CRASHES crash-related lines in logcat"
-    adb -s "$DEVICE" logcat -d -t 30 --pid="$PID" \
-        | grep -iE 'fatal|crash|java\.lang\.\w+exception' | head -5
+FATAL=$(adb -s "$DEVICE" logcat -d --pid="$PID" 2>/dev/null \
+    | grep -cE 'FATAL EXCEPTION|AndroidRuntime: .*org\.techempower\.candela' || true)
+if [ "$FATAL" -gt 0 ]; then
+    echo "FAIL: $FATAL fatal crash lines in logcat (PID $PID)"
+    adb -s "$DEVICE" logcat -d --pid="$PID" \
+        | grep -E -A6 'FATAL EXCEPTION|AndroidRuntime: .*org\.techempower\.candela' | head -20
     exit 1
 fi
+
+# Informational only — non-fatal exceptions at W/E for the human to eyeball.
+NOISE=$(adb -s "$DEVICE" logcat -d --pid="$PID" 2>/dev/null \
+    | grep -cE '^[0-9-]+ [0-9:.]+ +[0-9]+ +[0-9]+ [WE] .*java\.lang\.\w+(Exception|Error)' || true)
+[ "$NOISE" -gt 0 ] && echo "note: $NOISE non-fatal W/E exception lines (not a failure) — first:" \
+    && adb -s "$DEVICE" logcat -d --pid="$PID" \
+        | grep -E '^[0-9-]+ [0-9:.]+ +[0-9]+ +[0-9]+ [WE] .*java\.lang\.\w+(Exception|Error)' | head -2 | cut -c1-160
 
 echo "PASS: v$ACTUAL_VNAME running (PID $PID), no crashes"


### PR DESCRIPTION
Fixes #1726. Step 3 grepped 'fatal|crash|java\.lang\.\w+exception' at any
log level inside a 30-line window, so W-level library noise (ML Kit's
ComponentDiscovery stacks, #1727) failed a healthy v1.14.0 launch on one
phone while the other passed only because its window missed them.

Now: FAIL iff the launched PID logged 'FATAL EXCEPTION' or an AndroidRuntime
line for our package (whole PID lifetime, no -t window); a missing process
also dumps any death/fatal lines for context; non-fatal W/E exceptions are
reported as an informational note, not a failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)