### PR TITLE
build(deps): bump gradle-wrapper from 9.7.0 to 9.7.1 (#1735)

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500


### PR DESCRIPTION
Wrapper jar from Dependabot's #1735; properties bumped from 9.7.0 (main, #1730). Also the first real regression check of the familiar Gradle-home migration (#1725). Supersedes #1735 (closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)