### PR TITLE
build(deps): bump agp from 9.3.1 to 9.4.0 (#1737)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # Build tools
-agp = "9.3.1"
+agp = "9.4.0"
 kotlin = "2.4.10"
 ksp = "2.3.11"
 # Triple-T gradle-play-publisher — `./gradlew publishReleaseBundle` uploads


### PR DESCRIPTION
Toolchain bump verified alone, separately from the library batch. Supersedes #1737 (closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)