### PR TITLE
build(deps): batch 8 library bumps (#1731 #1732 #1733 #1734 #1736 #1738 #1739 #1740)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,11 +8,11 @@ ksp = "2.3.11"
 # Cloud service-account JSON with Play Console "Release manager"
 # permission (see docs/play-store/RUNBOOK.md). Plugin is wired but no-ops
 # unless `storyvox.playPublisher.credentialsFile` is set in local.properties.
-play-publisher = "4.0.0"
+play-publisher = "4.1.1"
 
 # AndroidX core
 core-ktx = "1.19.0"
-appcompat = "1.7.1"
+appcompat = "1.8.0"
 activity-compose = "1.13.0"
 lifecycle = "2.11.0"
 navigation-compose = "2.9.8"
@@ -27,7 +27,7 @@ compose-material-icons = "1.7.8"
 # 15.x is the AGP 9 / Compose 1.10 line; the `.plugin.android` plugin variant
 # (split out in v13) auto-generates the dependency + license metadata into the
 # consuming module's `R.raw.aboutlibraries` during the Android build, GMS-free.
-aboutlibraries = "15.0.4"
+aboutlibraries = "15.2.0"
 
 # Hilt + Hilt-Work
 hilt = "2.60.1"
@@ -40,7 +40,7 @@ work = "2.11.2"
 datastore = "1.2.1"
 
 # Media3 (playback / session / Auto)
-media3 = "1.10.1"
+media3 = "1.11.0"
 
 # Networking + parsing
 okhttp = "4.12.0"
@@ -55,7 +55,7 @@ readability4j = "1.0.8"
 # for text-layer extraction; scanned/image PDFs route through the
 # pluggable OCR seam (#995) since they carry no text layer.
 pdfbox-android = "2.0.27.0"
-androidx-webkit = "1.16.0"
+androidx-webkit = "1.17.0"
 androidx-browser = "1.10.0"
 
 # Concurrency
@@ -65,7 +65,7 @@ coroutines = "1.11.0"
 kotlinx-serialization = "1.11.0"
 
 # Image loading
-coil = "3.5.0"
+coil = "3.6.1"
 
 # Legacy media (MediaBrowserServiceCompat for Auto)
 androidx-media = "1.8.0"
@@ -103,9 +103,9 @@ robolectric = "4.16.1"
 # handle Android 14's new "Waiting for app processes to flush
 # profiles..." prefix line. 1.3.x throws IllegalStateException on
 # that output on the Tab A7 Lite (Android 14, June 2025 patch).
-benchmark = "1.5.0-beta01"
+benchmark = "1.5.0-rc02"
 uiautomator = "2.4.0"
-baselineprofile-gradle = "1.5.0-rc01"
+baselineprofile-gradle = "1.5.0-rc02"
 
 # Desugaring
 desugar = "2.1.5"


### PR DESCRIPTION
One verified build instead of eight serialized Dependabot rebases (the load
that OOMs the familiar runner). Individually CI-green or freshly opened by
Dependabot on 2026-09-06; verified together here against current main.

- media3 1.10.1 → 1.11.0 (3 artifacts)          (#1731)
- androidx.benchmark 1.5.0-beta01 → 1.5.0-rc02    (#1732)
- aboutlibraries 15.0.4 → 15.2.0                  (#1733)
- androidx.webkit 1.16.0 → 1.17.0                 (#1734)
- androidx.appcompat 1.7.1 → 1.8.0                (#1736)
- coil 3.5.0 → 3.6.1                              (#1738)
- androidx.baselineprofile 1.5.0-rc01 → 1.5.0-rc02 (#1739)
- gradle-play-publisher 4.0.0 → 4.1.1             (#1740)

AGP 9.4.0 (#1737) and the wrapper 9.7.1 (#1735) are verified on their own.

Supersedes #1731 #1732 #1733 #1734 #1736 #1738 #1739 #1740 (closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated several app development and runtime libraries to newer versions.
  - Updated media playback, web content, image loading, compatibility, app information, publishing, benchmarking, and performance tooling components.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->